### PR TITLE
TreeSelect: Support the multiple prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   `TreeSelect`: Support the `multiple` prop, matching `SelectControl`.
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
 -   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -100,19 +100,22 @@ If this property is added, a label will be generated using label property as the
 
 The position of the label.
 
+### `multiple`
+
+ - Type: `false`
+ - Required: No
+ - Default: `false`
+
+If this property is added, multiple values can be selected. The `selectedId` passed should be an array.
+
+In most cases, it is preferable to use the `FormTokenField` or `CheckboxControl` components instead.
+
 ### `noOptionLabel`
 
  - Type: `string`
  - Required: No
 
 If this property is added, an option will be added with this label to represent empty selection.
-
-### `onChange`
-
- - Type: `((value: string, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void) | undefined`
- - Required: No
-
-A function that receives the value of the new option that is being selected as input.
 
 ### `options`
 
@@ -122,6 +125,16 @@ A function that receives the value of the new option that is being selected as i
 An array of option property objects to be rendered,
 each with a `label` and `value` property, as well as any other
 `<option>` attributes.
+
+### `onChange`
+
+ - Type: `((value: string, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void) | undefined`
+ - Required: No
+
+A function that receives the value of the new option that is being selected as input.
+
+If `multiple` is `true`, the value received is an array of the selected value.
+Otherwise, the value received is a single value with the new selected value.
 
 ### `prefix`
 
