### PR TITLE
Query Loop: Rename the "Keyword" filter to "Search terms" and add help text

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.jsx
+++ b/packages/block-library/src/query/edit/inspector-controls/index.jsx
@@ -440,6 +440,9 @@ export default function QueryInspectorControls( props ) {
 						>
 							<TextControl
 								label={ __( 'Keyword' ) }
+								help={ __(
+									'Filter the query by keywords in the title, excerpt, or content.'
+								) }
 								value={ querySearch }
 								onChange={ ( newQuerySearch ) => {
 									debouncedQuerySearch( newQuerySearch );

--- a/packages/block-library/src/query/edit/inspector-controls/index.jsx
+++ b/packages/block-library/src/query/edit/inspector-controls/index.jsx
@@ -432,16 +432,16 @@ export default function QueryInspectorControls( props ) {
 					{ showSearchControl && (
 						<ToolsPanelItem
 							hasValue={ () => !! querySearch }
-							label={ __( 'Keyword' ) }
+							label={ __( 'Search terms' ) }
 							onDeselect={ () => {
 								setQuery( { search: '' } );
 								setQuerySearch( '' );
 							} }
 						>
 							<TextControl
-								label={ __( 'Keyword' ) }
+								label={ __( 'Search terms' ) }
 								help={ __(
-									'Filter the query by keywords in the title, excerpt, or content.'
+									'Filter the query by keywords that appear in the content, title, or excerpt.'
 								) }
 								value={ querySearch }
 								onChange={ ( newQuerySearch ) => {


### PR DESCRIPTION
## What?

Fixes: https://github.com/WordPress/gutenberg/issues/60198

Renames the "Keyword" filter of the Query Loop block to "Search terms" and adds a help text describing what it searches (content, title, or excerpt).

The issue mentions the confusion with tags, so this also renames the filter as suggested in the issue. "Search terms" also matches better how the search works in core, as the value is split into multiple terms(by spaces or commas) and all of them need to match.

The help text is from Joen's suggestion [below](https://github.com/WordPress/gutenberg/pull/82387#issuecomment-5525928999).

## Testing Instructions

1. Add a Query Loop block.
2. In the "Filters" panel, select "Search terms".
3. Check the label and the help text under the input.
4. Add some terms and check that the results are filtered as before, in the editor and the front end.

## Screenshots

<img width="553" height="265" alt="Screenshot 2026-09-03 at 7 40 44 PM" src="https://github.com/user-attachments/assets/7ba500aa-98af-4e13-89d1-8eccc454edfc" />


## Use of AI Tools

Generated with Fable 5.1 and adjusted/reviewed manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added contextual help text to the query keyword filter, clarifying that searches include titles, excerpts, and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
