### PR TITLE
Components: deprecate Badge

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecations
 
--   Deprecate `Badge` in the private APIs; use `Badge` from `@wordpress/ui` instead.
+-   Deprecate `Badge` in the private APIs; use `Badge` from `@wordpress/ui` instead. ([#82379](https://github.com/WordPress/gutenberg/pull/82379)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Deprecate `Badge` in the private APIs; use `Badge` from `@wordpress/ui` instead.
+
 ### Enhancements
 
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).

--- a/packages/components/schemas/docs-manifest.json
+++ b/packages/components/schemas/docs-manifest.json
@@ -1,6 +1,6 @@
 {
-	"title": "JSON schema for @wordpress/components README manifests",
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "JSON schema for @wordpress/components README manifests",
 	"type": "object",
 	"properties": {
 		"displayName": {
@@ -10,6 +10,10 @@
 		"filePath": {
 			"type": "string",
 			"description": "The file path where the component is located."
+		},
+		"deprecated": {
+			"type": "string",
+			"description": "If set, a deprecation callout is rendered in the README. Use the replacement guidance, e.g. 'Please use `Badge` from the `@wordpress/ui` package instead.'"
 		},
 		"subcomponents": {
 			"type": "array",

--- a/packages/components/src/badge/README.md
+++ b/packages/components/src/badge/README.md
@@ -4,6 +4,8 @@
 
 🔒 This component is locked as a [private API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-private-apis/). We do not yet recommend using this outside of the Gutenberg project.
 
+<p class="callout callout-alert">This component is deprecated. Please use `Badge` from the `@wordpress/ui` package instead.</p>
+
 <p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>
 
 ## Props

--- a/packages/components/src/badge/docs-manifest.json
+++ b/packages/components/src/badge/docs-manifest.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "../../schemas/docs-manifest.json",
 	"displayName": "Badge",
-	"filePath": "./index.tsx"
+	"filePath": "./index.tsx",
+	"deprecated": "Please use `Badge` from the `@wordpress/ui` package instead."
 }

--- a/packages/components/src/badge/index.tsx
+++ b/packages/components/src/badge/index.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { info, caution, error, published } from '@wordpress/icons';
+import deprecated from '@wordpress/deprecated';
 import type { BadgeProps } from './types';
 import type { WordPressComponentProps } from '../context';
 import Icon from '../icon';
@@ -24,12 +25,21 @@ function contextBasedIcon( intent: BadgeProps[ 'intent' ] = 'default' ) {
 	}
 }
 
+/**
+ * @deprecated Use `Badge` from `@wordpress/ui` instead.
+ */
 function Badge( {
 	className,
 	intent = 'default',
 	children,
 	...props
 }: WordPressComponentProps< BadgeProps, 'span', false > ) {
+	deprecated( 'wp.components.privateApis.Badge', {
+		since: '7.2',
+		alternative: 'Badge from @wordpress/ui',
+		hint: 'This private API will be completely removed within a few Gutenberg plugin releases.',
+	} );
+
 	const icon = contextBasedIcon( intent );
 	const hasIcon = !! icon;
 

--- a/packages/components/src/badge/stories/index.story.tsx
+++ b/packages/components/src/badge/stories/index.story.tsx
@@ -1,16 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import Badge from '..';
 
+/**
+ * This component is deprecated. Please use `Badge` from the `@wordpress/ui`
+ * package instead.
+ */
 const meta: Meta< typeof Badge > = {
 	component: Badge,
-	title: 'Components/Containers/Badge',
+	title: 'Components/Deprecated/Badge',
 	id: 'components-badge',
 	tags: [ 'status-private' ],
 	parameters: {
 		componentStatus: {
-			status: 'use-with-caution',
+			status: 'not-recommended',
 			whereUsed: 'global',
-			notes: 'Will be superseded by [`Badge`](?path=/docs/design-system-components-badge--docs) in `@wordpress/ui`, but continue using for now.',
+			notes: 'Deprecated. Use [`Badge`](?path=/docs/design-system-components-badge--docs) from `@wordpress/ui` instead.',
 		},
 	},
 };

--- a/packages/components/src/badge/test/index.jsdom.test.tsx
+++ b/packages/components/src/badge/test/index.jsdom.test.tsx
@@ -6,6 +6,16 @@ const Badge = ( props: React.ComponentProps< typeof _Badge > ) => (
 	<_Badge data-testid={ testid } { ...props } />
 );
 
+describe( 'Shows a deprecation warning', () => {
+	it( 'Badge', () => {
+		render( <Badge>Code is Poetry</Badge> );
+
+		expect( console ).toHaveWarnedWith(
+			'wp.components.privateApis.Badge is deprecated since version 7.2. Please use Badge from @wordpress/ui instead. Note: This private API will be completely removed within a few Gutenberg plugin releases.'
+		);
+	} );
+} );
+
 describe( 'Badge', () => {
 	it( 'should render correctly with default props', () => {
 		render( <Badge>Code is Poetry</Badge> );

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   Update `use-recommended-components` rule to prefer `Badge` from `@wordpress/ui` over the private `@wordpress/components` `Badge`. ([#82379](https://github.com/WordPress/gutenberg/pull/82379))
 -   Update `use-recommended-components` rule to prefer `@wordpress/ui` `Field` and `Fieldset` over legacy `@wordpress/components` `BaseControl` ([#82095](https://github.com/WordPress/gutenberg/pull/82095)).
 
 ### Bug Fixes

--- a/packages/eslint-plugin/rules/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/use-recommended-components.js
@@ -85,6 +85,7 @@ const DENYLIST = {
 			'{{ name }} is planned for deprecation. Write your own CSS instead.',
 		Animate:
 			'Write your own CSS animations instead, preferably using the motion tokens available in `@wordpress/theme`.',
+		Badge: 'Use `{{ name }}` from `@wordpress/ui` instead.',
 		BaseControl:
 			'Use `Field` from `@wordpress/ui` instead. For a purely visual label, use `Field.VisualLabel`. For a group legend, use `Fieldset` and `Fieldset.Legend`.',
 		Card: 'Use `Card.Root` from `@wordpress/ui` instead.',

--- a/tools/docs/gen-components-docs/index.mjs
+++ b/tools/docs/gen-components-docs/index.mjs
@@ -128,6 +128,7 @@ await Promise.all(
 			typeDocs,
 			subcomponentTypeDocs,
 			tags,
+			deprecated: manifest.deprecated,
 		} );
 		const outputFile = path.resolve(
 			path.dirname( manifestPath ),

--- a/tools/docs/gen-components-docs/markdown/index.mjs
+++ b/tools/docs/gen-components-docs/markdown/index.mjs
@@ -15,6 +15,7 @@ export function generateMarkdownDocs( {
 	typeDocs,
 	subcomponentTypeDocs,
 	tags,
+	deprecated,
 } ) {
 	const mainDocsJson = [
 		{ h1: typeDocs.displayName },
@@ -22,6 +23,11 @@ export function generateMarkdownDocs( {
 		tags.includes( 'status-private' ) && [
 			{
 				p: '🔒 This component is locked as a [private API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-private-apis/). We do not yet recommend using this outside of the Gutenberg project.',
+			},
+		],
+		deprecated && [
+			{
+				p: `<p class="callout callout-alert">This component is deprecated. ${ deprecated }</p>`,
 			},
 		],
 		{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Depends on https://github.com/WordPress/gutenberg/issues/82440

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Deprecates private `Badge` component from `@wordpress/components` and directs future usage to Badge from `@wordpress/ui`.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Newer [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs) from `@wordpress/ui` is ready to use.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Marked the private `@wordpress/components` `Badge` as deprecated, following the same patterns as `ButtonGroup` / `ValidatedInputControl` / `Surface`.
- Runtime — `deprecated( 'wp.components.privateApis.Badge', … )` warning.
- Storybook — Moved to Components/Deprecated folder with "not-recommended" status.
- README — Alert callout. Wired through `docs-manifest.json` deprecated so regeneration keeps it.
- Tests


Nine existing `unlock( … Badge )` calls will start logging the warning, and migrating them can be a follow-up:

| Package | File |
|---|---|
| `block-editor` | `src/components/block-card/index.jsx` |
| `block-editor` | `src/components/block-visibility/viewport-visibility-info.jsx` |
| `block-editor` | `src/components/global-styles/state-control-badges.jsx` |
| `block-editor` | `src/components/link-control/link-preview.jsx` |
| `block-editor` | `src/components/link-picker/link-preview.jsx` |
| `block-library` | `src/video/tracks-editor.jsx` |
| `editor` | `src/components/post-card-panel/index.jsx` |
| `fields` | `src/fields/page-title/view.tsx` |
| `global-styles-ui` | `src/screen-revisions/revisions-buttons.tsx` |

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Badge usage in Gutenberg yelds console warning.
Storybook changes make sense.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="1383" height="713" alt="Screenshot 2026-09-03 at 14 25 24" src="https://github.com/user-attachments/assets/7367c262-f65f-432a-a49c-3cf124bea087" />

### After
<img width="1757" height="966" alt="Screenshot 2026-09-03 at 13 53 00" src="https://github.com/user-attachments/assets/13da13b3-1c84-417a-aad0-537479eb40b0" />

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Deprecated the private `Badge` component.
  * Added runtime warnings, documentation, and Storybook guidance directing users to `Badge` from `@wordpress/ui`, including removal guidance.
  * Updated recommended-component checks to prefer the replacement.

* **Documentation**
  * Added support for deprecation notices and replacement guidance in generated component documentation.

* **Tests**
  * Added coverage verifying the deprecation warning is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->