@@ -144,13 +157,6 @@ import {
   prefix={<InputControlPrefixWrapper>@</InputControlPrefixWrapper>}
 />
 ```
-
-### `selectedId`
-
- - Type: `string`
- - Required: No
-
-The id of the currently selected node.
 
 ### `size`
 
@@ -181,6 +187,15 @@ import {
   suffix={<InputControlSuffixWrapper>%</InputControlSuffixWrapper>}
 />
 ```
+
+### `selectedId`
+
+ - Type: `string`
+ - Required: No
+
+The id of the currently selected node.
+
+If `multiple` is true, the `selectedId` should be an array of selected node ids.
 
 ### `tree`
 

--- a/packages/components/src/tree-select/index.tsx
+++ b/packages/components/src/tree-select/index.tsx
@@ -1,12 +1,19 @@
 import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { SelectControl } from '../select-control';
-import type { TreeSelectProps, Tree, Truthy } from './types';
+import type { SelectControlSingleSelectionProps } from '../select-control/types';
+import type {
+	TreeSelectMultipleSelectionProps,
+	TreeSelectProps,
+	TreeSelectSingleSelectionProps,
+	Tree,
+	Truthy,
+} from './types';
 
 function getSelectOptions(
 	tree: Tree[],
 	level = 0
-): NonNullable< TreeSelectProps[ 'options' ] > {
+): NonNullable< SelectControlSingleSelectionProps[ 'options' ] > {
 	return tree.flatMap( ( treeNode ) => [
 		{
 			value: treeNode.id,
@@ -64,6 +71,12 @@ function getSelectOptions(
  * }
  * ```
  */
+export function TreeSelect(
+	props: TreeSelectSingleSelectionProps
+): JSX.Element;
+export function TreeSelect(
+	props: TreeSelectMultipleSelectionProps
+): JSX.Element;
 export function TreeSelect( props: TreeSelectProps ) {
 	const {
 		// Prevent passing legacy props to internal component.
@@ -71,9 +84,9 @@ export function TreeSelect( props: TreeSelectProps ) {
 		__next40pxDefaultSize: _next40pxDefaultSize,
 		label,
 		noOptionLabel,
-		onChange,
-		selectedId,
 		tree = [],
+		selectedId: _selectedId,
+		onChange: _onChange,
 		...restProps
 	} = props;
 
@@ -84,11 +97,26 @@ export function TreeSelect( props: TreeSelectProps ) {
 		].filter( < T, >( option: T ): option is Truthy< T > => !! option );
 	}, [ noOptionLabel, tree ] );
 
+	if ( props.multiple ) {
+		return (
+			<SelectControl
+				{ ...restProps }
+				label={ label }
+				multiple
+				options={ options }
+				onChange={ props.onChange }
+				value={ props.selectedId }
+			/>
+		);
+	}
+
 	return (
 		<SelectControl
-			{ ...{ label, options, onChange } }
-			value={ selectedId }
 			{ ...restProps }
+			label={ label }
+			options={ options }
+			onChange={ props.onChange }
+			value={ props.selectedId }
 		/>
 	);
 }

--- a/packages/components/src/tree-select/stories/index.story.tsx
+++ b/packages/components/src/tree-select/stories/index.story.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryFn } from '@storybook/react-vite';
-import type { ComponentProps } from 'react';
 import { useState } from '@wordpress/element';
 import TreeSelect from '../';
 
@@ -30,14 +29,25 @@ const meta: Meta< typeof TreeSelect > = {
 export default meta;
 
 const TreeSelectWithState: StoryFn< typeof TreeSelect > = ( props ) => {
-	const [ selection, setSelection ] =
-		useState< ComponentProps< typeof TreeSelect >[ 'selectedId' ] >();
+	const [ selectedId, setSelectedId ] = useState< string >();
+	const [ selectedIds, setSelectedIds ] = useState< string[] >();
+
+	if ( props.multiple ) {
+		return (
+			<TreeSelect
+				{ ...props }
+				multiple
+				onChange={ setSelectedIds }
+				selectedId={ selectedIds }
+			/>
+		);
+	}
 
 	return (
 		<TreeSelect
 			{ ...props }
-			onChange={ setSelection }
-			selectedId={ selection }
+			onChange={ setSelectedId }
+			selectedId={ selectedId }
 		/>
 	);
 };
@@ -73,4 +83,13 @@ Default.args = {
 			],
 		},
 	],
+};
+
+/**
+ * Native multi-select is a listbox. Hold Shift or Ctrl (Command on macOS) to select more than one option.
+ */
+export const Multiple = TreeSelectWithState.bind( {} );
+Multiple.args = {
+	...Default.args,
+	multiple: true,
 };

--- a/packages/components/src/tree-select/test/index.jsdom.test.tsx
+++ b/packages/components/src/tree-select/test/index.jsdom.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TreeSelect from '..';
+
+const tree = [
+	{
+		name: 'Page 1',
+		id: 'p1',
+		children: [ { name: 'Descend 1 of page 1', id: 'p11' } ],
+	},
+	{
+		name: 'Page 2',
+		id: 'p2',
+	},
+];
+
+describe( 'TreeSelect', () => {
+	it( 'should show flattened tree options including nested children', () => {
+		render( <TreeSelect label="Parent page" tree={ tree } /> );
+
+		expect(
+			screen.getByRole( 'option', { name: 'Page 1' } )
+		).toBeVisible();
+		expect(
+			screen.getByRole( 'option', { name: /Descend 1 of page 1/ } )
+		).toBeVisible();
+	} );
+
+	it( 'should call onChange with the selected node id', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<TreeSelect
+				label="Parent page"
+				tree={ tree }
+				onChange={ onChange }
+			/>
+		);
+
+		await user.selectOptions( screen.getByRole( 'combobox' ), 'p11' );
+
+		expect( onChange ).toHaveBeenCalledWith( 'p11', expect.anything() );
+	} );
+
+	it( 'should show noOptionLabel as an option', () => {
+		render(
+			<TreeSelect
+				label="Parent page"
+				noOptionLabel="No parent page"
+				tree={ tree }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'option', { name: 'No parent page' } )
+		).toBeVisible();
+	} );
+
+	it( 'should call onChange with an array of selected node ids when multiple', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<TreeSelect
+				label="Parent page"
+				multiple
+				tree={ tree }
+				onChange={ onChange }
+			/>
+		);
+
+		const listbox = screen.getByRole( 'listbox' );
+		await user.selectOptions( listbox, [ 'p1', 'p11' ] );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			[ 'p1', 'p11' ],
+			expect.anything()
+		);
+	} );
+
+	/* eslint-disable jest/expect-expect */
+	describe( 'static typing', () => {
+		it( 'should reject a string selectedId when multiple is true', () => {
+			<TreeSelect
+				multiple
+				// @ts-expect-error string is not an array of node ids
+				selectedId="p1"
+			/>;
+
+			<TreeSelect
+				selectedId="p1"
+				onChange={ ( value ) => {
+					const _id: string = value;
+					return _id;
+				} }
+			/>;
+
+			<TreeSelect
+				multiple
+				selectedId={ [ 'p1' ] }
+				onChange={ ( value ) => {
+					const _ids: string[] = value;
+					return _ids;
+				} }
+			/>;
+		} );
+	} );
+	/* eslint-enable jest/expect-expect */
+} );

--- a/packages/components/src/tree-select/types.ts
+++ b/packages/components/src/tree-select/types.ts
@@ -1,4 +1,7 @@
-import type { SelectControlSingleSelectionProps } from '../select-control/types';
+import type {
+	SelectControlMultipleSelectionProps,
+	SelectControlSingleSelectionProps,
+} from '../select-control/types';
 
 export type Truthy< T > = T extends false | '' | 0 | null | undefined
 	? never
@@ -10,27 +13,59 @@ export interface Tree {
 	children?: Tree[];
 }
 
-// `TreeSelect` inherits props from `SelectControl`, but only
-// in single selection mode (ie. when the `multiple` prop is not defined).
-export interface TreeSelectProps
-	extends Omit<
-		SelectControlSingleSelectionProps,
-		'value' | 'multiple' | 'onChange'
-	> {
+type TreeSelectOwnProps = {
 	/**
 	 * If this property is added, an option will be added with this label to represent empty selection.
 	 */
 	noOptionLabel?: string;
 	/**
-	 * A function that receives the value of the new option that is being selected as input.
-	 */
-	onChange?: SelectControlSingleSelectionProps[ 'onChange' ];
-	/**
 	 * An array containing the tree objects with the possible nodes the user can select.
 	 */
 	tree?: Tree[];
-	/**
-	 * The id of the currently selected node.
-	 */
-	selectedId?: SelectControlSingleSelectionProps[ 'value' ];
-}
+};
+
+export type TreeSelectSingleSelectionProps = Omit<
+	SelectControlSingleSelectionProps,
+	'value' | 'multiple'
+> &
+	TreeSelectOwnProps & {
+		/**
+		 * If this property is added, multiple values can be selected. The `selectedId` passed should be an array.
+		 *
+		 * In most cases, it is preferable to use the `FormTokenField` or `CheckboxControl` components instead.
+		 *
+		 * @default false
+		 */
+		multiple?: false;
+		/**
+		 * The id of the currently selected node.
+		 *
+		 * If `multiple` is true, the `selectedId` should be an array of selected node ids.
+		 */
+		selectedId?: SelectControlSingleSelectionProps[ 'value' ];
+	};
+
+export type TreeSelectMultipleSelectionProps = Omit<
+	SelectControlMultipleSelectionProps,
+	'value' | 'multiple'
+> &
+	TreeSelectOwnProps & {
+		/**
+		 * If this property is added, multiple values can be selected. The `selectedId` passed should be an array.
+		 *
+		 * In most cases, it is preferable to use the `FormTokenField` or `CheckboxControl` components instead.
+		 *
+		 * @default false
+		 */
+		multiple: true;
+		/**
+		 * The id of the currently selected node.
+		 *
+		 * If `multiple` is true, the `selectedId` should be an array of selected node ids.
+		 */
+		selectedId?: SelectControlMultipleSelectionProps[ 'value' ];
+	};
+
+export type TreeSelectProps =
+	| TreeSelectSingleSelectionProps
+	| TreeSelectMultipleSelectionProps;

--- a/test/unit/test-migration.json
+++ b/test/unit/test-migration.json
@@ -282,6 +282,7 @@
 			"packages/components/src/tree-grid/test/roving-tab-index-item.jsdom.test.tsx",
 			"packages/components/src/tree-grid/test/roving-tab-index.jsdom.test.tsx",
 			"packages/components/src/tree-grid/test/row.jsdom.test.tsx",
+			"packages/components/src/tree-select/test/index.jsdom.test.tsx",
 			"packages/components/src/truncate/test/index.jsdom.test.tsx",
 			"packages/components/src/unit-control/test/index.jsdom.test.tsx",
 			"packages/components/src/utils/hooks/test/use-controlled-state.jsdom.test.tsx",


### PR DESCRIPTION
## What?
Closes #63765

`TreeSelect` now accepts `SelectControl`'s `multiple` prop.

## Why?
`TreeSelect` was single-select only. `SelectControl` already supports native multi-select. Passing that through is the smallest way to give `TreeSelect` the same capability.

## How?
`TreeSelectProps` is a discriminant union, matching `SelectControl`. `selectedId` stays one prop. It is a string in single-select mode and a string array when `multiple` is true. `onChange` follows the same split. Flattening is unchanged. Callers that omit `multiple` keep the old types.

Function overloads keep the generated README on the single-select signature, so inherited prop types stay concrete. The Multiple story covers `multiple: true`. QueryControls, AuthorSelect, CategorySelect, and HierarchicalTermSelector are unchanged.

## Testing Instructions
1. Open the TreeSelect Multiple story in Storybook (`Components/Selection & Input/Common/TreeSelect`).
2. Confirm the control is a native listbox, not a combobox.
3. Click one option, then hold Shift or Command (Ctrl on Windows) and select another. Both stay selected.
4. Open the Default story and confirm single-select still works.

### Testing Instructions for Keyboard
1. Open the Multiple story.
2. Tab to the listbox.
3. Use Arrow keys to move. Hold Shift and press Arrow to extend the selection.