### PR TITLE
Global Styles: Retain responsive styles in block style variation partials

### DIFF
--- a/backport-changelog/7.1/13325.md
+++ b/backport-changelog/7.1/13325.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13325
+
+* https://github.com/WordPress/gutenberg/pull/82403

--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -241,6 +241,8 @@ Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-
 
 Organized way to set CSS properties. Styles in the top-level will be added in the `body` selector.
 
+In a block style variation partial (a theme.json file with a `blockTypes` property), the styles are scoped to the listed block types instead, and the responsive (`@mobile`, `@tablet`) and pseudo-selector (`:hover`, `:focus`, `:focus-visible`, `:active`) states available to block style variations are also allowed at this level.
+
 ### background
 
 Background styles.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1246,6 +1246,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$valid_block_names` and `$valid_element_name` parameters.
 	 * @since 6.6.0 Extended schema definition to allow enhanced block style variations.
+	 * @since 7.1.1 Updated schema to allow responsive breakpoint states at the top level of `styles`.
 	 *
 	 * @param array $input               Structure to sanitize.
 	 * @param array $valid_block_names   List of valid block names.
@@ -1435,6 +1436,21 @@ class WP_Theme_JSON_Gutenberg {
 		$schema['settings']                               = static::VALID_SETTINGS;
 		$schema['settings']['blocks']                     = $schema_settings_blocks;
 		$schema['settings']['typography']['fontFamilies'] = static::schema_in_root_and_per_origin( static::FONT_FAMILY_SCHEMA );
+
+		/*
+		 * Add responsive breakpoint states to the top-level styles schema.
+		 *
+		 * Block style variations defined in a standalone JSON partial within a
+		 * theme's `styles` directory declare their styles at the root of the
+		 * `styles` object. Those partials are sanitized against the top-level
+		 * schema, so it needs to allow the same responsive breakpoint states
+		 * that are allowed for variations declared inline in theme.json.
+		 */
+		foreach ( array_keys( $responsive_media_queries ) as $breakpoint_state ) {
+			$schema['styles'][ $breakpoint_state ]             = $styles_non_top_level;
+			$schema['styles'][ $breakpoint_state ]['elements'] = $schema_styles_elements;
+			$schema['styles'][ $breakpoint_state ]['blocks']   = $schema_styles_blocks;
+		}
 
 		// Remove anything that's not present in the schema.
 		foreach ( array( 'styles', 'settings' ) as $subtree ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1246,7 +1246,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$valid_block_names` and `$valid_element_name` parameters.
 	 * @since 6.6.0 Extended schema definition to allow enhanced block style variations.
-	 * @since 7.1.1 Updated schema to allow responsive breakpoint states at the top level of `styles`.
+	 * @since 7.1.1 Updated schema to allow responsive breakpoint states and pseudo-selectors
+	 *              at the top level of `styles` for block style variation partials.
 	 *
 	 * @param array $input               Structure to sanitize.
 	 * @param array $valid_block_names   List of valid block names.
