### PR TITLE
Validated form controls: Use design token for invalid focus rings

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring.
+-   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
 -   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
+-   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring and border ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
 -   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring.
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
 -   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).

--- a/packages/components/src/validated-form-controls/style.scss
+++ b/packages/components/src/validated-form-controls/style.scss
@@ -1,7 +1,7 @@
 @use "@wordpress/base-styles/colors" as *;
 
 %red-focus-ring {
-	--focus-color: #{ $alert-red };
+	--focus-color: var(--wpds-color-stroke-interactive-error);
 }
 
 .components-validated-control {

--- a/packages/components/src/validated-form-controls/style.scss
+++ b/packages/components/src/validated-form-controls/style.scss
@@ -1,23 +1,23 @@
-@use "@wordpress/base-styles/colors" as *;
-
 %red-focus-ring {
 	--focus-color: var(--wpds-color-stroke-interactive-error);
+}
+
+%red-error-border {
+	@extend %red-focus-ring;
+
+	border-color: var(--wpds-color-stroke-interactive-error);
 }
 
 .components-validated-control {
 	// For components based on InputBase
 	&:has(:is(input, select):invalid[data-validity-visible])
 	.components-input-control__backdrop {
-		@extend %red-focus-ring;
-
-		border-color: $alert-red;
+		@extend %red-error-border;
 	}
 
 	// For TextareaControl
 	textarea:invalid[data-validity-visible] {
-		@extend %red-focus-ring;
-
-		border-color: $alert-red;
+		@extend %red-error-border;
 	}
 }
 
@@ -26,17 +26,13 @@
 
 	// For CustomSelectControl
 	&:has(select:invalid[data-validity-visible]) .components-input-control__backdrop {
-		@extend %red-focus-ring;
-
-		border-color: $alert-red;
+		@extend %red-error-border;
 	}
 
 	// For ContentEditableControl
 	&:has(input:invalid[data-validity-visible])
 	.components-validated-control__content-editable [role="textbox"] {
-		@extend %red-focus-ring;
-
-		border-color: $alert-red;
+		@extend %red-error-border;
 	}
 }
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### Enhancements
 
--   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring.
+-   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   DataForm: Communicate the timezone a `datetime` value is edited in. When the site timezone differs from the visitor's, the control renders help text under the input naming the site timezone: the zone name (e.g. `(CEST) Europe/Madrid`) or the UTC offset for sites pinned to one ([#82291](https://github.com/WordPress/gutenberg/pull/82291)).
 -   Export the `DataViewsProps` and `ItemWithId` types ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).
 -   Export the `DataViewsProps` and `ItemWithId` types and document every type property ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Enhancements
 
+-   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring.
 -   DataForm: Communicate the timezone a `datetime` value is edited in. When the site timezone differs from the visitor's, the control renders help text under the input naming the site timezone: the zone name (e.g. `(CEST) Europe/Madrid`) or the UTC offset for sites pinned to one ([#82291](https://github.com/WordPress/gutenberg/pull/82291)).
 -   Export the `DataViewsProps` and `ItemWithId` types ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).
 -   Export the `DataViewsProps` and `ItemWithId` types and document every type property ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### Enhancements
 
--   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
+-   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring and border ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   DataForm: Communicate the timezone a `datetime` value is edited in. When the site timezone differs from the visitor's, the control renders help text under the input naming the site timezone: the zone name (e.g. `(CEST) Europe/Madrid`) or the UTC offset for sites pinned to one ([#82291](https://github.com/WordPress/gutenberg/pull/82291)).
 -   Export the `DataViewsProps` and `ItemWithId` types ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).
 -   Export the `DataViewsProps` and `ItemWithId` types and document every type property ([#82326](https://github.com/WordPress/gutenberg/pull/82326)).

--- a/packages/dataviews/src/components/validated-form-controls/style.scss
+++ b/packages/dataviews/src/components/validated-form-controls/style.scss
@@ -1,17 +1,18 @@
-@use "@wordpress/base-styles/colors" as *;
-@use "@wordpress/base-styles/variables" as *;
-
 %red-focus-ring {
 	--focus-color: var(--wpds-color-stroke-interactive-error);
+}
+
+%red-error-border {
+	@extend %red-focus-ring;
+
+	border-color: var(--wpds-color-stroke-interactive-error);
 }
 
 .dataviews-validated-control {
 	// For components based on InputBase
 	&:has(:is(input, select):invalid[data-validity-visible]) {
 		.components-input-control__backdrop {
-			@extend %red-focus-ring;
-
-			border-color: $alert-red;
+			@extend %red-error-border;
 		}
 	}
 
@@ -19,9 +20,7 @@
 	.components-combobox-control__suggestions-container {
 		&:has(input:invalid[data-validity-visible]) {
 			&:not(:has([aria-expanded="true"])) {
-				@extend %red-focus-ring;
-
-				border-color: $alert-red;
+				@extend %red-error-border;
 			}
 		}
 	}
@@ -35,9 +34,7 @@
 		.components-form-token-field__input-container:not(
 			:has([aria-expanded="true"])
 		) {
-		@extend %red-focus-ring;
-
-		border-color: $alert-red;
+		@extend %red-error-border;
 	}
 
 	// For ToggleGroupControl

--- a/packages/dataviews/src/components/validated-form-controls/style.scss
+++ b/packages/dataviews/src/components/validated-form-controls/style.scss
@@ -2,7 +2,7 @@
 @use "@wordpress/base-styles/variables" as *;
 
 %red-focus-ring {
-	--focus-color: #{$alert-red};
+	--focus-color: var(--wpds-color-stroke-interactive-error);
 }
 
 .dataviews-validated-control {


### PR DESCRIPTION
## What?
Replace `$alert-red` with `--wpds-color-stroke-interactive-error` on the invalid-state focus ring and border of validated form controls.

## Why?
`$alert-red` is a compiled hex. The error stroke should read the token so `ThemeProvider` and token updates apply to both the ring and the border. `@wordpress/ui` already sets this token on invalid `input-layout`.

## How?
`%red-focus-ring` sets `--focus-color`. A new `%red-error-border` placeholder extends that and sets `border-color` to the same token. Call sites that need both extend `%red-error-border`. ToggleGroupControl still extends `%red-focus-ring` only, because that wrapper has no error border. The package build injects `#cc1818` as the fallback, which is the same value as `$alert-red`.

## Testing Instructions
1. Open Storybook for a validated form control (for example Components / Selection & Input / Validated Form Controls).
2. Enter an invalid value and leave the field so validity becomes visible.
3. The control border should be the error red (`#cc1818` in the default theme).
4. Focus the control. The focus ring should match that border.
5. Repeat with a DataViews/DataForm control that uses the dataviews validated wrappers (for example Combobox or Form Token Field in an invalid state).
6. For ToggleGroupControl, confirm the invalid focus ring is red and that the wrapper does not pick up an extra error border.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated invalid form controls with consistent error-state focus rings and borders.
  * Applied the standardized error styling across inputs, selects, text areas, custom selects, content-editable fields, and comboboxes.

* **Bug Fixes**
  * Improved consistency of validation feedback by aligning error indicators with the design system’s interactive error color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->