### PR TITLE
Agents: Apply repository skills to CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,4 +7,5 @@ knowledge_base:
     code_guidelines:
         filePatterns:
             - files: '.agents/skills/**/SKILL.md'
-              applyTo: '**'
+              # Include ordinary paths, dotfiles, and files in dot-directories.
+              applyTo: '**,**/.*,**/.*/**'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# CodeRabbit discovers AGENTS.md files automatically. Skills need an explicit
+# mapping because their directory does not match the source files they govern.
+inheritance: true
+knowledge_base:
+    code_guidelines:
+        filePatterns:
+            - files: '.agents/skills/**/SKILL.md'
+              applyTo: '**'

--- a/docs/contributors/code/agents-and-skills.md
+++ b/docs/contributors/code/agents-and-skills.md
@@ -22,7 +22,11 @@ This structure controls context bloat. The root `AGENTS.md` is a fixed cost in e
 
 ## Supported agents
 
-Codex discovers the repository skill catalog natively. Claude Code uses a generated compatibility view. Installing dependencies updates that view when it contains only catalog entries; it leaves the view unchanged when it finds unmatched local entries. No other agent-specific view is currently configured.
+Codex discovers the repository skill catalog natively. Claude Code uses a generated compatibility view. Installing dependencies updates that view when it contains only catalog entries; it leaves the view unchanged when it finds unmatched local entries.
+
+CodeRabbit discovers `AGENTS.md` files without a compatibility view. The repository's [`.coderabbit.yaml`](../../../.coderabbit.yaml) also maps the canonical skill entry points to reviewed files so automatic reviews can apply their guidance.
+
+No other agent-specific view is currently configured.
 
 ## Creating skills
 

--- a/docs/contributors/code/agents-and-skills.md
+++ b/docs/contributors/code/agents-and-skills.md
@@ -24,7 +24,7 @@ This structure controls context bloat. The root `AGENTS.md` is a fixed cost in e
 
 Codex discovers the repository skill catalog natively. Claude Code uses a generated compatibility view. Installing dependencies updates that view when it contains only catalog entries; it leaves the view unchanged when it finds unmatched local entries.
 
-CodeRabbit discovers `AGENTS.md` files without a compatibility view. The repository's [`.coderabbit.yaml`](../../../.coderabbit.yaml) also maps the canonical skill entry points to reviewed files so automatic reviews can apply their guidance.
+CodeRabbit discovers `AGENTS.md` files without a compatibility view. The repository's [`.coderabbit.yaml`](https://github.com/WordPress/gutenberg/blob/trunk/.coderabbit.yaml) also maps the canonical skill entry points to reviewed files so automatic reviews can apply their guidance.
 
 No other agent-specific view is currently configured.
 


### PR DESCRIPTION
## What?

Configure CodeRabbit's automatic reviews to use the repository's canonical `.agents/skills/**/SKILL.md` files as code guidelines. Document how CodeRabbit consumes `AGENTS.md` files and skills.

## Why?

CodeRabbit discovers nested `AGENTS.md` files automatically, but it scopes custom guideline files to their own directory by default. The skill catalog lives under `.agents/skills/`, so its guidance would not otherwise apply to the source files under review.

## How?

Add a root `.coderabbit.yaml` that maps every skill entry point to all reviewed paths. Enable inheritance so this repository-specific mapping keeps the existing CodeRabbit settings from higher configuration levels.

## Testing Instructions

1. Run `npm run lint:md:docs -- docs/contributors/code/agents-and-skills.md`.
2. Run `npm exec --no -- prettier --check .coderabbit.yaml docs/contributors/code/agents-and-skills.md`.
3. Run `@coderabbitai configuration` on this pull request and confirm that the resolved configuration maps `.agents/skills/**/SKILL.md` to ordinary paths, dotfiles, and files in dot-directories.

### Testing Instructions for Keyboard

Not applicable. This pull request does not change the UI.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to research CodeRabbit's current configuration documentation, implement the change, and verify the files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified supported agent behavior for Codex, Claude Code, and CodeRabbit.
  - Documented CodeRabbit’s direct `AGENTS.md` discovery and skill-entry mapping.
  - Clarified that no other agent-specific compatibility view is configured.

- **Chores**
  - Added CodeRabbit configuration for schema metadata, inheritance, and skill guideline mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->