### PR TITLE
Style Book: Skip the extra iframe document tab stop

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Style Book: Skip the extra iframe document tab stop before interactive examples.
 -   Attach media an Image or Gallery block displays to the post on save, when it is not already attached to another post, matching what uploading into that post has always done ([#81977](https://github.com/WordPress/gutenberg/pull/81977)).
 -   Color the welcome guide's hovered button icon with `color` rather than `fill`, so stroke-based icons follow it. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `EditorInterface`: Apply the `showListViewByDefault` preference when the editor enters edit mode, so every editor built on the package honors it — including the extensible site editor, which previously ignored it. The logic moves here from `edit-post` and `edit-site`.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Bug Fixes
 
--   Style Book: Skip the extra iframe document tab stop before interactive examples.
+-   Style Book: Skip the extra iframe document tab stop before interactive examples ([#82393](https://github.com/WordPress/gutenberg/pull/82393)).
 -   Attach media an Image or Gallery block displays to the post on save, when it is not already attached to another post, matching what uploading into that post has always done ([#81977](https://github.com/WordPress/gutenberg/pull/81977)).
 -   Color the welcome guide's hovered button icon with `color` rather than `fill`, so stroke-based icons follow it. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `EditorInterface`: Apply the `showListViewByDefault` preference when the editor enters edit mode, so every editor built on the package honors it — including the extensible site editor, which previously ignored it. The logic moves here from `edit-post` and `edit-site`.

--- a/packages/editor/src/components/style-book/index.jsx
+++ b/packages/editor/src/components/style-book/index.jsx
@@ -12,6 +12,8 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import { useSelect, dispatch } from '@wordpress/data';
+import { useRefEffect } from '@wordpress/compose';
+import { focus } from '@wordpress/dom';
 import { mergeGlobalStyles } from '@wordpress/global-styles-engine';
 import {
 	useMemo,
@@ -557,6 +559,27 @@ export const StyleBookBody = ( {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ hasIframeLoaded, setHasIframeLoaded ] = useState( false );
 	const iframeRef = useRef( null );
+	const contentRef = useRefEffect(
+		( node ) => {
+			if ( ! onSelect || onClick ) {
+				return;
+			}
+
+			const { ownerDocument } = node;
+			const onFocus = ( event ) => {
+				// Firefox focuses the iframe document before its contents, even
+				// when neither the iframe nor its body has a tabindex.
+				if ( event.target === ownerDocument ) {
+					focus.tabbable.find( node )[ 0 ]?.focus();
+				}
+			};
+			ownerDocument.addEventListener( 'focus', onFocus, true );
+			return () => {
+				ownerDocument.removeEventListener( 'focus', onFocus, true );
+			};
+		},
+		[ onSelect, onClick ]
+	);
 	// The presence of an `onClick` prop indicates that the Style Book is being used as a button.
 	// In this case, add additional props to the iframe to make it behave like a button.
 	const buttonModeProps = {
@@ -596,6 +619,7 @@ export const StyleBookBody = ( {
 		<Iframe
 			onLoad={ handleLoad }
 			ref={ iframeRef }
+			contentRef={ contentRef }
 			className={ clsx( 'editor-style-book__iframe', {
 				'is-focused': isFocused && !! onClick,
 				'is-button': !! onClick,

--- a/packages/editor/src/components/style-book/test/index.jsdom.test.js
+++ b/packages/editor/src/components/style-book/test/index.jsdom.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createElement, forwardRef } from '@wordpress/element';
+import { StyleBookBody } from '../';
+
+vi.hoisted( () => {
+	globalThis.wpVitest.mockMatchMedia();
+} );
+
+// JSDOM cannot load the iframe's blob document. Test the button-mode keyboard
+// handlers here; native iframe focus navigation is covered by the e2e tests.
+vi.mock( '@wordpress/block-editor/src/components/iframe', () => ( {
+	default: forwardRef( ( { role, tabIndex, onKeyDown, onClick }, ref ) =>
+		createElement( 'iframe', { role, tabIndex, onKeyDown, onClick, ref } )
+	),
+} ) );
+
+describe( 'StyleBookBody', () => {
+	it.each( [
+		[ 'Enter', 13 ],
+		[ 'Space', 32 ],
+	] )( 'activates button previews with %s', ( name, keyCode ) => {
+		const onClick = vi.fn();
+		render(
+			createElement( StyleBookBody, {
+				onClick,
+				settings: { styles: [] },
+			} )
+		);
+		const preview = screen.getByRole( 'button' );
+		expect( preview ).toHaveAttribute( 'tabindex', '0' );
+		fireEvent.keyDown( preview, {
+			key: name === 'Space' ? ' ' : name,
+			keyCode,
+		} );
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -70,6 +70,72 @@ test.describe( 'Style Book', () => {
 		).toBeVisible();
 	} );
 
+	test( 'should tab directly from the selected category to its first example @firefox @webkit', async ( {
+		page,
+	} ) => {
+		for ( const category of [ 'Overview', 'Text' ] ) {
+			const tab = page.getByRole( 'tab', {
+				name: category,
+				exact: true,
+			} );
+			await tab.focus();
+			await expect( tab ).toHaveAttribute( 'aria-selected', 'true' );
+
+			const firstExample = page
+				.getByRole( 'tabpanel', { name: category, exact: true } )
+				.frameLocator( '[name="style-book-canvas"]' )
+				.getByRole( 'button' )
+				.first();
+			await expect( firstExample ).toBeVisible();
+			await page.keyboard.press( 'Tab' );
+			await expect( firstExample ).toBeFocused();
+
+			await tab.focus();
+			await page.keyboard.press( 'ArrowRight' );
+			await page.keyboard.press( 'Enter' );
+		}
+	} );
+
+	test( 'should shift-tab directly from the first example to the selected category @firefox @webkit', async ( {
+		page,
+	} ) => {
+		for ( const category of [ 'Overview', 'Text' ] ) {
+			const tab = page.getByRole( 'tab', {
+				name: category,
+				exact: true,
+			} );
+			await tab.click();
+
+			await page
+				.getByRole( 'tabpanel', { name: category, exact: true } )
+				.frameLocator( '[name="style-book-canvas"]' )
+				.getByRole( 'button' )
+				.first()
+				.focus();
+			await page.keyboard.press( 'Shift+Tab' );
+			await expect( tab ).toBeFocused();
+		}
+	} );
+
+	test( 'should navigate examples with arrow keys @firefox @webkit', async ( {
+		page,
+	} ) => {
+		await page.getByRole( 'tab', { name: 'Media', exact: true } ).click();
+		const examples = page
+			.getByRole( 'tabpanel', { name: 'Media', exact: true } )
+			.frameLocator( '[name="style-book-canvas"]' )
+			.getByRole( 'button' );
+		await examples.first().focus();
+		await page.keyboard.press( 'ArrowDown' );
+		await expect( examples.nth( 1 ) ).toBeFocused();
+		await page.keyboard.press( 'Tab' );
+		await expect( examples.nth( 1 ) ).not.toBeFocused();
+		await page.keyboard.press( 'Shift+Tab' );
+		await expect( examples.nth( 1 ) ).toBeFocused();
+		await page.keyboard.press( 'ArrowUp' );
+		await expect( examples.first() ).toBeFocused();
+	} );
+
 	test( 'should open correct Global Styles panel when example is clicked', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
Closes #65065.

## What?

Skip the extra iframe document tab stop before interactive Style Book examples.

## Why?

In Firefox, Tab from a category stops on the iframe document before reaching an example. Changing the body's tabindex does not remove that stop.

## How?

When the interactive Style Book document receives focus, move focus to its tabbable example. This preserves the active example when returning to the grid. Button and static previews keep their existing behavior. The shared `Iframe` and `WritingFlow` components are unchanged.

## Testing Instructions

1. Open the Site Editor with a block theme, then open Styles and Style Book.
2. Follow the keyboard steps below in Chrome, Firefox, and Safari.
3. Check that selecting an example still opens its Styles panel. With a supported classic theme, open `wp-admin/site-editor.php` and choose Styles to check the static preview.

### Testing Instructions for Keyboard

1. Focus the Overview category and press Tab. Focus should move directly to the first example.
2. Press Shift+Tab. Focus should return directly to Overview.
3. Press Right Arrow, then Enter to activate Text. Repeat the Tab and Shift+Tab checks.
4. Activate Media and enter its examples. Use Down and Up Arrow to move between examples.
5. From a different example, press Tab to leave the grid, then Shift+Tab. Focus should return to that same example.

<details>
<summary>Verification</summary>

The forward Tab regression failed in Firefox before the fix. The full Style Book spec passed three times, with the keyboard cases also running in Firefox and WebKit, for 54 passing executions. Build, typecheck, focused lint, unit tests, and test-routing checks passed.

Native Safari and screen-reader testing remain unverified. Button-mode keyboard handlers have unit coverage with an iframe stub; there is no current application caller for that mode.

</details>

## Screen capture


https://github.com/user-attachments/assets/d6293ef6-98b8-4743-a373-d1e684228d1e


## Use of AI Tools

Codex implemented the change, added and ran the tests, and drafted this description. Human review is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Style Book keyboard navigation by skipping the extra iframe tab stop before interactive examples.
  - Focus now moves directly to the first tabbable example when entering interactive previews.

- **Accessibility**
  - Improved navigation between Style Book categories and examples, including forward/reverse tabbing and arrow-key movement.
  - Interactive button previews now respond correctly to Enter and Space keyboard input.

- **Deprecations**
  - Deprecated menu-link behavior for `PluginPreviewMenuItem`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->