### PR TITLE
Add the template e2e tests for the editor inspector consolidation experiment

### DIFF
--- a/test/e2e/specs/editor/various/post-summary-dataform/pages.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/pages.spec.js
@@ -1,0 +1,160 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS, openPostSummary } = require( './utils' );
+
+/*
+ * Mirrors the 'swap template and reset to default' and 'change template
+ * options should respect the declared `postTypes`' tests of
+ * `test/e2e/specs/site-editor/pages.spec.js` with the DataForm inspector
+ * experiment enabled; delete those tests when the experiment graduates.
+ */
+/**
+ * Activates a theme, retrying on the transient "socket hang up"
+ * (ECONNRESET) connection error that intermittently occurs in CI.
+ *
+ * See https://github.com/WordPress/gutenberg/issues/74483.
+ *
+ * @param {Object} requestUtils Playwright request utils.
+ * @param {string} themeSlug    Theme slug to activate.
+ */
+async function activateThemeWithRetry( requestUtils, themeSlug ) {
+	const maxAttempts = 3;
+	for ( let attempt = 1; attempt <= maxAttempts; attempt++ ) {
+		try {
+			await requestUtils.activateTheme( themeSlug );
+			return;
+		} catch ( error ) {
+			const isTransient = /socket hang up|ECONNRESET/i.test(
+				error?.message ?? ''
+			);
+			if ( ! isTransient || attempt === maxAttempts ) {
+				throw error;
+			}
+		}
+	}
+}
+
+async function draftNewPage( page ) {
+	await page.getByRole( 'button', { name: 'Pages' } ).click();
+	await page.getByRole( 'button', { name: 'Add page' } ).click();
+	await page
+		.getByRole( 'dialog', { name: 'Draft new: page' } )
+		.getByRole( 'textbox', { name: 'title' } )
+		.fill( 'Test Page' );
+	await page.keyboard.press( 'Enter' );
+	await expect(
+		page
+			.getByRole( 'button', { name: 'Dismiss this notice' } )
+			.getByText( '"Test Page" successfully created.' )
+	).toBeVisible();
+}
+
+test.describe( 'Pages (DataForm inspector)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await activateThemeWithRetry( requestUtils, 'emptytheme' );
+		await Promise.all( [
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllPages(),
+		] );
+	} );
+
+	test.beforeEach( async ( { requestUtils, admin } ) => {
+		await Promise.all( [
+			requestUtils.setGutenbergExperiments( EXPERIMENTS ),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllPages(),
+		] );
+		await admin.visitSiteEditor();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await activateThemeWithRetry( requestUtils, 'twentytwentyone' );
+		await Promise.all( [
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllPages(),
+		] );
+	} );
+
+	test( 'swap template and reset to default', async ( {
+		admin,
+		page,
+		editor,
+	} ) => {
+		// Create a custom template first.
+		const templateName = 'demo';
+		await page.getByRole( 'button', { name: 'Templates' } ).click();
+		await page.getByRole( 'button', { name: 'Add template' } ).click();
+		await page
+			.getByRole( 'button', {
+				name: 'A custom template can be manually applied to any post or page.',
+			} )
+			.click();
+		// Fill the template title and submit.
+		await page
+			.getByRole( 'dialog', { name: 'Create custom template' } )
+			.getByRole( 'textbox', { name: 'Name' } )
+			.fill( templateName );
+		await page.keyboard.press( 'Enter' );
+		await page
+			.locator( '.block-editor-block-patterns-list__list-item' )
+			.click();
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+		await admin.visitSiteEditor();
+
+		// Create new page that has the default template so as to swap it.
+		await draftNewPage( page );
+		const summary = await openPostSummary( { editor, page } );
+		const templateButton = summary.getByRole( 'button', {
+			name: 'Edit Template',
+		} );
+		await expect( templateButton ).toHaveAccessibleDescription(
+			'Single Entries'
+		);
+		await templateButton.click();
+		const templateSelect = page.getByRole( 'combobox', {
+			name: 'Template',
+		} );
+		// Empty theme's custom template with `postTypes: ['post']`, should not be suggested.
+		await expect( templateSelect.getByRole( 'option' ) ).toHaveText( [
+			'Single Entries',
+			templateName,
+		] );
+		await templateSelect.selectOption( { label: templateName } );
+		await page.keyboard.press( 'Escape' );
+		await expect( templateButton ).toHaveAccessibleDescription(
+			templateName
+		);
+		await editor.saveSiteEditorEntities( {
+			isOnlyCurrentEntityDirty: true,
+		} );
+
+		// Now reset, and apply the default template back.
+		await templateButton.click();
+		await templateSelect.selectOption( { label: 'Single Entries' } );
+		await page.keyboard.press( 'Escape' );
+		await expect( templateButton ).toHaveAccessibleDescription(
+			'Single Entries'
+		);
+	} );
+
+	test( 'change template options should respect the declared `postTypes`', async ( {
+		page,
+		editor,
+	} ) => {
+		await draftNewPage( page );
+		const summary = await openPostSummary( { editor, page } );
+		await summary.getByRole( 'button', { name: 'Edit Template' } ).click();
+		// Empty theme has only one custom template with `postTypes: ['post']`,
+		// so it should not be suggested.
+		await expect(
+			page
+				.getByRole( 'combobox', { name: 'Template' } )
+				.getByRole( 'option' )
+		).toHaveText( [ 'Single Entries' ] );
+	} );
+} );

