### PR TITLE
API Fetch: Add unregister to remove a registered middleware

### DIFF
--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add `apiFetch.unregister` to remove a registered middleware, and expose `apiFetch.httpV1Middleware` so the `X-HTTP-Method-Override` behavior can be opted out of. ([#82408](https://github.com/WordPress/gutenberg/pull/82408))
+
 ## 7.54.0 (2026-08-26)
 
 ### Internal

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -115,6 +115,26 @@ apiFetch.use( ( options, next ) => {
 } );
 ```
 
+### Removing middlewares
+
+`apiFetch.unregister` removes a middleware by reference, and returns whether it
+was registered. Built-in middlewares can be removed too, as long as they are
+exposed on `apiFetch`.
+
+```js
+import apiFetch from '@wordpress/api-fetch';
+
+// Send `DELETE` as `DELETE`, rather than as a `POST` carrying an
+// `X-HTTP-Method-Override` header.
+apiFetch.unregister( apiFetch.httpV1Middleware );
+```
+
+Removal is global. Every `apiFetch` call on the page loses the middleware, so
+only remove a middleware you registered yourself, or a built-in whose behavior
+the whole page can do without. `httpV1Middleware` in particular exists so that
+requests keep working on servers and firewalls that reject `PATCH`, `PUT` and
+`DELETE`; removing it can break saving on those sites.
+
 ### Built-in middlewares
 
 The `api-fetch` package provides built-in middlewares you can use to provide a `nonce` and a custom `rootURL`.

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -117,23 +117,16 @@ apiFetch.use( ( options, next ) => {
 
 ### Removing middlewares
 
-`apiFetch.unregister` removes a middleware by reference, and returns whether it
-was registered. Built-in middlewares can be removed too, as long as they are
-exposed on `apiFetch`.
+`apiFetch.unregister` removes a middleware by reference, and returns whether it was registered. Built-in middlewares can be removed too, as long as they are exposed on `apiFetch`.
 
 ```js
 import apiFetch from '@wordpress/api-fetch';
 
-// Send `DELETE` as `DELETE`, rather than as a `POST` carrying an
-// `X-HTTP-Method-Override` header.
+// Send `DELETE` as `DELETE`, rather than as a `POST` carrying an `X-HTTP-Method-Override` header.
 apiFetch.unregister( apiFetch.httpV1Middleware );
 ```
 
-Removal is global. Every `apiFetch` call on the page loses the middleware, so
-only remove a middleware you registered yourself, or a built-in whose behavior
-the whole page can do without. `httpV1Middleware` in particular exists so that
-requests keep working on servers and firewalls that reject `PATCH`, `PUT` and
-`DELETE`; removing it can break saving on those sites.
+Removal is global. Every `apiFetch` call on the page loses the middleware, so only remove a middleware you registered yourself, or a built-in whose behavior the whole page can do without. `httpV1Middleware` in particular exists so that requests keep working on servers and firewalls that reject `PATCH`, `PUT` and `DELETE`; removing it can break saving on those sites.
 
 ### Built-in middlewares
 

--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -58,6 +58,21 @@ function registerMiddleware( middleware: APIFetchMiddleware ) {
 	middlewares.unshift( middleware );
 }
 
+/**
+ * Unregister a middleware
+ *
+ * @param middleware
+ * @return Whether the middleware was registered.
+ */
+function unregisterMiddleware( middleware: APIFetchMiddleware ) {
+	const index = middlewares.indexOf( middleware );
+	if ( index === -1 ) {
+		return false;
+	}
+	middlewares.splice( index, 1 );
+	return true;
+}
+
 function enablePreloadMultiUse() {
 	for ( const middleware of middlewares ) {
 		( middleware as any )[ PRELOADING_ENABLE_MULTI_USE ]?.();
@@ -151,11 +166,13 @@ export interface ApiFetch {
 	nonceEndpoint?: string;
 	nonceMiddleware?: ReturnType< typeof createNonceMiddleware >;
 	use: ( middleware: APIFetchMiddleware ) => void;
+	unregister: ( middleware: APIFetchMiddleware ) => boolean;
 	setFetchHandler: ( newFetchHandler: FetchHandler ) => void;
 	createNonceMiddleware: typeof createNonceMiddleware;
 	createPreloadingMiddleware: typeof createPreloadingMiddleware;
 	createRootURLMiddleware: typeof createRootURLMiddleware;
 	fetchAllMiddleware: typeof fetchAllMiddleware;
+	httpV1Middleware: typeof httpV1Middleware;
 	mediaUploadMiddleware: typeof mediaUploadMiddleware;
 	createThemePreviewMiddleware: typeof createThemePreviewMiddleware;
 	privateApis: object;
@@ -205,6 +222,7 @@ const apiFetch: ApiFetch = ( options ) => {
 };
 
 apiFetch.use = registerMiddleware;
+apiFetch.unregister = unregisterMiddleware;
 apiFetch.setFetchHandler = setFetchHandler;
 
 // Attached to the function (rather than a named export) because
@@ -222,6 +240,7 @@ apiFetch.createNonceMiddleware = createNonceMiddleware;
 apiFetch.createPreloadingMiddleware = createPreloadingMiddleware;
 apiFetch.createRootURLMiddleware = createRootURLMiddleware;
 apiFetch.fetchAllMiddleware = fetchAllMiddleware;
+apiFetch.httpV1Middleware = httpV1Middleware;
 apiFetch.mediaUploadMiddleware = mediaUploadMiddleware;
 apiFetch.createThemePreviewMiddleware = createThemePreviewMiddleware;
 

--- a/packages/api-fetch/src/test/index.jsdom.test.js
+++ b/packages/api-fetch/src/test/index.jsdom.test.js
@@ -359,4 +359,64 @@ describe( 'apiFetch', () => {
 
 		await apiFetch( expectedOptions );
 	} );
+
+	describe( 'unregister', () => {
+		it( 'should stop calling a middleware once it is unregistered', async () => {
+			const middleware = jest.fn( ( options, next ) => next( options ) );
+			const fetchHandler = jest
+				.fn()
+				.mockResolvedValue( DEFAULT_FETCH_MOCK_RETURN );
+			apiFetch.setFetchHandler( fetchHandler );
+
+			apiFetch.use( middleware );
+
+			await apiFetch( { path: '/random' } );
+			expect( middleware ).toHaveBeenCalledTimes( 1 );
+
+			apiFetch.unregister( middleware );
+
+			await apiFetch( { path: '/random' } );
+			expect( middleware ).toHaveBeenCalledTimes( 1 );
+			expect( fetchHandler ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'should report whether the middleware was registered', () => {
+			const middleware = ( options, next ) => next( options );
+
+			expect( apiFetch.unregister( middleware ) ).toBe( false );
+
+			apiFetch.use( middleware );
+
+			expect( apiFetch.unregister( middleware ) ).toBe( true );
+			expect( apiFetch.unregister( middleware ) ).toBe( false );
+		} );
+
+		it( 'should stop overriding the method once httpV1Middleware is removed', async () => {
+			globalThis.fetch.mockResolvedValue( DEFAULT_FETCH_MOCK_RETURN );
+
+			await apiFetch( { path: '/random', method: 'DELETE' } );
+
+			expect( globalThis.fetch ).toHaveBeenCalledWith(
+				'/random?_locale=user',
+				expect.objectContaining( {
+					method: 'POST',
+					headers: expect.objectContaining( {
+						'X-HTTP-Method-Override': 'DELETE',
+					} ),
+				} )
+			);
+
+			expect( apiFetch.unregister( apiFetch.httpV1Middleware ) ).toBe(
+				true
+			);
+
+			await apiFetch( { path: '/random', method: 'DELETE' } );
+
+			const [ , options ] = globalThis.fetch.mock.lastCall;
+			expect( options.method ).toBe( 'DELETE' );
+			expect( options.headers ).not.toHaveProperty(
+				'X-HTTP-Method-Override'
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?
Closes #16805.
Closes #67655.
Alternative to #70506 and #67919.

Adds `apiFetch.unregister( middleware )`, which removes a middleware by reference and returns whether it was registered. Exposes `apiFetch.httpV1Middleware` so the built-in one can be passed to it.

Not exposing `userLocaleMiddleware` and `namespaceEndpointMiddleware`. Removing them can break the app.

Consumers can now opt out of a middleware they registered, or out of the `X-HTTP-Method-Override` behavior:

```js
apiFetch.unregister( apiFetch.httpV1Middleware );
```

`PATCH`, `PUT` and `DELETE` then go out as themselves instead of as a `POST` carrying the override header.

## Why?
See linked issue for general motivation.

`httpV1Middleware` has been unconditional since it moved into the package in #7018, and it was inherited from a 2018 plugin-wide shim for hosts and firewalls that reject `PUT` (#5741). Whether that is still needed is unanswerable while there is no way to turn it off, and it has already caused one bug on its own (#76284).

## Testing Instructions
Verified by unit tests.

```
npm run test:unit -- packages/api-fetch/src/test/index.jsdom.test.js
```

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to unregister middleware from `apiFetch`.
  - Added access to the built-in HTTP method override middleware, allowing it to be removed when needed.
  - Unregistration reports whether the middleware was registered and successfully removed.
  - Removing the built-in middleware disables HTTP method override behavior.

- **Documentation**
  - Documented middleware removal, including built-in middleware, global usage, and compatibility considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->