### PR TITLE
Fix help paragraph color contrast ratio in the Connectors page.

### DIFF
--- a/routes/connectors-home/stage.tsx
+++ b/routes/connectors-home/stage.tsx
@@ -173,7 +173,7 @@ function ConnectorsPage() {
 					</VStack>
 				) }
 				{ canInstallPlugins && ! isFileModDisabled && (
-					<p>
+					<p className="connectors-page__help-text">
 						{ createInterpolateElement(
 							__(
 								'If the connector you need is not listed, <a>search the plugin directory</a> to see if a connector is available.'

--- a/routes/connectors-home/style.scss
+++ b/routes/connectors-home/style.scss
@@ -85,8 +85,8 @@ $sticky-header-clearance: 120px;
 		}
 	}
 
-	> p {
-		color: $gray-600;
+	&__help-text {
+		color: $gray-700;
 	}
 
 	@media (max-width: 680px) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/82329

<!-- In a few words, what is the PR actually doing? -->

The paragraph at the bottom of the Connectors page has insufficient color contrast ratio. It should be at least 4.5:1.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Compliance with basic WCAG requirements for color contrast.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The current color `$gray-600: #949494;` is clearly documented [by an inline comment](https://github.com/WordPress/gutenberg/blob/aa054bb3d83a67f9d0dcce7bf790b82f1353f58b/packages/base-styles/_colors.scss#L10) as 'Meets 3:1 UI or large text contrast against white.'

It can't be used for regular text. It can only be used for large text or for [non-text contrast](https://www.w3.org/TR/WCAG22/#non-text-contrast).

Changed to `$gray-700` for consistency with similar text displayed at the bottom of the Fonts > Upload page.

Note;
This issue, while trivial, is a blocker for Core https://github.com/WordPress/wordpress-develop/pull/13348.
Can we please add this fix to the changes for WordPress 7.1.1? Thanks.
Cc @t-hamano 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to the Wp Admin > Settings > Connectors
- Observe the paragraph at the bottom of the page with text `If the connector you need is not listed ...`.
- Observe the text color is now `#757575`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated connector directory help text styling for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->