### PR TITLE
Page: make breadcrumbs declarative

### DIFF
--- a/packages/admin-ui/src/page/breadcrumbs.tsx
+++ b/packages/admin-ui/src/page/breadcrumbs.tsx
@@ -1,0 +1,44 @@
+// eslint-disable-next-line @wordpress/use-recommended-components -- `Breadcrumb` is the intended primitive for Page's declarative `breadcrumbs` prop; it predates the component's promotion to the recommended allowlist.
+import { Breadcrumb } from '@wordpress/ui';
+import type { PageBreadcrumbItem } from './types';
+
+/**
+ * Renders the `Page` `breadcrumbs` prop (declarative data) as a
+ * `Breadcrumb` trail from `@wordpress/ui`.
+ *
+ * All items except the last one must provide an `href`. In development mode,
+ * an error is thrown when a non-last item is missing `href`. The last item
+ * represents the current page.
+ */
+export default function PageBreadcrumbs( {
+	items,
+}: {
+	items: PageBreadcrumbItem[];
+} ) {
+	if ( ! items.length ) {
+		return null;
+	}
+
+	const precedingItems = items.slice( 0, -1 );
+	const lastItem = items[ items.length - 1 ];
+
+	if ( process.env.NODE_ENV !== 'production' ) {
+		const invalidItem = precedingItems.find( ( item ) => ! item.href );
+		if ( invalidItem ) {
+			throw new Error(
+				`Page: breadcrumb item "${ invalidItem.label }" is missing an \`href\`. All items except the last one must have an \`href\`.`
+			);
+		}
+	}
+
+	return (
+		<Breadcrumb.Root>
+			{ precedingItems.map( ( item, index ) => (
+				<Breadcrumb.LinkItem key={ index } href={ item.href ?? '' }>
+					{ item.label }
+				</Breadcrumb.LinkItem>
+			) ) }
+			<Breadcrumb.CurrentItem>{ lastItem.label }</Breadcrumb.CurrentItem>
+		</Breadcrumb.Root>
+	);
+}

--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -3,7 +3,8 @@ import { Stack, Text } from '@wordpress/ui';
 import Navigation from '../navigation';
 import type { NavigationConfig } from '../navigation/types';
 import { SidebarToggleSlot } from './sidebar-toggle-slot';