@@ -1438,18 +1439,45 @@ class WP_Theme_JSON_Gutenberg {
 		$schema['settings']['typography']['fontFamilies'] = static::schema_in_root_and_per_origin( static::FONT_FAMILY_SCHEMA );
 
 		/*
-		 * Add responsive breakpoint states to the top-level styles schema.
+		 * Add block style variation states to the top-level styles schema.
 		 *
 		 * Block style variations defined in a standalone JSON partial within a
 		 * theme's `styles` directory declare their styles at the root of the
-		 * `styles` object. Those partials are sanitized against the top-level
-		 * schema, so it needs to allow the same responsive breakpoint states
-		 * that are allowed for variations declared inline in theme.json.
+		 * `styles` object, so they are sanitized against the top-level schema.
+		 * It needs to allow the same states that are allowed for variations
+		 * declared inline in theme.json, otherwise those states are silently
+		 * removed as unknown keys.
+		 *
+		 * The `blockTypes` property is only present on block style variation
+		 * partials, so it both identifies the config as a variation and
+		 * determines which pseudo-selectors are valid for it. Regular
+		 * theme.json files are unaffected.
 		 */
-		foreach ( $breakpoint_states as $breakpoint_state ) {
-			$schema['styles'][ $breakpoint_state ]             = $styles_non_top_level;
-			$schema['styles'][ $breakpoint_state ]['elements'] = $schema_styles_elements;
-			$schema['styles'][ $breakpoint_state ]['blocks']   = $schema_styles_blocks;
+		if ( ! empty( $input['blockTypes'] ) && is_array( $input['blockTypes'] ) ) {
+			$variation_pseudo_selectors = array();
+			foreach ( $input['blockTypes'] as $variation_block_type ) {
+				if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $variation_block_type ] ) ) {
+					$variation_pseudo_selectors = array_merge(
+						$variation_pseudo_selectors,
+						static::VALID_BLOCK_PSEUDO_SELECTORS[ $variation_block_type ]
+					);
+				}
+			}
+			$variation_pseudo_selectors = array_unique( $variation_pseudo_selectors );
+
+			foreach ( $breakpoint_states as $breakpoint_state ) {
+				$schema['styles'][ $breakpoint_state ]             = $styles_non_top_level;
+				$schema['styles'][ $breakpoint_state ]['elements'] = $schema_styles_elements;
+				$schema['styles'][ $breakpoint_state ]['blocks']   = $schema_styles_blocks;
+
+				foreach ( $variation_pseudo_selectors as $pseudo_selector ) {
+					$schema['styles'][ $breakpoint_state ][ $pseudo_selector ] = $styles_non_top_level;
+				}
+			}
+
+			foreach ( $variation_pseudo_selectors as $pseudo_selector ) {
+				$schema['styles'][ $pseudo_selector ] = $styles_non_top_level;
+			}
 		}
 
 		// Remove anything that's not present in the schema.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1408,7 +1408,6 @@ class WP_Theme_JSON_Gutenberg {
 					foreach ( array_keys( $responsive_media_queries ) as $breakpoint_state ) {
 						$variation_schema[ $breakpoint_state ]             = $styles_non_top_level;
 						$variation_schema[ $breakpoint_state ]['elements'] = $schema_styles_elements;
-						$variation_schema[ $breakpoint_state ]['blocks']   = $schema_styles_blocks;
 
 						if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 							foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
@@ -1468,7 +1467,6 @@ class WP_Theme_JSON_Gutenberg {
 			foreach ( $breakpoint_states as $breakpoint_state ) {
 				$schema['styles'][ $breakpoint_state ]             = $styles_non_top_level;
 				$schema['styles'][ $breakpoint_state ]['elements'] = $schema_styles_elements;
-				$schema['styles'][ $breakpoint_state ]['blocks']   = $schema_styles_blocks;
 
 				foreach ( $variation_pseudo_selectors as $pseudo_selector ) {
 					$schema['styles'][ $breakpoint_state ][ $pseudo_selector ] = $styles_non_top_level;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1446,7 +1446,7 @@ class WP_Theme_JSON_Gutenberg {
 		 * schema, so it needs to allow the same responsive breakpoint states
 		 * that are allowed for variations declared inline in theme.json.
 		 */
-		foreach ( array_keys( $responsive_media_queries ) as $breakpoint_state ) {
+		foreach ( $breakpoint_states as $breakpoint_state ) {
 			$schema['styles'][ $breakpoint_state ]             = $styles_non_top_level;
 			$schema['styles'][ $breakpoint_state ]['elements'] = $schema_styles_elements;
 			$schema['styles'][ $breakpoint_state ]['blocks']   = $schema_styles_blocks;

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -276,6 +276,76 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that responsive breakpoint styles defined in a standalone block style
+	 * variation partial within a theme's `styles` directory are preserved when
+	 * the partial is sanitized.
+	 *
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_style_variations
+	 */
+	public function test_block_style_variation_partial_retains_responsive_styles() {
+		switch_theme( 'block-theme' );
+
+		$variations = WP_Theme_JSON_Resolver_Gutenberg::get_style_variations( 'block' );
+		$actual     = null;
+
+		foreach ( $variations as $variation ) {
+			if ( isset( $variation['slug'] ) && 'responsive-variation' === $variation['slug'] ) {
+				$actual = $variation;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $actual, 'The responsive block style variation partial was not found.' );
+		$this->assertSame(
+			array( 'fontSize' => '28px' ),
+			$actual['styles']['@tablet']['typography'] ?? null,
+			'Tablet styles should be preserved when reading a block style variation partial.'
+		);
+		$this->assertSame(
+			array( 'fontSize' => '16px' ),
+			$actual['styles']['@mobile']['typography'] ?? null,
+			'Mobile styles should be preserved when reading a block style variation partial.'
+		);
+	}
+
+	/**
+	 * Tests that responsive breakpoint styles defined in a standalone block style
+	 * variation partial generate the expected media query CSS.
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_support_styles
+	 */
+	public function test_block_style_variation_partial_responsive_styles_generate_css() {
+		switch_theme( 'block-theme' );
+
+		try {
+			$parsed_block = array(
+				'blockName' => 'core/preformatted',
+				'attrs'     => array(
+					'className' => 'wp-block-preformatted is-style-responsive-variation',
+				),
+			);
+
+			gutenberg_render_block_style_variation_support_styles( $parsed_block );
+			$inline_styles     = wp_styles()->get_data( 'block-style-variation-styles', 'after' );
+			$actual_stylesheet = is_array( $inline_styles ) ? implode( '', $inline_styles ) : '';
+
+			$this->assertStringContainsString(
+				'@media (480px < width <= 782px)',
+				$actual_stylesheet,
+				'CSS should contain the tablet viewport media query.'
+			);
+			$this->assertStringContainsString(
+				'@media (width <= 480px)',
+				$actual_stylesheet,
+				'CSS should contain the mobile viewport media query.'
+			);
+		} finally {
+			wp_deregister_style( 'block-style-variation-styles' );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+	}
+
+	/**
 	 * Tests that block style variations resolve any `ref` values when generating styles.
 	 */
 	public function test_block_style_variation_ref_values() {

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -458,6 +458,109 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `blocks` nested within a responsive breakpoint state is not
+	 * retained for a block style variation partial, since that shape generates
+	 * no CSS. The supported shape nests the breakpoint state within `blocks`.
+	 *
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 */
+	public function test_block_style_variation_partial_does_not_allow_blocks_within_breakpoint_state() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'    => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'blockTypes' => array( 'core/group' ),
+				'styles'     => array(
+					'blocks'  => array(
+						'core/heading' => array(
+							'@mobile' => array(
+								'typography' => array( 'fontSize' => '18px' ),
+							),
+						),
+					),
+					'@mobile' => array(
+						'blocks' => array(
+							'core/heading' => array(
+								'typography' => array( 'fontSize' => '18px' ),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$actual = $theme_json->get_raw_data()['styles'];
+
+		$this->assertSame(
+			array( 'fontSize' => '18px' ),
+			$actual['blocks']['core/heading']['@mobile']['typography'] ?? null,
+			'A breakpoint state nested within `blocks` should be retained.'
+		);
+		$this->assertArrayNotHasKey(
+			'blocks',
+			$actual['@mobile'] ?? array(),
+			'`blocks` nested within a breakpoint state should not be retained.'
+		);
+	}
+
+	/**
+	 * Tests that `blocks` nested within a responsive breakpoint state is not
+	 * retained for a block style variation declared inline in theme.json,
+	 * matching the behaviour for variation partials.
+	 *
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 */
+	public function test_block_style_variation_does_not_allow_blocks_within_breakpoint_state() {
+		register_block_style(
+			'core/group',
+			array(
+				'name'  => 'blocks-in-breakpoint',
+				'label' => 'Blocks In Breakpoint',
+			)
+		);
+
+		try {
+			$theme_json = new WP_Theme_JSON_Gutenberg(
+				array(
+					'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+					'styles'  => array(
+						'blocks' => array(
+							'core/group' => array(
+								'variations' => array(
+									'blocks-in-breakpoint' => array(
+										'@mobile' => array(
+											'color'  => array( 'text' => 'red' ),
+											'blocks' => array(
+												'core/heading' => array(
+													'typography' => array( 'fontSize' => '18px' ),
+												),
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				)
+			);
+
+			$variation = $theme_json->get_raw_data()['styles']['blocks']['core/group']['variations']['blocks-in-breakpoint'] ?? array();
+
+			$this->assertSame(
+				array( 'text' => 'red' ),
+				$variation['@mobile']['color'] ?? null,
+				'Style properties within a breakpoint state should be retained.'
+			);
+			$this->assertArrayNotHasKey(
+				'blocks',
+				$variation['@mobile'] ?? array(),
+				'`blocks` nested within a breakpoint state should not be retained.'
+			);
+		} finally {
+			unregister_block_style( 'core/group', 'blocks-in-breakpoint' );
+		}
+	}
+
+	/**
 	 * Tests that block style variations resolve any `ref` values when generating styles.
 	 */
 	public function test_block_style_variation_ref_values() {

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -346,6 +346,118 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that pseudo-selector styles defined in a standalone block style
+	 * variation partial are preserved when the partial is sanitized, both at
+	 * the root of `styles` and within a responsive breakpoint state.
+	 *
+	 * @covers WP_Theme_JSON_Resolver_Gutenberg::get_style_variations
+	 */
+	public function test_block_style_variation_partial_retains_pseudo_selector_styles() {
+		switch_theme( 'block-theme' );
+
+		$actual = null;
+		foreach ( WP_Theme_JSON_Resolver_Gutenberg::get_style_variations( 'block' ) as $variation ) {
+			if ( isset( $variation['slug'] ) && 'pseudo-variation' === $variation['slug'] ) {
+				$actual = $variation;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $actual, 'The pseudo-selector block style variation partial was not found.' );
+		$this->assertSame(
+			array( 'text' => 'blue' ),
+			$actual['styles'][':hover']['color'] ?? null,
+			'Pseudo-selector styles should be preserved when reading a block style variation partial.'
+		);
+		$this->assertSame(
+			array( 'text' => 'purple' ),
+			$actual['styles']['@tablet'][':hover']['color'] ?? null,
+			'Pseudo-selector styles within a breakpoint state should be preserved.'
+		);
+	}
+
+	/**
+	 * Tests that pseudo-selector styles defined in a standalone block style
+	 * variation partial generate the expected CSS, including within a
+	 * responsive breakpoint state.
+	 *
+	 * @covers ::gutenberg_render_block_style_variation_support_styles
+	 */
+	public function test_block_style_variation_partial_pseudo_selector_styles_generate_css() {
+		switch_theme( 'block-theme' );
+
+		try {
+			$parsed_block = array(
+				'blockName' => 'core/navigation-link',
+				'attrs'     => array(
+					'className' => 'wp-block-navigation-link is-style-pseudo-variation',
+				),
+			);
+
+			gutenberg_render_block_style_variation_support_styles( $parsed_block );
+			$inline_styles     = wp_styles()->get_data( 'block-style-variation-styles', 'after' );
+			$actual_stylesheet = is_array( $inline_styles ) ? implode( '', $inline_styles ) : '';
+
+			$this->assertStringContainsString(
+				':hover',
+				$actual_stylesheet,
+				'CSS should contain the pseudo-selector rule.'
+			);
+			$this->assertStringContainsString(
+				'blue',
+				$actual_stylesheet,
+				'CSS should contain the pseudo-selector declaration value.'
+			);
+			$this->assertStringContainsString(
+				'purple',
+				$actual_stylesheet,
+				'CSS should contain the pseudo-selector declaration value from the breakpoint state.'
+			);
+		} finally {
+			wp_deregister_style( 'block-style-variation-styles' );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+	}
+
+	/**
+	 * Tests that the block style variation states allowed at the root of a
+	 * partial are not allowed at the root of a regular theme.json file, which
+	 * has no `blockTypes` property.
+	 *
+	 * @covers WP_Theme_JSON_Gutenberg::sanitize
+	 */
+	public function test_theme_json_root_styles_do_not_allow_variation_states() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'color'   => array( 'text' => 'red' ),
+					'@tablet' => array( 'color' => array( 'text' => 'green' ) ),
+					':hover'  => array( 'color' => array( 'text' => 'blue' ) ),
+				),
+			)
+		);
+
+		$actual = $theme_json->get_raw_data()['styles'];
+
+		$this->assertSame(
+			array( 'text' => 'red' ),
+			$actual['color'] ?? null,
+			'Base root styles should be retained.'
+		);
+		$this->assertArrayNotHasKey(
+			'@tablet',
+			$actual,
+			'Responsive breakpoint states should not be allowed at the root of a regular theme.json.'
+		);
+		$this->assertArrayNotHasKey(
+			':hover',
+			$actual,
+			'Pseudo-selectors should not be allowed at the root of a regular theme.json.'
+		);
+	}
+
+	/**
 	 * Tests that block style variations resolve any `ref` values when generating styles.
 	 */
 	public function test_block_style_variation_ref_values() {

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1129,6 +1129,27 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					array(
+						'blockTypes' => array( 'core/preformatted' ),
+						'version'    => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+						'slug'       => 'responsive-variation',
+						'title'      => 'Responsive Variation',
+						'styles'     => array(
+							'typography' => array(
+								'fontSize' => '40px',
+							),
+							'@tablet'    => array(
+								'typography' => array(
+									'fontSize' => '28px',
+								),
+							),
+							'@mobile'    => array(
+								'typography' => array(
+									'fontSize' => '16px',
+								),
+							),
+						),
+					),
+					array(
 						'blockTypes' => array( 'core/group', 'core/columns' ),
 						'version'    => 3,
 						'slug'       => 'WithSlug',

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1129,6 +1129,32 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					array(
+						'blockTypes' => array( 'core/navigation-link' ),
+						'version'    => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+						'slug'       => 'pseudo-variation',
+						'title'      => 'Pseudo Variation',
+						'styles'     => array(
+							'color'   => array(
+								'text' => 'red',
+							),
+							':hover'  => array(
+								'color' => array(
+									'text' => 'blue',
+								),
+							),
+							'@tablet' => array(
+								'color'  => array(
+									'text' => 'green',
+								),
+								':hover' => array(
+									'color' => array(
+										'text' => 'purple',
+									),
+								),
+							),
+						),
+					),
+					array(
 						'blockTypes' => array( 'core/preformatted' ),
 						'version'    => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 						'slug'       => 'responsive-variation',

--- a/phpunit/data/themedir1/block-theme/styles/block-style-variation-pseudo.json
+++ b/phpunit/data/themedir1/block-theme/styles/block-style-variation-pseudo.json
@@ -1,0 +1,26 @@
+{
+	"version": 3,
+	"blockTypes": [ "core/navigation-link" ],
+	"slug": "pseudo-variation",
+	"title": "Pseudo Variation",
+	"styles": {
+		"color": {
+			"text": "red"
+		},
+		":hover": {
+			"color": {
+				"text": "blue"
+			}
+		},
+		"@tablet": {
+			"color": {
+				"text": "green"
+			},
+			":hover": {
+				"color": {
+					"text": "purple"
+				}
+			}
+		}
+	}
+}

--- a/phpunit/data/themedir1/block-theme/styles/block-style-variation-responsive.json
+++ b/phpunit/data/themedir1/block-theme/styles/block-style-variation-responsive.json
@@ -1,0 +1,21 @@
+{
+	"version": 3,
+	"blockTypes": [ "core/preformatted" ],
+	"slug": "responsive-variation",
+	"title": "Responsive Variation",
+	"styles": {
+		"typography": {
+			"fontSize": "40px"
+		},
+		"@tablet": {
+			"typography": {
+				"fontSize": "28px"
+			}
+		},
+		"@mobile": {
+			"typography": {
+				"fontSize": "16px"
+			}
+		}
+	}
+}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2095,6 +2095,37 @@
 				}
 			}
 		},
+		"stylesVariationPartialRootPropertiesComplete": {
+			"description": "Styles at the root of a block style variation partial (a theme.json file with a `blockTypes` property). Supports everything allowed at the top-level styles of a regular theme.json, plus the responsive and pseudo-selector states available to a variation declared inline in theme.json.",
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesBlocksResponsiveSelectorsWithPseudoProperties"
+				},
+				{
+					"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+				},
+				{
+					"type": "object",
+					"propertyNames": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/stylesPropertyNames"
+							},
+							{
+								"enum": [ "elements", "blocks", "variations" ]
+							},
+							{
+								"$ref": "#/definitions/stylesBlocksResponsiveSelectorsPropertyNames"
+							},
+							{
+								"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
+							}
+						]
+					}
+				}
+			]
+		},
 		"stylesBlockVariationsWithPseudoProperties": {
 			"description": "Block style variations for blocks that support pseudo-selectors. Each variation supports the same style properties, responsive states and pseudo-selectors as the block itself.",
 			"type": "object",
@@ -3520,7 +3551,7 @@
 			]
 		},
 		"styles": {
-			"description": "Organized way to set CSS properties. Styles in the top-level will be added in the `body` selector.",
+			"description": "Organized way to set CSS properties. Styles in the top-level will be added in the `body` selector.\n\nIn a block style variation partial (a theme.json file with a `blockTypes` property), the styles are scoped to the listed block types instead, and the responsive (`@mobile`, `@tablet`) and pseudo-selector (`:hover`, `:focus`, `:focus-visible`, `:active`) states available to block style variations are also allowed at this level.",
 			"allOf": [
 				{
 					"$ref": "#/definitions/stylesProperties"
@@ -3537,19 +3568,6 @@
 						"variations": {
 							"$ref": "#/definitions/stylesVariationsProperties"
 						}
-					}
-				},
-				{
-					"type": "object",
-					"propertyNames": {
-						"anyOf": [
-							{
-								"$ref": "#/definitions/stylesPropertyNames"
-							},
-							{
-								"enum": [ "elements", "blocks", "variations" ]
-							}
-						]
 					}
 				}
 			]
@@ -3610,6 +3628,40 @@
 			"type": "array",
 			"items": {
 				"type": "string"
+			}
+		}
+	},
+	"if": {
+		"type": "object",
+		"required": [ "blockTypes" ],
+		"properties": {
+			"blockTypes": {
+				"type": "array",
+				"minItems": 1
+			}
+		}
+	},
+	"then": {
+		"properties": {
+			"styles": {
+				"$ref": "#/definitions/stylesVariationPartialRootPropertiesComplete"
+			}
+		}
+	},
+	"else": {
+		"properties": {
+			"styles": {
+				"type": "object",
+				"propertyNames": {
+					"anyOf": [
+						{
+							"$ref": "#/definitions/stylesPropertyNames"
+						},
+						{
+							"enum": [ "elements", "blocks", "variations" ]
+						}
+					]
+				}
 			}
 		}
 	},

--- a/test/integration/fixtures/schemas/stylesRootPseudoSelectors.json
+++ b/test/integration/fixtures/schemas/stylesRootPseudoSelectors.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		":hover": {
+			"color": {
+				"text": "blue"
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesRootResponsiveStates.json
+++ b/test/integration/fixtures/schemas/stylesRootResponsiveStates.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"@tablet": {
+			"typography": {
+				"fontSize": "1.25rem"
+			}
+		}
+	}
+}

--- a/test/integration/fixtures/schemas/stylesVariationPartialRootInvalid.json
+++ b/test/integration/fixtures/schemas/stylesVariationPartialRootInvalid.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "../../../../schemas/json/theme.json",
+	"version": 3,
+	"blockTypes": [ "core/button" ],
+	"styles": {
+		"invalidAdditionalProperty": true
+	}
+}

--- a/test/integration/fixtures/theme-json/variation-partial-states/theme.json
+++ b/test/integration/fixtures/theme-json/variation-partial-states/theme.json
@@ -1,0 +1,53 @@
+{
+	"$schema": "../../../../../schemas/json/theme.json",
+	"version": 3,
+	"title": "Variation Partial States",
+	"slug": "variation-partial-states",
+	"blockTypes": [ "core/button" ],
+	"styles": {
+		"color": {
+			"text": "red"
+		},
+		":hover": {
+			"color": {
+				"text": "blue"
+			}
+		},
+		"@mobile": {
+			"color": {
+				"text": "green"
+			},
+			":hover": {
+				"color": {
+					"text": "purple"
+				}
+			},
+			"elements": {
+				"link": {
+					"color": {
+						"text": "yellow"
+					}
+				}
+			}
+		},
+		"@tablet": {
+			"typography": {
+				"fontSize": "1.25rem"
+			}
+		},
+		"elements": {
+			"link": {
+				"color": {
+					"text": "fuchsia"
+				}
+			}
+		},
+		"blocks": {
+			"core/heading": {
+				"color": {
+					"text": "violet"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #82392.

Ports the core fix in https://github.com/WordPress/wordpress-develop/pull/13325
(Trac ticket https://core.trac.wordpress.org/ticket/65992, milestoned 7.1.1) to
the plugin. Since `WP_Theme_JSON_Gutenberg` overrides core's class while the
plugin is active, the core fix alone does not resolve this for Gutenberg users.

## What

Responsive `@tablet` and `@mobile` styles are silently dropped from block style
variations declared in a standalone JSON partial in a theme's `styles/`
directory. The base rule is generated, but no media query CSS is emitted, and
nothing surfaces an error in the editor or on the front end.

The same variation declared inline in `theme.json` under
`styles.blocks.<block>.variations.<slug>` works correctly. Only the standalone
partial path is affected.

## Why

Partials declare their styles at the root of the `styles` object, and
`WP_Theme_JSON_Resolver_Gutenberg::get_style_variations()` sanitizes each partial
by running it through `WP_Theme_JSON_Gutenberg`. So partials are validated
against the top-level styles schema in `WP_Theme_JSON_Gutenberg::sanitize()`.

That schema is built to mirror the block style variation schema — both are
`VALID_STYLES` plus `blocks` and `elements` — which is what makes partials
sanitize correctly in the first place. The responsive breakpoint states were only
added to the block, element, and variation branches, so `@tablet` and `@mobile`
at the top level are removed by `remove_keys_not_in_schema()` as unknown keys.

The variation branch cannot cover this case: it validates
`styles.blocks.<block>.variations.<slug>`, a different location in the tree, and
its guard also requires the variation to already be present in
`$valid_variations`, which is derived from the block styles registry. Partials
are not registered until
`gutenberg_register_block_style_variations_from_theme_json_partials()` runs,
which happens after `get_style_variations()` returns.

## How

Add the responsive breakpoint states to the top-level styles schema, mirroring
what the block style variation branch already does. This restores the parity the
two schemas were written to have.

## Testing instructions

1. On a block theme, create `styles/article-heading-xl.json`:

```json
{
	"version": 3,
	"title": "Heading XL",
	"slug": "article-heading-xl",
	"blockTypes": [ "core/heading" ],
	"styles": {
		"typography": { "fontSize": "40px", "fontWeight": "700", "lineHeight": "1.3" },
		"@tablet": { "typography": { "fontSize": "28px" } },
		"@mobile": { "typography": { "fontSize": "16px", "lineHeight": "1.35" } }
	}
}
```

2. Add a Heading block to a page and apply the "Heading XL" style variation.
3. View the page on the front end and inspect the heading.

**Before:** only the base rule is generated; the heading keeps its desktop font
size at every viewport width.

**After:** the base rule plus tablet and mobile media query rules are generated,
and the font size steps down at each breakpoint.

## Automated tests

- `test_block_style_variation_partial_retains_responsive_styles` — asserts the
  breakpoint keys survive `WP_Theme_JSON_Resolver_Gutenberg::get_style_variations()`.
- `test_block_style_variation_partial_responsive_styles_generate_css` — asserts
  the expected media queries appear in the generated CSS.

Both fail before the change and pass after. An existing expectation in
`WP_Theme_JSON_Resolver_Gutenberg_Test` is updated to account for the new test
fixture. The full PHP suite passes (2295 tests, no failures), and `phpcs` is
clean on the changed files.

Note on `@since`: this file uses WordPress versions rather than plugin versions,
so the annotation is `@since 7.1.1` to match the Trac milestone. Happy to change
it if the fix should ride a different release.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 5)
- **Used for:** Root cause analysis, drafting the fix, and the two regression tests.

The tests were written first and confirmed failing against unpatched trunk, then
confirmed passing after the change. All output was reviewed by me before
submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block style variation partials support responsive styles, including breakpoint-specific typography and generated CSS.
  * Pseudo-selector styles, such as hover states, are supported at the root and within responsive breakpoints.
  * Responsive and pseudo-selector variation styles are preserved during processing.
* **Bug Fixes**
  * Regular `theme.json` files no longer accept variation-only responsive or pseudo-selector states.
  * Invalid properties in variation partial styles are now rejected during schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->