### PR TITLE
Templates REST API: prevent fatal error when a null template reaches prepare_item_for_response

### DIFF
--- a/backport-changelog/7.2/13375.md
+++ b/backport-changelog/7.2/13375.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13375
+
+* https://github.com/WordPress/gutenberg/pull/82374

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
@@ -64,7 +64,15 @@ class Gutenberg_REST_Templates_Controller_7_2 extends Gutenberg_REST_Templates_C
 		//////////////////////////////
 		// START CORE MODIFICATIONS //
 		//////////////////////////////
-		if ( isset( $request['source'] ) && 'theme' === $request['source'] && ! get_block_file_template( $request['id'], $this->post_type ) ) {
+		/*
+		 * Refuse the revert only when the template exists (for an unknown id,
+		 * core answers 404 below) but no theme or plugin version of it does.
+		 */
+		if (
+			isset( $request['source'] ) && 'theme' === $request['source']
+			&& get_block_template( $request['id'], $this->post_type )
+			&& ! get_block_file_template( $request['id'], $this->post_type )
+		) {
 			return new WP_Error(
 				'rest_invalid_template',
 				__( 'This template cannot be reverted because the active theme and plugins do not provide a version of it.' ),

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Core class used to access templates via the REST API for WordPress 7.2.
+ * Core class used to access templates via the REST API before WordPress 7.2.
  *
  * This class extension exists to prevent a fatal error when a `null` template
  * reaches `prepare_item_for_response`, which reads and assigns properties on
@@ -10,8 +10,6 @@
  * its "revert to theme" path, which force-deletes the template's post before
  * checking that a theme or plugin version of the template exists.
  *
- * Note: this change needs to be backported to WordPress core.
- * See `WP_REST_Templates_Controller::prepare_item_for_response()`.
  *
  * @see Gutenberg_REST_Templates_Controller_7_0
  */

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
@@ -5,10 +5,10 @@
  *
  * This class extension exists to prevent a fatal error when a `null` template
  * reaches `prepare_item_for_response`, which reads and assigns properties on
- * it. Core's `update_item` can pass `null` there: its "revert to theme" path
- * deletes the template's post before checking that a theme or plugin version
- * of the template exists, so reverting a template that only exists in the
- * database deletes it and then refetches `null`.
+ * it. Core's `update_item` can pass `null` there from either of its two
+ * unchecked `get_block_template()` refetches: after writing an update, and on
+ * its "revert to theme" path, which force-deletes the template's post before
+ * checking that a theme or plugin version of the template exists.
  *
  * Note: this change needs to be backported to WordPress core.
  * See `WP_REST_Templates_Controller::prepare_item_for_response()`.
@@ -32,9 +32,10 @@ class Gutenberg_REST_Templates_Controller_7_2 extends Gutenberg_REST_Templates_C
 		// START CORE MODIFICATIONS //
 		//////////////////////////////
 		/*
-		 * Core can pass `null` here, e.g. when `update_item` refetches a
-		 * template after deleting its post. Reading `$item->content` on
-		 * `null` is a fatal error, so answer with an error response instead.
+		 * Core's `update_item` passes its `get_block_template()` refetches
+		 * here unchecked, both after writing an update and after deleting
+		 * the post on its revert path. Reading `$item->content` on `null`
+		 * is a fatal error, so answer with an error response instead.
 		 */
 		if ( ! $item ) {
 			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.' ), array( 'status' => 404 ) );

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
@@ -3,18 +3,52 @@
 /**
  * Core class used to access templates via the REST API for WordPress 7.2.
  *
- * This class extension guards the "revert to theme" path of `update_item`.
- * Core deletes the template's post before checking that a theme or plugin
- * version of the template exists, so reverting a template that only exists
- * in the database destroys it and then crashes with a fatal error when the
- * refetched template is `null`.
+ * This class extension protects against a fatal error when a `null` template
+ * reaches `prepare_item_for_response`, which reads and assigns properties on
+ * it. Core's `update_item` can pass `null` there: its "revert to theme" path
+ * deletes the template's post before checking that a theme or plugin version
+ * of the template exists, so reverting a template that only exists in the
+ * database destroys it and then refetches `null`. `update_item` refuses such
+ * reverts before deleting anything, and `prepare_item_for_response` answers
+ * any remaining `null` with an error response instead of crashing.
  *
- * Note: this change needs to be backported to WordPress core.
- * See `WP_REST_Templates_Controller::update_item()`.
+ * Note: these changes need to be backported to WordPress core.
+ * See `WP_REST_Templates_Controller::update_item()` and
+ * `WP_REST_Templates_Controller::prepare_item_for_response()`.
  *
  * @see Gutenberg_REST_Templates_Controller_7_0
  */
 class Gutenberg_REST_Templates_Controller_7_2 extends Gutenberg_REST_Templates_Controller_7_0 {
+	/**
+	 * Prepares a single template output for response.
+	 *
+	 * @since 5.8.0
+	 * @since 7.2.0 Answers with an error response instead of a fatal error
+	 *              when the template is `null`.
+	 *
+	 * @param WP_Block_Template|null $item    Template instance.
+	 * @param WP_REST_Request        $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error when the template is `null`.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		//////////////////////////////
+		// START CORE MODIFICATIONS //
+		//////////////////////////////
+		/*
+		 * Core can pass `null` here, e.g. when `update_item` refetches a
+		 * template after deleting its post. Reading `$item->content` on
+		 * `null` is a fatal error, so answer with an error response instead.
+		 */
+		if ( ! $item ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.' ), array( 'status' => 404 ) );
+		}
+		//////////////////////////////
+		// END CORE MODIFICATIONS //
+		//////////////////////////////
+
+		return parent::prepare_item_for_response( $item, $request );
+	}
+
 	/**
 	 * Updates a single template.
 	 *

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Core class used to access templates via the REST API for WordPress 7.2.
+ *
+ * This class extension guards the "revert to theme" path of `update_item`.
+ * Core deletes the template's post before checking that a theme or plugin
+ * version of the template exists, so reverting a template that only exists
+ * in the database destroys it and then crashes with a fatal error when the
+ * refetched template is `null`.
+ *
+ * Note: this change needs to be backported to WordPress core.
+ * See `WP_REST_Templates_Controller::update_item()`.
+ *
+ * @see Gutenberg_REST_Templates_Controller_7_0
+ */
+class Gutenberg_REST_Templates_Controller_7_2 extends Gutenberg_REST_Templates_Controller_7_0 {
+	/**
+	 * Updates a single template.
+	 *
+	 * @since 5.8.0
+	 * @since 7.2.0 Reverting to the theme version is refused when no theme or
+	 *              plugin version of the template exists, instead of deleting
+	 *              the template and crashing.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function update_item( $request ) {
+		//////////////////////////////
+		// START CORE MODIFICATIONS //
+		//////////////////////////////
+		if ( isset( $request['source'] ) && 'theme' === $request['source'] && ! get_block_file_template( $request['id'], $this->post_type ) ) {
+			return new WP_Error(
+				'rest_invalid_template',
+				__( 'This template cannot be reverted because the active theme and plugins do not provide a version of it.' ),
+				array( 'status' => 400 )
+			);
+		}
+		//////////////////////////////
+		// END CORE MODIFICATIONS //
+		//////////////////////////////
+
+		return parent::update_item( $request );
+	}
+}

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php
@@ -3,18 +3,15 @@
 /**
  * Core class used to access templates via the REST API for WordPress 7.2.
  *
- * This class extension protects against a fatal error when a `null` template
+ * This class extension exists to prevent a fatal error when a `null` template
  * reaches `prepare_item_for_response`, which reads and assigns properties on
  * it. Core's `update_item` can pass `null` there: its "revert to theme" path
  * deletes the template's post before checking that a theme or plugin version
  * of the template exists, so reverting a template that only exists in the
- * database destroys it and then refetches `null`. `update_item` refuses such
- * reverts before deleting anything, and `prepare_item_for_response` answers
- * any remaining `null` with an error response instead of crashing.
+ * database deletes it and then refetches `null`.
  *
- * Note: these changes need to be backported to WordPress core.
- * See `WP_REST_Templates_Controller::update_item()` and
- * `WP_REST_Templates_Controller::prepare_item_for_response()`.
+ * Note: this change needs to be backported to WordPress core.
+ * See `WP_REST_Templates_Controller::prepare_item_for_response()`.
  *
  * @see Gutenberg_REST_Templates_Controller_7_0
  */
@@ -47,42 +44,5 @@ class Gutenberg_REST_Templates_Controller_7_2 extends Gutenberg_REST_Templates_C
 		//////////////////////////////
 
 		return parent::prepare_item_for_response( $item, $request );
-	}
-
-	/**
-	 * Updates a single template.
-	 *
-	 * @since 5.8.0
-	 * @since 7.2.0 Reverting to the theme version is refused when no theme or
-	 *              plugin version of the template exists, instead of deleting
-	 *              the template and crashing.
-	 *
-	 * @param WP_REST_Request $request Full details about the request.
-	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
-	 */
-	public function update_item( $request ) {
-		//////////////////////////////
-		// START CORE MODIFICATIONS //
-		//////////////////////////////
-		/*
-		 * Refuse the revert only when the template exists (for an unknown id,
-		 * core answers 404 below) but no theme or plugin version of it does.
-		 */
-		if (
-			isset( $request['source'] ) && 'theme' === $request['source']
-			&& get_block_template( $request['id'], $this->post_type )
-			&& ! get_block_file_template( $request['id'], $this->post_type )
-		) {
-			return new WP_Error(
-				'rest_invalid_template',
-				__( 'This template cannot be reverted because the active theme and plugins do not provide a version of it.' ),
-				array( 'status' => 400 )
-			);
-		}
-		//////////////////////////////
-		// END CORE MODIFICATIONS //
-		//////////////////////////////
-
-		return parent::update_item( $request );
 	}
 }

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -17,3 +17,37 @@ function gutenberg_register_view_config_controller_endpoints_7_2() {
 }
 remove_action( 'rest_api_init', 'gutenberg_register_view_config_controller_endpoints', PHP_INT_MAX );
 add_action( 'rest_api_init', 'gutenberg_register_view_config_controller_endpoints_7_2', PHP_INT_MAX );
+
+/**
+ * Registers the Templates REST API routes.
+ *
+ * Runs after the WordPress 7.0 filter of the same shape, so this controller
+ * class wins.
+ *
+ * @see Gutenberg_REST_Templates_Controller_7_2
+ *
+ * @param array $args Array of arguments for registering a post type.
+ * @return array Modified array of arguments.
+ */
+function gutenberg_modify_wp_template_post_type_args_7_2( $args ) {
+	$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_7_2';
+	return $args;
+}
+add_filter( 'register_wp_template_post_type_args', 'gutenberg_modify_wp_template_post_type_args_7_2' );
+
+/**
+ * Registers the Template Parts REST API routes.
+ *
+ * Runs after the WordPress 7.0 filter of the same shape, so this controller
+ * class wins.
+ *
+ * @see Gutenberg_REST_Templates_Controller_7_2
+ *
+ * @param array $args Array of arguments for registering a post type.
+ * @return array Modified array of arguments.
+ */
+function gutenberg_modify_wp_template_part_post_type_args_7_2( $args ) {
+	$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_7_2';
+	return $args;
+}
+add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_wp_template_part_post_type_args_7_2' );

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -19,9 +19,9 @@ remove_action( 'rest_api_init', 'gutenberg_register_view_config_controller_endpo
 add_action( 'rest_api_init', 'gutenberg_register_view_config_controller_endpoints_7_2', PHP_INT_MAX );
 
 /**
- * Registers the Templates REST API routes.
+ * Registers the Templates and Template Parts REST API routes.
  *
- * Runs after the WordPress 7.0 filter of the same shape, so this controller
+ * Runs after the WordPress 7.0 filters of the same shape, so this controller
  * class wins.
  *
  * @see Gutenberg_REST_Templates_Controller_7_2
@@ -29,25 +29,9 @@ add_action( 'rest_api_init', 'gutenberg_register_view_config_controller_endpoint
  * @param array $args Array of arguments for registering a post type.
  * @return array Modified array of arguments.
  */
-function gutenberg_modify_wp_template_post_type_args_7_2( $args ) {
+function gutenberg_modify_template_post_type_args_7_2( $args ) {
 	$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_7_2';
 	return $args;
 }
-add_filter( 'register_wp_template_post_type_args', 'gutenberg_modify_wp_template_post_type_args_7_2' );
-
-/**
- * Registers the Template Parts REST API routes.
- *
- * Runs after the WordPress 7.0 filter of the same shape, so this controller
- * class wins.
- *
- * @see Gutenberg_REST_Templates_Controller_7_2
- *
- * @param array $args Array of arguments for registering a post type.
- * @return array Modified array of arguments.
- */
-function gutenberg_modify_wp_template_part_post_type_args_7_2( $args ) {
-	$args['rest_controller_class'] = 'Gutenberg_REST_Templates_Controller_7_2';
-	return $args;
-}
-add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_wp_template_part_post_type_args_7_2' );
+add_filter( 'register_wp_template_post_type_args', 'gutenberg_modify_template_post_type_args_7_2' );
+add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_template_post_type_args_7_2' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -72,6 +72,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-7.1/block-comments.php';
 
 	// WordPress 7.2 compat.
+	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php';
 	require __DIR__ . '/compat/wordpress-7.2/view-config-api.php';
 	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php';
 	require __DIR__ . '/compat/wordpress-7.2/rest-api.php';

--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -248,6 +248,22 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	}
 
 	/**
+	 * A `null` template must produce an error response, not a fatal error from
+	 * reading properties on `null`.
+	 *
+	 * @covers Gutenberg_REST_Templates_Controller_7_2::prepare_item_for_response
+	 */
+	public function test_prepare_item_for_response_with_null_template() {
+		$controller = new Gutenberg_REST_Templates_Controller_7_2( 'wp_template' );
+		$request    = new WP_REST_Request( 'PUT', '/wp/v2/templates/default//does-not-exist' );
+
+		$response = $controller->prepare_item_for_response( null, $request );
+
+		$this->assertWPError( $response, 'A null template should produce a WP_Error, not a fatal error.' );
+		$this->assertSame( 'rest_template_not_found', $response->get_error_code() );
+	}
+
+	/**
 	 * @ticket 54422
 	 * @covers WP_REST_Templates_Controller::get_item_schema
 	 */

--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -183,10 +183,54 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	}
 
 	/**
-	 * @doesNotPerformAssertions
+	 * Reverting a template to its theme version must be refused when neither
+	 * the active theme nor a plugin provides the template, since deleting the
+	 * database copy would destroy the only version.
+	 *
+	 * @covers Gutenberg_REST_Templates_Controller_7_2::update_item
 	 */
 	public function test_update_item() {
-		// Not testing item update.
+		wp_set_current_user( self::$admin_id );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'db-only-template',
+				'post_title'   => 'Database-only template',
+				'post_content' => '<!-- wp:paragraph --><p>Custom</p><!-- /wp:paragraph -->',
+			)
+		);
+		wp_set_post_terms( $post_id, get_stylesheet(), 'wp_theme' );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/' . get_stylesheet() . '//db-only-template' );
+		$request->set_body_params( array( 'source' => 'theme' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_template', $response, 400 );
+		$this->assertInstanceOf( 'WP_Post', get_post( $post_id ), 'The database copy of the template should not be deleted.' );
+	}
+
+	/**
+	 * Reverting a customized template to its theme version must still work
+	 * when the active theme provides the template.
+	 *
+	 * @covers Gutenberg_REST_Templates_Controller_7_2::update_item
+	 */
+	public function test_update_item_reverts_to_theme_when_theme_file_exists() {
+		wp_set_current_user( self::$admin_id );
+		switch_theme( 'block-theme' );
+
+		// Customizing the theme's template creates a database copy of it.
+		$customize = new WP_REST_Request( 'PUT', '/wp/v2/templates/block-theme//page-home' );
+		$customize->set_body_params( array( 'content' => '<!-- wp:paragraph --><p>Customized</p><!-- /wp:paragraph -->' ) );
+		$response = rest_get_server()->dispatch( $customize );
+		$this->assertSame( 200, $response->get_status(), 'Customizing a theme template should succeed.' );
+		$this->assertSame( 'custom', $response->get_data()['source'], 'The customized template should come from the database.' );
+
+		$revert = new WP_REST_Request( 'PUT', '/wp/v2/templates/block-theme//page-home' );
+		$revert->set_body_params( array( 'source' => 'theme' ) );
+		$response = rest_get_server()->dispatch( $revert );
+		$this->assertSame( 200, $response->get_status(), 'Reverting a customized theme template should succeed.' );
+		$this->assertSame( 'theme', $response->get_data()['source'], 'The reverted template should come from the theme file again.' );
 	}
 
 	/**

--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -210,6 +210,21 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	}
 
 	/**
+	 * A revert for a template id that does not exist at all must keep core's
+	 * 404 response rather than the guard's 400.
+	 *
+	 * @covers Gutenberg_REST_Templates_Controller_7_2::update_item
+	 */
+	public function test_update_item_returns_404_for_unknown_template() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/' . get_stylesheet() . '//does-not-exist' );
+		$request->set_body_params( array( 'source' => 'theme' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_template_not_found', $response, 404 );
+	}
+
+	/**
 	 * Reverting a customized template to its theme version must still work
 	 * when the active theme provides the template.
 	 *

--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -183,69 +183,10 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	}
 
 	/**
-	 * Reverting a template to its theme version must be refused when neither
-	 * the active theme nor a plugin provides the template, since deleting the
-	 * database copy would destroy the only version.
-	 *
-	 * @covers Gutenberg_REST_Templates_Controller_7_2::update_item
+	 * @doesNotPerformAssertions
 	 */
 	public function test_update_item() {
-		wp_set_current_user( self::$admin_id );
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'    => 'wp_template',
-				'post_name'    => 'db-only-template',
-				'post_title'   => 'Database-only template',
-				'post_content' => '<!-- wp:paragraph --><p>Custom</p><!-- /wp:paragraph -->',
-			)
-		);
-		wp_set_post_terms( $post_id, get_stylesheet(), 'wp_theme' );
-
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/' . get_stylesheet() . '//db-only-template' );
-		$request->set_body_params( array( 'source' => 'theme' ) );
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertErrorResponse( 'rest_invalid_template', $response, 400 );
-		$this->assertInstanceOf( 'WP_Post', get_post( $post_id ), 'The database copy of the template should not be deleted.' );
-	}
-
-	/**
-	 * A revert for a template id that does not exist at all must keep core's
-	 * 404 response rather than the guard's 400.
-	 *
-	 * @covers Gutenberg_REST_Templates_Controller_7_2::update_item
-	 */
-	public function test_update_item_returns_404_for_unknown_template() {
-		wp_set_current_user( self::$admin_id );
-		$request = new WP_REST_Request( 'PUT', '/wp/v2/templates/' . get_stylesheet() . '//does-not-exist' );
-		$request->set_body_params( array( 'source' => 'theme' ) );
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertErrorResponse( 'rest_template_not_found', $response, 404 );
-	}
-
-	/**
-	 * Reverting a customized template to its theme version must still work
-	 * when the active theme provides the template.
-	 *
-	 * @covers Gutenberg_REST_Templates_Controller_7_2::update_item
-	 */
-	public function test_update_item_reverts_to_theme_when_theme_file_exists() {
-		wp_set_current_user( self::$admin_id );
-		switch_theme( 'block-theme' );
-
-		// Customizing the theme's template creates a database copy of it.
-		$customize = new WP_REST_Request( 'PUT', '/wp/v2/templates/block-theme//page-home' );
-		$customize->set_body_params( array( 'content' => '<!-- wp:paragraph --><p>Customized</p><!-- /wp:paragraph -->' ) );
-		$response = rest_get_server()->dispatch( $customize );
-		$this->assertSame( 200, $response->get_status(), 'Customizing a theme template should succeed.' );
-		$this->assertSame( 'custom', $response->get_data()['source'], 'The customized template should come from the database.' );
-
-		$revert = new WP_REST_Request( 'PUT', '/wp/v2/templates/block-theme//page-home' );
-		$revert->set_body_params( array( 'source' => 'theme' ) );
-		$response = rest_get_server()->dispatch( $revert );
-		$this->assertSame( 200, $response->get_status(), 'Reverting a customized theme template should succeed.' );
-		$this->assertSame( 'theme', $response->get_data()['source'], 'The reverted template should come from the theme file again.' );
+		// Not testing item update.
 	}
 
 	/**


### PR DESCRIPTION
## What?

Prevents an uncaught fatal error in the templates REST controller:

```
Attempt to assign property "content" on null
```

## Why?

Core's `WP_REST_Templates_Controller::update_item()` passes its `get_block_template()` refetches to `prepare_item_for_response()` without checking them, both after writing an update (line 423, where a production trace shows the fatal firing) and on its revert-to-theme path, which force-deletes the template's post first (line 380). When a refetch returns `null`, the method fatals reading `$item->content`. The WP 7.2 compat controller now answers a `null` template with a `rest_template_not_found` (404) error response instead of crashing. Needs backporting to core.

## How does the test prove the guard?

`test_prepare_item_for_response_with_null_template` calls `prepare_item_for_response( null, … )` directly — the exact condition that fatals on trunk — and asserts a `WP_Error` with code `rest_template_not_found` comes back. Without the guard, the call fatals and the test run aborts, so the test can only pass through the guard.

## Testing Instructions

The revert path is the easiest way to reach the fatal:

1. Create a template that exists only in the database: `POST /wp/v2/templates` with `{ "slug": "db-only", "title": "T", "content": "" }`.
2. Send `PUT /wp/v2/templates/<theme>//db-only` with `{ "source": "theme" }`.
3. On trunk this fatals with the error above; with this branch it returns 404 `rest_template_not_found`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in WordPress 7.2 where requesting a nonexistent template through the REST API could trigger a fatal error.
  * Nonexistent templates now return a proper “not found” error response.
  * Improved REST API compatibility for templates and template parts on WordPress 7.2.

* **Documentation**
  * Added links to the related WordPress and Gutenberg pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->