--- a/test/e2e/specs/editor/various/post-summary-dataform/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/post-editor-template-mode.spec.js
@@ -1,0 +1,306 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS, openPostSummary } = require( './utils' );
+
+/*
+ * Mirrors `test/e2e/specs/editor/various/post-editor-template-mode.spec.js`
+ * with the DataForm inspector experiment enabled; delete that spec when the
+ * experiment graduates.
+ */
+test.use( {
+	postEditorTemplateMode: async (
+		{ admin, editor, page, pageUtils, requestUtils },
+		use
+	) => {
+		await use(
+			new PostEditorTemplateMode( {
+				admin,
+				editor,
+				page,
+				pageUtils,
+				requestUtils,
+			} )
+		);
+	},
+} );
+
+test.describe( 'Post Editor Template mode (DataForm inspector)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( 'gutenberg-test-block-templates' );
+		// Document-Isolation-Policy places the editor in its own agent cluster.
+		// Template creation involves page reload and preview opens frontend
+		// pages without the DIP header, creating an agent cluster mismatch
+		// that breaks cross-window communication.
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
+	} );
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.setGutenbergExperiments( [] ),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllTemplates( 'wp_template_part' ),
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deactivatePlugin( 'gutenberg-test-block-templates' );
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-disable-client-side-media-processing'
+		);
+	} );
+
+	test( 'Allow to switch to template mode, edit the template and check the result', async ( {
+		editor,
+		page,
+		requestUtils,
+		postEditorTemplateMode,
+	} ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+
+		await postEditorTemplateMode.createPostAndSaveDraft();
+
+		await page.reload();
+		await postEditorTemplateMode.switchToTemplateMode();
+
+		// Edit the template.
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await page.keyboard.type(
+			'Just a random paragraph added to the template'
+		);
+
+		// Save changes.
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Back', exact: true } )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save', exact: true } )
+			.click();
+		await page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Save', exact: true } )
+			.click();
+
+		// Preview changes.
+		const previewPage = await editor.openPreviewPage();
+
+		await expect(
+			previewPage.getByText(
+				'Just a random paragraph added to the template',
+				{ exact: true }
+			)
+		).toBeVisible();
+	} );
+
+	test( 'Change templates and proper template resolution when switching to default template', async ( {
+		editor,
+		page,
+		requestUtils,
+		postEditorTemplateMode,
+	} ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await postEditorTemplateMode.createPostAndSaveDraft();
+		await page.reload();
+		await postEditorTemplateMode.disableTemplateWelcomeGuide();
+		await postEditorTemplateMode.openTemplatePopover();
+		// Change to a custom template, save and reload.
+		await page
+			.getByRole( 'combobox', { name: 'Template' } )
+			.selectOption( { label: 'Custom' } );
+		await page.keyboard.press( 'Escape' );
+		await expect(
+			page.getByRole( 'button', { name: 'Edit Template' } )
+		).toHaveAccessibleDescription( 'Custom' );
+		await editor.saveDraft();
+		await page.reload();
+		await expect(
+			page.getByRole( 'button', { name: 'Edit Template' } )
+		).toHaveAccessibleDescription( 'Custom' );
+		// Change to the default template.
+		await postEditorTemplateMode.openTemplatePopover();
+		await page
+			.getByRole( 'combobox', { name: 'Template' } )
+			.selectOption( { label: 'Single Entries' } );
+		await page.keyboard.press( 'Escape' );
+		await expect(
+			page.getByRole( 'button', { name: 'Edit Template' } )
+		).toHaveAccessibleDescription( 'Single Entries' );
+	} );
+
+	test( 'Allow creating custom block templates in classic themes', async ( {
+		editor,
+		page,
+		requestUtils,
+		postEditorTemplateMode,
+	} ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+
+		await postEditorTemplateMode.createPostAndSaveDraft();
+
+		await page.reload();
+
+		await postEditorTemplateMode.createNewTemplate( 'Blank Template' );
+
+		// Edit the template.
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await page.keyboard.type(
+			'Just a random paragraph added to the template'
+		);
+
+		await postEditorTemplateMode.saveTemplateWithoutPublishing();
+
+		// Preview changes.
+		const previewPage = await editor.openPreviewPage();
+
+		await expect(
+			previewPage.getByText(
+				'Just a random paragraph added to the template',
+				{ exact: true }
+			)
+		).toBeVisible();
+	} );
+} );
+
+class PostEditorTemplateMode {
+	constructor( { admin, editor, page, pageUtils, requestUtils } ) {
+		this.admin = admin;
+		this.editor = editor;
+		this.page = page;
+		this.pageUtils = pageUtils;
+		this.requestUtils = requestUtils;
+
+		this.editorSettingsSidebar = this.page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		this.editorTopBar = this.page.getByRole( 'region', {
+			name: 'Editor top bar',
+		} );
+	}
+
+	async disableTemplateWelcomeGuide() {
+		// Turn off the welcome guide.
+		await this.editor.setPreferences( 'core/edit-post', {
+			welcomeGuideTemplate: false,
+		} );
+	}
+
+	async openTemplatePopover() {
+		await openPostSummary( { editor: this.editor, page: this.page } );
+
+		await this.editorSettingsSidebar
+			.getByRole( 'button', { name: 'Edit Template' } )
+			.click();
+	}
+
+	async switchToTemplateMode() {
+		await this.disableTemplateWelcomeGuide();
+
+		await openPostSummary( { editor: this.editor, page: this.page } );
+		await this.editorSettingsSidebar
+			.getByRole( 'button', { name: 'Template: Single Entries' } )
+			.click();
+		await this.editorSettingsSidebar
+			.getByRole( 'button', { name: 'Edit', exact: true } )
+			.click();
+
+		// Check that we switched properly to edit mode.
+		await expect(
+			this.page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.getByText(
+					'Editing template. Changes made here affect all posts and pages that use the template.'
+				)
+		).toBeVisible();
+
+		const title = this.editorTopBar.getByRole( 'heading', {
+			name: 'Single Entries',
+		} );
+
+		await expect( title ).toBeVisible();
+	}
+
+	async createPostAndSaveDraft() {
+		await this.admin.createNewPost();
+		// Create a random post.
+		await this.page.keyboard.type( 'Just an FSE Post' );
+		await this.page.keyboard.press( 'Enter' );
+		await this.page.keyboard.type( 'Hello World' );
+
+		// Unselect the blocks.
+		await this.page.evaluate( () => {
+			window.wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
+		} );
+
+		// Save the post
+		// Saving shouldn't be necessary but unfortunately,
+		// there's a template resolution bug forcing us to do so.
+		await this.editor.saveDraft();
+	}
+
+	async createNewTemplate( templateName ) {
+		await this.disableTemplateWelcomeGuide();
+
+		await openPostSummary( { editor: this.editor, page: this.page } );
+		await this.editorSettingsSidebar
+			.getByRole( 'button', { name: 'Template', exact: true } )
+			.click();
+		await this.editorSettingsSidebar
+			.getByRole( 'button', { name: 'Create block template' } )
+			.click();
+
+		// Fill the template title and submit.
+		await this.page
+			.getByRole( 'dialog', { name: 'Create custom template' } )
+			.getByRole( 'textbox', { name: 'Name' } )
+			.fill( templateName );
+		await this.page.keyboard.press( 'Enter' );
+
+		// Check that we switched properly to edit mode.
+		await expect(
+			this.page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.getByText(
+					"Custom template created. You're in template mode now."
+				)
+		).toBeVisible();
+
+		// Wait for the editor to be fully loaded and ready before making changes.
+		// Without this, the editor may move focus to body while still typing,
+		// and save states will not be counted as dirty.
+		await this.page.waitForFunction(
+			() =>
+				window.wp?.data?.select( 'core/block-editor' )?.getBlocks()
+					?.length > 0
+		);
+	}
+
+	async saveTemplateWithoutPublishing() {
+		await this.page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Back', exact: true } )
+			.click();
+		await this.page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Save', exact: true } )
+			.click();
+		const editorPublishRegion = this.page.getByRole( 'region', {
+			name: 'Editor publish',
+		} );
+		await editorPublishRegion
+			.getByRole( 'button', { name: 'Save', exact: true } )
+			.click();
+		// Avoid publishing the post.
+		const cancelButton = editorPublishRegion.getByRole( 'button', {
+			name: 'Cancel',
+		} );
+		await expect( cancelButton ).toBeEnabled();
+		await cancelButton.click();
+	}
+}