-import type { PageComponents } from './types';
+import PageBreadcrumbs from './breadcrumbs';
+import type { PageBreadcrumbItem, PageComponents } from './types';
 import styles from './style.module.css';
 
 export default function Header( {
@@ -19,7 +20,7 @@ export default function Header( {
 	showSidebarToggle = true,
 }: {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
-	breadcrumbs?: React.ReactNode;
+	breadcrumbs?: PageBreadcrumbItem[];
 	badges?: React.ReactNode;
 	visual?: React.ReactNode;
 	title?: React.ReactNode;
@@ -76,7 +77,9 @@ export default function Header( {
 							{ title }
 						</Text>
 					) }
-					{ breadcrumbs }
+					{ !! breadcrumbs?.length && (
+						<PageBreadcrumbs items={ breadcrumbs } />
+					) }
 					{ badges }
 				</Stack>
 				{ actions && (

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import type { NavigationConfig } from '../navigation/types';
 import Header from './header';
-import type { PageComponents } from './types';
+import type { PageBreadcrumbItem, PageComponents } from './types';
 import NavigableRegion from '../navigable-region';
 import { SidebarToggleFill } from './sidebar-toggle-slot';
 import styles from './style.module.css';
@@ -23,7 +23,11 @@ function Page( {
 	showSidebarToggle = true,
 }: {
 	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
-	breadcrumbs?: React.ReactNode;
+	/**
+	 * An array of items to display in the breadcrumb trail. The last item is
+	 * considered the current item.
+	 */
+	breadcrumbs?: PageBreadcrumbItem[];
 	badges?: React.ReactNode;
 	/**
 	 * Optional visual mark (icon, image, etc.) shown before the page title or breadcrumbs.
@@ -62,7 +66,7 @@ function Page( {
 	return (
 		<NavigableRegion className={ classes } ariaLabel={ effectiveAriaLabel }>
 			{ ( title ||
-				breadcrumbs ||
+				!! breadcrumbs?.length ||
 				badges ||
 				actions ||
 				visual ||

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -4,9 +4,7 @@ import { useCallback, useState } from '@wordpress/element';
 import { Badge, Button, Text } from '@wordpress/ui';
 import { Icon, wordpress } from '@wordpress/icons';
 import Page from '..';
-import Breadcrumbs from '../../breadcrumbs';
 import type { NavigationLinkProps } from '../../navigation/types';
-import { withRouter } from '../../stories/with-router';
 
 const meta: Meta< typeof Page > = {
 	component: Page,
@@ -47,17 +45,12 @@ export const WithSubtitle: Story = {
 };
 
 export const WithBreadcrumbs: Story = {
-	decorators: [ withRouter ],
 	args: {
 		showSidebarToggle: false,
-		breadcrumbs: (
-			<Breadcrumbs
-				items={ [
-					{ label: 'Root breadcrumb', to: '/connectors' },
-					{ label: 'Level 1 breadcrumb' },
-				] }
-			/>
-		),
+		breadcrumbs: [
+			{ label: 'Root breadcrumb', href: '/connectors' },
+			{ label: 'Level 1 breadcrumb' },
+		],
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
 	},
@@ -74,18 +67,13 @@ export const WithVisual: Story = {
 };
 
 export const WithVisualAndBreadcrumbs: Story = {
-	decorators: [ withRouter ],
 	args: {
 		visual: <Icon icon={ wordpress } size={ 24 } />,
 		showSidebarToggle: false,
-		breadcrumbs: (
-			<Breadcrumbs
-				items={ [
-					{ label: 'Root breadcrumb', to: '/connectors' },
-					{ label: 'Level 1 breadcrumb' },
-				] }
-			/>
-		),
+		breadcrumbs: [
+			{ label: 'Root breadcrumb', href: '/connectors' },
+			{ label: 'Level 1 breadcrumb' },
+		],
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
 	},
@@ -113,18 +101,13 @@ export const WithImageVisual: Story = {
 };
 
 export const WithBreadcrumbsAndSubtitle: Story = {
-	decorators: [ withRouter ],
 	args: {
 		showSidebarToggle: false,
 		subTitle: 'All of the subtitle text you need goes here.',
-		breadcrumbs: (
-			<Breadcrumbs
-				items={ [
-					{ label: 'Root breadcrumb', to: '/connectors' },
-					{ label: 'Level 1 breadcrumb' },
-				] }
-			/>
-		),
+		breadcrumbs: [
+			{ label: 'Root breadcrumb', href: '/connectors' },
+			{ label: 'Level 1 breadcrumb' },
+		],
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
 	},
@@ -149,17 +132,12 @@ export const WithTitleAndBadges: Story = {
 };
 
 export const WithBreadcrumbsAndBadges: Story = {
-	decorators: [ withRouter ],
 	args: {
 		showSidebarToggle: false,
-		breadcrumbs: (
-			<Breadcrumbs
-				items={ [
-					{ label: 'Root breadcrumb', to: '/connectors' },
-					{ label: 'Level 1 breadcrumb' },
-				] }
-			/>
-		),
+		breadcrumbs: [
+			{ label: 'Root breadcrumb', href: '/connectors' },
+			{ label: 'Level 1 breadcrumb' },
+		],
 		badges: <Badge intent="none">Published</Badge>,
 		hasPadding: true,
 		children: <Text>Page content here</Text>,
@@ -259,18 +237,13 @@ export const WithNavigationAndActions: Story = {
 };
 
 export const FullHeader: Story = {
-	decorators: [ withRouter ],
 	args: {
 		visual: <Icon icon={ wordpress } size={ 24 } />,
 		subTitle: 'All of the subtitle text you need goes here.',
-		breadcrumbs: (
-			<Breadcrumbs
-				items={ [
-					{ label: 'Root breadcrumb', to: '/connectors' },
-					{ label: 'Level 1 breadcrumb' },
-				] }
-			/>
-		),
+		breadcrumbs: [
+			{ label: 'Root breadcrumb', href: '/connectors' },
+			{ label: 'Level 1 breadcrumb' },
+		],
 		badges: <Badge intent="informational">Status</Badge>,
 		navigation: {
 			items: [

--- a/packages/admin-ui/src/page/types.ts
+++ b/packages/admin-ui/src/page/types.ts
@@ -1,6 +1,20 @@
 import { type ComponentType } from 'react';
 import type { NavigationLinkProps } from '../navigation/types';
 
+export interface PageBreadcrumbItem {
+	/**
+	 * The label text for the breadcrumb item.
+	 */
+	label: string;
+
+	/**
+	 * The destination for the breadcrumb item.
+	 * It is optional for the last item (the current page).
+	 * All preceding items must provide an `href`.
+	 */
+	href?: string;
+}
+
 export interface PageComponents {
 	/**
 	 * Component rendered in place of the default `<a>` for link-based UI in


### PR DESCRIPTION
WIP

Adds declarative breadcrumbs prop to the existing Page component: breadcrumbs is now an array of { label, href } instead of React.ReactNode, rendered internally via the Breadcrumb primitive from @wordpress/ui instead of the route-coupled Breadcrumbs component. Page no longer needs a router context to render its own breadcrumbs; stories drop the withRouter decorator accordingly. This is a breaking change to Page's breadcrumbs prop; no production usage currently passes it.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
