### PR TITLE
Page: add Page.FullBleed and Page.Narrow

### DIFF
--- a/packages/admin-ui/src/page/full-bleed.tsx
+++ b/packages/admin-ui/src/page/full-bleed.tsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import styles from './style.module.css';
+
+/**
+ * A container that breaks out of `Page`'s inline padding to span
+ * edge-to-edge. Useful for content such as a full-width table that should
+ * align with the page's outer edges.
+ *
+ * Must be used as a child of `Page`, and only has an effect when the page's
+ * `hasPadding` prop is set — there is no padding to cancel otherwise.
+ */
+export const FullBleed = forwardRef<
+	HTMLDivElement,
+	React.ComponentPropsWithoutRef< 'div' >
+>( function PageFullBleed( { className, ...props }, ref ) {
+	return (
+		<div
+			ref={ ref }
+			className={ clsx( styles[ 'full-bleed' ], className ) }
+			{ ...props }
+		/>
+	);
+} );

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -4,6 +4,8 @@ import Header from './header';
 import type { PageComponents } from './types';
 import NavigableRegion from '../navigable-region';
 import { SidebarToggleFill } from './sidebar-toggle-slot';
+import { FullBleed } from './full-bleed';
+import { Narrow } from './narrow';
 import styles from './style.module.css';
 
 function Page( {
@@ -97,5 +99,7 @@ function Page( {
 }
 
 Page.SidebarToggleFill = SidebarToggleFill;
+Page.FullBleed = FullBleed;
+Page.Narrow = Narrow;
 
 export default Page;

--- a/packages/admin-ui/src/page/narrow.tsx
+++ b/packages/admin-ui/src/page/narrow.tsx
@@ -1,0 +1,22 @@
+import clsx from 'clsx';
+import { forwardRef } from '@wordpress/element';
+import styles from './style.module.css';
+
+/**
+ * A centered, width-constrained container for content that should not span
+ * the full width of the page, such as a settings form.
+ *
+ * Must be used as a child of `Page`.
+ */
+export const Narrow = forwardRef<
+	HTMLDivElement,
+	React.ComponentPropsWithoutRef< 'div' >
+>( function PageNarrow( { className, ...props }, ref ) {
+	return (
+		<div
+			ref={ ref }
+			className={ clsx( styles.narrow, className ) }
+			{ ...props }
+		/>
+	);
+} );

--- a/packages/admin-ui/src/page/stories/index.story.tsx
+++ b/packages/admin-ui/src/page/stories/index.story.tsx
@@ -296,3 +296,48 @@ export const FullHeader: Story = {
 		children: <Text>Page content here</Text>,
 	},
 };
+
+/**
+ * `Page.FullBleed` neutralizes the page's inline padding for its children,
+ * so content such as a full-width table can align with the page's outer
+ * edges. Only has an effect when `hasPadding` is set.
+ */
+export const WithFullBleedContent: Story = {
+	args: {
+		title: 'Page title',
+		showSidebarToggle: false,
+		hasPadding: true,
+		children: (
+			<>
+				<Text>Regular, padded content.</Text>
+				<Page.FullBleed
+					style={ {
+						background:
+							'var(--wpds-color-background-surface-neutral-strong)',
+						padding: 16,
+					} }
+				>
+					<Text>Full-bleed content, edge-to-edge.</Text>
+				</Page.FullBleed>
+				<Text>Regular, padded content.</Text>
+			</>
+		),
+	},
+};
+
+/**
+ * `Page.Narrow` centers and constrains the width of content, such as a
+ * settings form, that should not span the full width of the page.
+ */
+export const WithNarrowContent: Story = {
+	args: {
+		title: 'Page title',
+		showSidebarToggle: false,
+		hasPadding: true,
+		children: (
+			<Page.Narrow>
+				<Text>Narrow, centered content.</Text>
+			</Page.Narrow>
+		),
+	},
+};

--- a/packages/admin-ui/src/page/style.module.css
+++ b/packages/admin-ui/src/page/style.module.css
@@ -1,4 +1,7 @@
 .page {
+	--admin-ui-page-padding-inline: var(--wpds-dimension-padding-2xl);
+	--admin-ui-page-padding-block: var(--wpds-dimension-padding-lg);
+
 	display: flex;
 	height: 100%;
 	background-color: var(--wpds-color-background-surface-neutral);
@@ -10,7 +13,7 @@
 }
 
 .header {
-	padding: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
+	padding: var(--admin-ui-page-padding-block) var(--admin-ui-page-padding-inline);
 	border-block-end: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 	background: var(--wpds-color-background-surface-neutral-strong);
 	position: sticky;
@@ -81,6 +84,26 @@ truncates instead of overflowing the page horizontally. */
 	flex-direction: column;
 
 	&.has-padding {
-		padding: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
+		padding: var(--admin-ui-page-padding-block) var(--admin-ui-page-padding-inline);
 	}
+}
+
+/*
+ * Neutralizes `.content.has-padding`'s inline padding. Only meaningful when
+ * `hasPadding` is set — there is no padding to cancel otherwise.
+ */
+.full-bleed {
+	box-sizing: border-box;
+}
+
+.content.has-padding > .full-bleed {
+	margin-inline: calc(-1 * var(--admin-ui-page-padding-inline));
+	width: calc(100% + 2 * var(--admin-ui-page-padding-inline));
+}
+
+.narrow {
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 680px;
+	margin-inline: auto;
 }


### PR DESCRIPTION
WIP

Adds FullBleed (padding-cancelling edge-to-edge wrapper) and Narrow (centered, width-constrained wrapper) content components to the existing Page component.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