--- a/test/e2e/specs/editor/various/post-summary-dataform/template-registration.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/template-registration.spec.js
@@ -1,0 +1,141 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS, openPostSummary } = require( './utils' );
+
+/*
+ * Mirrors the 'registered templates are available in the Change template
+ * screen' and 'themes can override registered templates' tests of
+ * `test/e2e/specs/site-editor/template-registration.spec.js` with the
+ * DataForm inspector experiment enabled; delete those tests when the
+ * experiment graduates.
+ */
+test.use( {
+	blockTemplateRegistrationUtils: async ( { editor, page }, use ) => {
+		await use( new BlockTemplateRegistrationUtils( { editor, page } ) );
+	},
+} );
+
+test.describe( 'Block template registration (DataForm inspector)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.activatePlugin(
+			'gutenberg-test-block-template-registration'
+		);
+	} );
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [] );
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllPosts();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-block-template-registration'
+		);
+	} );
+
+	test( 'registered templates are available in the Change template screen', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Create a post.
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'User-created post.' },
+		} );
+
+		// Change template.
+		const summary = await openPostSummary( { editor, page, tab: 'Post' } );
+		await summary.getByRole( 'button', { name: 'Edit Template' } ).click();
+		await page
+			.getByRole( 'combobox', { name: 'Template' } )
+			.selectOption( { label: 'Plugin Template' } );
+		await page.keyboard.press( 'Escape' );
+
+		// Verify the template is applied.
+		const postId = await editor.publishPost();
+		await page.goto( `?p=${ postId }` );
+		await expect(
+			page.getByText( 'This is a plugin-registered template.' )
+		).toBeVisible();
+	} );
+
+	test( 'themes can override registered templates', async ( {
+		admin,
+		editor,
+		page,
+		blockTemplateRegistrationUtils,
+	} ) => {
+		// Create a post.
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'User-created post.' },
+		} );
+
+		// Change template.
+		const summary = await openPostSummary( { editor, page, tab: 'Post' } );
+		await summary.getByRole( 'button', { name: 'Edit Template' } ).click();
+		await page
+			.getByRole( 'combobox', { name: 'Template' } )
+			.selectOption( { label: 'Custom' } );
+		await page.keyboard.press( 'Escape' );
+
+		// Verify the theme template is applied.
+		const postId = await editor.publishPost();
+		await page.goto( `?p=${ postId }` );
+		await expect(
+			page.getByText( 'Custom template for Posts' )
+		).toBeVisible();
+		await expect(
+			page.getByText(
+				'This is a plugin-registered template and overridden by a theme.'
+			)
+		).toBeHidden();
+
+		// Verify the plugin-registered template doesn't appear in the Site Editor.
+		await admin.visitSiteEditor( {
+			postType: 'wp_template',
+		} );
+		await blockTemplateRegistrationUtils.searchForTemplate( 'Custom' );
+		await expect(
+			page.getByText( 'Custom Template (overridden by the theme)' )
+		).toBeHidden();
+		// Verify the template description fall backs to the plugin registered description.
+		await expect(
+			page.getByText(
+				'A custom template registered by a plugin and overridden by a theme.'
+			)
+		).toBeVisible();
+		// Verify the theme template shows the theme name as the author.
+		await expect( page.getByText( 'AuthorEmptytheme' ) ).toBeVisible();
+	} );
+} );
+
+class BlockTemplateRegistrationUtils {
+	constructor( { page } ) {
+		this.page = page;
+	}
+
+	async searchForTemplate( searchTerm ) {
+		const searchResults = this.page.getByLabel( 'Actions' );
+		await expect
+			.poll( async () => await searchResults.count() )
+			.toBeGreaterThan( 0 );
+		const initialSearchResultsCount = await searchResults.count();
+		await this.page.getByPlaceholder( 'Search' ).fill( searchTerm );
+		await expect
+			.poll( async () => await searchResults.count() )
+			.toBeLessThanOrEqual( initialSearchResultsCount );
+		await expect
+			.poll( async () => this.page.url() )
+			.toContain( `search=${ encodeURIComponent( searchTerm ) }` );
+	}
+}

