### PR TITLE
ESLint: Thin use-recommended-components tests

### DIFF
--- a/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
+++ b/packages/eslint-plugin/rules/__tests__/use-recommended-components.js
@@ -23,16 +23,6 @@ ruleTester.run( 'use-recommended-components', rule, {
 
 		// Allowed @wordpress/ui components.
 		"import { Badge } from '@wordpress/ui';",
-		"import { Icon } from '@wordpress/ui';",
-		"import { Link } from '@wordpress/ui';",
-		"import { Stack } from '@wordpress/ui';",
-		"import { Text } from '@wordpress/ui';",
-		"import { Autocomplete, Badge, Field, Fieldset, Icon, Link, Stack, Tabs, Text, Tooltip } from '@wordpress/ui';",
-		"import { Spinner } from '@wordpress/ui';",
-		"import { KeyboardShortcutDescription, KeyboardShortcutDisplay, useKeyboardShortcutProps } from '@wordpress/ui';",
-		"import { ControlWithError } from '@wordpress/ui';",
-		"import { ValidatedInputControl, InputLayout } from '@wordpress/ui';",
-		"import { ValidatedTextareaControl } from '@wordpress/ui';",
 
 		// Unlocked private APIs are only checked for denied names.
 		"import { privateApis } from '@wordpress/components'; import { unlock } from '../../lock-unlock'; const { SomethingElse } = unlock( privateApis );",
@@ -96,17 +86,6 @@ ruleTester.run( 'use-recommended-components', rule, {
 			],
 		},
 		{
-			code: "import { Tabs, TabPanel } from '@wordpress/components';",
-			errors: [
-				{
-					message: 'Use `Tabs` from `@wordpress/ui` instead.',
-				},
-				{
-					message: 'Use `Tabs` from `@wordpress/ui` instead.',
-				},
-			],
-		},
-		{
 			code: "import { privateApis } from '@wordpress/components'; import { unlock } from '../../lock-unlock'; const { Tabs } = unlock( privateApis );",
 			errors: [
 				{
@@ -119,14 +98,6 @@ ruleTester.run( 'use-recommended-components', rule, {
 			errors: [
 				{
 					message: 'Use `Tabs` from `@wordpress/ui` instead.',
-				},
-			],
-		},
-		{
-			code: "import { Tooltip } from '@wordpress/components';",
-			errors: [
-				{
-					message: 'Use `Tooltip` from `@wordpress/ui` instead.',
 				},
 			],
 		},


### PR DESCRIPTION
## What?
Drop redundant cases from the `use-recommended-components` ESLint rule tests. Coverage goes from 26 cases to 14.

## Why?
Until a certain point, many new recommended `@wordpress/ui` components were adding another valid import that hit the same `allowed.includes` path. The allowlist is already the source of truth. Those cases made every allowlist change pay a test update without covering a new branch.

## How?
Keep one case per rule branch: ignored packages, default and namespace imports, one allowlisted name, allowlist misses (single and multiple specifiers), one denylist hit, import aliases, and the `unlock` private-API paths. Drop the extra allowlisted names, the combined import, the second denylist import, and the duplicate `Tooltip` case.

## Testing Instructions
1. Run `npm run test:unit:vitest -- packages/eslint-plugin/rules/__tests__/use-recommended-components.js`.
1. Confirm 14 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated linting rule test coverage by removing scenarios for certain permitted UI components and legacy import patterns.
  * No user-facing functionality or public API changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->