### PR TITLE
Page: make badges declarative

### DIFF
--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
-import { Stack, Text } from '@wordpress/ui';
+import { Badge, Stack, Text } from '@wordpress/ui';
 import Navigation from '../navigation';
 import type { NavigationConfig } from '../navigation/types';
 import { SidebarToggleSlot } from './sidebar-toggle-slot';
-import type { PageComponents } from './types';
+import type { PageBadge, PageComponents } from './types';
 import styles from './style.module.css';
 
 export default function Header( {
@@ -20,7 +20,7 @@ export default function Header( {
 }: {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
-	badges?: React.ReactNode;
+	badges?: PageBadge[];
 	visual?: React.ReactNode;
 	title?: React.ReactNode;
 	subTitle: React.ReactNode;
@@ -77,7 +77,11 @@ export default function Header( {
 						</Text>
 					) }
 					{ breadcrumbs }
-					{ badges }
+					{ badges?.map( ( badge, index ) => (
+						<Badge key={ index } intent={ badge.intent }>
+							{ badge.label }
+						</Badge>
+					) ) }
 				</Stack>
 				{ actions && (
 					<Stack

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import type { NavigationConfig } from '../navigation/types';
 import Header from './header';
-import type { PageComponents } from './types';
+import type { PageBadge, PageComponents } from './types';
 import NavigableRegion from '../navigable-region';
 import { SidebarToggleFill } from './sidebar-toggle-slot';
 import styles from './style.module.css';
@@ -24,7 +24,10 @@ function Page( {
 }: {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
 	breadcrumbs?: React.ReactNode;
-	badges?: React.ReactNode;
+	/**
+	 * Badges displayed alongside the page title.
+	 */
+	badges?: PageBadge[];
 	/**
 	 * Optional visual mark (icon, image, etc.) shown before the page title or breadcrumbs.
 	 *
@@ -63,7 +66,7 @@ function Page( {
 		<NavigableRegion className={ classes } ariaLabel={ effectiveAriaLabel }>
 			{ ( title ||
 				breadcrumbs ||
-				badges ||
+				!! badges?.length ||
 				actions ||
 				visual ||
 				!! navigation?.items?.length ) && (

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useCallback, useState } from '@wordpress/element';
 // eslint-disable-next-line @wordpress/use-recommended-components -- admin-ui is a bundled package that depends on @wordpress/ui
-import { Badge, Button, Text } from '@wordpress/ui';
+import { Button, Text } from '@wordpress/ui';
 import { Icon, wordpress } from '@wordpress/icons';
 import Page from '..';
 import Breadcrumbs from '../../breadcrumbs';
@@ -141,7 +141,7 @@ export const WithoutHeader: Story = {
 export const WithTitleAndBadges: Story = {
 	args: {
 		title: 'Page title',
-		badges: <Badge intent="informational">Status</Badge>,
+		badges: [ { label: 'Status', intent: 'informational' } ],
 		showSidebarToggle: false,
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
@@ -160,7 +160,7 @@ export const WithBreadcrumbsAndBadges: Story = {
 				] }
 			/>
 		),
-		badges: <Badge intent="none">Published</Badge>,
+		badges: [ { label: 'Published', intent: 'none' } ],
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
 	},
@@ -271,7 +271,7 @@ export const FullHeader: Story = {
 				] }
 			/>
 		),
-		badges: <Badge intent="informational">Status</Badge>,
+		badges: [ { label: 'Status', intent: 'informational' } ],
 		navigation: {
 			items: [
 				{ label: 'Overview', href: '/overview' },

--- a/packages/admin-ui/src/page/types.ts
+++ b/packages/admin-ui/src/page/types.ts
@@ -1,5 +1,20 @@
-import { type ComponentType } from 'react';
+import { type ComponentProps, type ComponentType } from 'react';
+import type { Badge } from '@wordpress/ui';
 import type { NavigationLinkProps } from '../navigation/types';
+
+export interface PageBadge {
+	/**
+	 * The text to display in the badge.
+	 */
+	label: string;
+
+	/**
+	 * The semantic intent of the badge, communicating its meaning through color.
+	 *
+	 * @default "none"
+	 */
+	intent?: ComponentProps< typeof Badge >[ 'intent' ];
+}
 
 export interface PageComponents {
 	/**


### PR DESCRIPTION
WIP

Part of https://github.com/WordPress/gutenberg/issues/77628

Adds declarative badges prop to the existing Page component: badges is now an array of { label, intent } instead of React.ReactNode, rendered internally via Badge from @wordpress/ui. 

This is a breaking change.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
