### PR TITLE
UI: Re-read the native validity on blur in ControlWithError

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `Input`, `Textarea`, `InputControl`, `TextareaControl`: Use `--wpds-color-foreground-interactive-neutral-weak` for enabled placeholder text so it meets the 4.5:1 contrast minimum ([#82304](https://github.com/WordPress/gutenberg/pull/82304)).
 -   `SearchableChipSelect`, `SearchableChipSelectControl`: Fix the gray background on disabled search fields in WordPress admin ([#82304](https://github.com/WordPress/gutenberg/pull/82304)).
 -   `ValidityIndicator`: Remove the built-in outer margin. Spacing belongs on the consumer. `ControlWithError` now uses `Stack` with `gap="sm"` so validated controls keep the same gap. ([#82267](https://github.com/WordPress/gutenberg/pull/82267))
+-   `ControlWithError`: Re-read the native validity after the control blurs, so a control that commits an adjusted value on blur (e.g. a number control clamping to its `min`) doesn't keep showing a stale error message ([#82376](https://github.com/WordPress/gutenberg/pull/82376)).
 -   `AlertDialog`: Use a neutral tone for the cancel button. ([#82261](https://github.com/WordPress/gutenberg/pull/82261))
 -   `Input`: Hide the field focus ring when a prefix or suffix slot control is focused. ([#82257](https://github.com/WordPress/gutenberg/pull/82257))
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))

--- a/packages/ui/src/form/primitives/control-with-error/control-with-error.tsx
+++ b/packages/ui/src/form/primitives/control-with-error/control-with-error.tsx
@@ -220,21 +220,35 @@ export const ControlWithError = forwardRef<
 		setShowMessage( true );
 	}, [ isTouched, customValidity?.type, showMessage ] );
 
-	// Mark blurred fields as touched.
+	// Mark blurred fields as touched, and re-read the native validity once
+	// the control has settled.
 	const onBlur = ( event: React.FocusEvent< HTMLDivElement > ) => {
-		if ( isTouched ) {
-			return;
-		}
-
 		// Only consider "blurred from the component" if focus has fully left the wrapping div.
 		// This prevents unnecessary blurs from components with multiple focusable elements.
 		if (
-			! event.relatedTarget ||
-			! event.currentTarget.contains( event.relatedTarget )
+			event.relatedTarget &&
+			event.currentTarget.contains( event.relatedTarget )
 		) {
+			return;
+		}
+
+		if ( ! isTouched ) {
 			setIsTouched( true );
 			getValidityTarget()?.setAttribute( VALIDITY_VISIBLE_ATTRIBUTE, '' );
 		}
+
+		// A control that commits an adjusted value on blur (e.g. a number
+		// control clamping to its `min`) can take a few more commits to settle
+		// while its controlled value catches up with the parent, so a message
+		// sampled in the render triggered by this event may be stale. Re-read
+		// it once React has flushed the blur's work.
+		const validityTarget = getValidityTarget();
+		const isValidating = customValidity?.type === 'validating';
+		window.queueMicrotask( () => {
+			if ( ! isValidating ) {
+				setErrorMessage( validityTarget?.validationMessage );
+			}
+		} );
 	};
 
 	const messageId = useId();

--- a/packages/ui/src/form/primitives/control-with-error/test/control-with-error.jsdom.test.tsx
+++ b/packages/ui/src/form/primitives/control-with-error/test/control-with-error.jsdom.test.tsx
@@ -3,12 +3,11 @@ import userEvent from '@testing-library/user-event';
 import {
 	forwardRef,
 	useCallback,
-	useEffect,
 	useId,
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { useMergeRefs } from '@wordpress/compose';
+import { useIsomorphicLayoutEffect, useMergeRefs } from '@wordpress/compose';
 import { ControlWithError } from '../index';
 
 const ValidatedInput = forwardRef<
@@ -568,7 +567,7 @@ describe( 'ControlWithError', () => {
 
 			// Mimics controls like `NumberControl`: the value is clamped on
 			// blur, and the committed value is synced into the control's own
-			// state (and the DOM) a render later.
+			// state (and the DOM) in a layout effect, a render later.
 			const ClampedNumberInput = forwardRef<
 				HTMLInputElement,
 				{
@@ -578,7 +577,7 @@ describe( 'ControlWithError', () => {
 				}
 			>( function ClampedNumberInput( { label, value, onChange }, ref ) {
 				const [ innerValue, setInnerValue ] = useState( value );
-				useEffect( () => {
+				useIsomorphicLayoutEffect( () => {
 					setInnerValue( value );
 				}, [ value ] );
 				return (
@@ -603,8 +602,9 @@ describe( 'ControlWithError', () => {
 			function Harness() {
 				const [ value, setValue ] = useState( '10' );
 				const ref = useRef< HTMLInputElement >( null );
+				const getValidityTarget = useCallback( () => ref.current, [] );
 				return (
-					<ControlWithError getValidityTarget={ () => ref.current }>
+					<ControlWithError getValidityTarget={ getValidityTarget }>
 						<ClampedNumberInput
 							ref={ ref }
 							label="Number"
@@ -617,9 +617,21 @@ describe( 'ControlWithError', () => {
 
 			render( <Harness /> );
 
-			const input = screen.getByRole( 'spinbutton', { name: 'Number' } );
+			const input = screen.getByRole< HTMLInputElement >( 'spinbutton', {
+				name: 'Number',
+			} );
 			await user.clear( input );
 			await user.type( input, '0' );
+			// The message has to be showing before the blur for the assertion below
+			// to mean anything. Surface it the way a save action would, by validating
+			// the form while the field is still focused.
+			act( () => {
+				input.reportValidity();
+			} );
+			expect(
+				screen.getByText( 'Constraints not satisfied' )
+			).toBeVisible();
+
 			await user.tab();
 
 			await waitFor( () => {

--- a/packages/ui/src/form/primitives/control-with-error/test/control-with-error.jsdom.test.tsx
+++ b/packages/ui/src/form/primitives/control-with-error/test/control-with-error.jsdom.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import {
 	forwardRef,
 	useCallback,
+	useEffect,
 	useId,
 	useRef,
 	useState,
@@ -558,6 +559,75 @@ describe( 'ControlWithError', () => {
 			await waitFor( () => {
 				expect( input ).not.toHaveAttribute( 'aria-describedby' );
 			} );
+		} );
+	} );
+
+	describe( 'Controls that commit their value on blur', () => {
+		it( 'should clear a stale native error once the control commits a valid value on blur', async () => {
+			const user = userEvent.setup();
+
+			// Mimics controls like `NumberControl`: the value is clamped on
+			// blur, and the committed value is synced into the control's own
+			// state (and the DOM) a render later.
+			const ClampedNumberInput = forwardRef<
+				HTMLInputElement,
+				{
+					label?: string;
+					value: string;
+					onChange: ( value: string ) => void;
+				}
+			>( function ClampedNumberInput( { label, value, onChange }, ref ) {
+				const [ innerValue, setInnerValue ] = useState( value );
+				useEffect( () => {
+					setInnerValue( value );
+				}, [ value ] );
+				return (
+					<input
+						ref={ ref }
+						type="number"
+						min={ 1 }
+						aria-label={ label }
+						value={ innerValue }
+						onChange={ ( event ) =>
+							setInnerValue( event.target.value )
+						}
+						onBlur={ () =>
+							onChange(
+								String( Math.max( 1, Number( innerValue ) ) )
+							)
+						}
+					/>
+				);
+			} );
+
+			function Harness() {
+				const [ value, setValue ] = useState( '10' );
+				const ref = useRef< HTMLInputElement >( null );
+				return (
+					<ControlWithError getValidityTarget={ () => ref.current }>
+						<ClampedNumberInput
+							ref={ ref }
+							label="Number"
+							value={ value }
+							onChange={ setValue }
+						/>
+					</ControlWithError>
+				);
+			}
+
+			render( <Harness /> );
+
+			const input = screen.getByRole( 'spinbutton', { name: 'Number' } );
+			await user.clear( input );
+			await user.type( input, '0' );
+			await user.tab();
+
+			await waitFor( () => {
+				expect( input ).toHaveValue( 1 );
+			} );
+			expect(
+				screen.queryByText( 'Constraints not satisfied' )
+			).not.toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
## What?

`ControlWithError` re-reads the input's native validation message after the control blurs, once React has flushed the blur's work.

## Why?

The message is only sampled in render-driven effects and on `invalid` events. A control that commits an adjusted value on blur (e.g. `NumberControl` clamping to its `min`) takes a few commits to settle, so the error sampled before the clamp stuck around. I noticed it in the DataForm inspector experiment: "Posts per page" on the index template kept showing "Value must be greater than or equal to 1." after the value was clamped to 1.

## Testing Instructions

1. Activate `emptytheme` (`test/emptytheme`) and enable the `gutenberg-dataform-inspector` experiment.
2. Edit the index template, open "Posts per page" in the summary, type `0` and press Tab.
3. Without this change the value becomes 1 but the error stays. With it, the error goes away.

Note that the bug is masked on themes whose index template has a Query Loop inheriting the site query (e.g. Twenty Twenty-Five): changing the setting re-renders the template's blocks and the summary with them, and that extra render happens to re-sample the input after it has settled. `emptytheme` uses a custom query, so nothing re-renders and the stale message stays.

## Video

https://github.com/user-attachments/assets/fe1e3810-47a8-4cea-be23-864595385fda




## Use of AI Tools

Generated with Fable 5.1 and adjusted/reviewed manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation when values are updated during blur events.
  * Prevented controls from being marked as touched when focus moves within the same control.
  * Ensured stale native validation messages clear after correcting an invalid value.
  * Improved placeholder contrast.
  * Corrected backgrounds for disabled search fields.

* **Enhancements**
  * Improved target handling and new-tab accessibility for links and menu link items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->