--- a/test/e2e/specs/editor/various/post-summary-dataform/template-resolution.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/template-resolution.spec.js
@@ -1,0 +1,89 @@
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { EXPERIMENTS, openPostSummary } = require( './utils' );
+
+/*
+ * Mirrors the '`page_for_posts` setting' tests of
+ * `test/e2e/specs/editor/various/template-resolution.spec.js` with the
+ * DataForm inspector experiment enabled; delete those tests when the
+ * experiment graduates.
+ */
+async function updateSiteSettings( { pageId, requestUtils } ) {
+	return requestUtils.updateSiteSettings( {
+		show_on_front: 'page',
+		page_on_front: 0,
+		page_for_posts: pageId,
+	} );
+}
+
+test.describe( 'Template resolution (DataForm inspector)', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( EXPERIMENTS );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.setGutenbergExperiments( [] ),
+			requestUtils.deleteAllPages(),
+			requestUtils.updateSiteSettings( {
+				show_on_front: 'posts',
+				page_on_front: 0,
+				page_for_posts: 0,
+			} ),
+		] );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.describe( '`page_for_posts` setting', () => {
+		test( 'Post editor proper template resolution', async ( {
+			page,
+			admin,
+			editor,
+			requestUtils,
+		} ) => {
+			const newPage = await requestUtils.createPage( {
+				title: 'Posts Page',
+				status: 'publish',
+			} );
+			await admin.editPost( newPage.id );
+			const summary = await openPostSummary( { editor, page } );
+			await expect(
+				summary.getByRole( 'button', { name: 'Edit Template' } )
+			).toHaveAccessibleDescription( 'Single Entries' );
+			await updateSiteSettings( { requestUtils, pageId: newPage.id } );
+			await page.reload();
+			await openPostSummary( { editor, page } );
+			await expect(
+				summary.getByRole( 'button', { name: 'Edit Template' } )
+			).toHaveAccessibleDescription( 'Index' );
+		} );
+
+		test( 'Site editor proper template resolution', async ( {
+			page,
+			editor,
+			admin,
+			requestUtils,
+		} ) => {
+			const newPage = await requestUtils.createPage( {
+				title: 'Posts Page',
+				status: 'publish',
+			} );
+			await updateSiteSettings( { requestUtils, pageId: newPage.id } );
+			await admin.visitSiteEditor( {
+				postId: newPage.id,
+				postType: 'page',
+				canvas: 'edit',
+			} );
+			const summary = await openPostSummary( { editor, page } );
+			await expect(
+				summary.getByRole( 'button', { name: 'Edit Template' } )
+			).toHaveAccessibleDescription( 'Index' );
+		} );
+	} );
+} );


### PR DESCRIPTION


## What?

Part of the e2e testing task in #76076.

Mirrors the classic e2e tests for the template panel (`post-editor-template-mode`, `template-resolution` and the template tests in site editor's `pages` and `template-registration`). In the experiment the `Template options` dropdown is replaced by the `Template` row of the summary and the `Template: <name>` panel, so only these interactions are rewritten and the rest of the flows and assertions are kept as they were.

### Notes

1. The mirrors keep the helper classes of the classic files and only change the methods for the UI that is different, to keep the diff easy to compare when the classic tests are removed.
2. The `pages.spec.js` writing prompt test turns on `Show template` from the template options dropdown as setup. That dropdown doesn't exist in the experiment and the same toggle is in the top bar `View` dropdown, so that line needs updating when the experiment graduates. Not for this PR.


## Testing Instructions

1. CI should be 🟢

## Use of AI Tools

Generated with Fable 5.1 and adjusted/reviewed manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for selecting, editing, previewing, and saving post and page templates.
  * Added tests for switching between custom and default templates, including classic themes.
  * Added coverage for registered templates, theme overrides, and template availability in the Site Editor.
  * Added validation for template resolution when configuring a posts page and related settings.
  * Improved test setup and cleanup for themes, templates, pages, plugins, and experiments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->