### PR TITLE
List: preserve the selection when indenting and outdenting

### DIFF
--- a/packages/block-library/src/list-item/edit.jsx
+++ b/packages/block-library/src/list-item/edit.jsx
@@ -26,7 +26,7 @@ import {
 
 export function IndentUI( { clientId } ) {
 	const indentListItem = useIndentListItem( clientId );
-	const outdentListItem = useOutdentListItem();
+	const outdentListItem = useOutdentListItem( clientId );
 	const { canIndent, canOutdent } = useSelect(
 		( select ) => {
 			const { getBlockIndex, getBlockRootClientId, getBlockName } =

--- a/packages/block-library/src/list-item/hooks/restore-selection.js
+++ b/packages/block-library/src/list-item/hooks/restore-selection.js
@@ -1,0 +1,118 @@
+/**
+ * Maps a rich text character offset within an element to a DOM node and offset.
+ * Text nodes count their length; void nodes such as line breaks or inline
+ * objects count as a single character, the same way rich text counts them.
+ *
+ * @param {Element} element The rich text element.
+ * @param {number}  offset  The character offset.
+ *
+ * @return {{node: Node, offset: number}} The DOM node and offset.
+ */
+function getPoint( element, offset ) {
+	let remaining = offset;
+
+	function walk( node ) {
+		for ( const child of node.childNodes ) {
+			if ( child.nodeType === child.TEXT_NODE ) {
+				if ( remaining <= child.length ) {
+					return { node: child, offset: remaining };
+				}
+				remaining -= child.length;
+			} else if (
+				child.nodeName === 'BR' ||
+				child.getAttribute?.( 'contenteditable' ) === 'false'
+			) {
+				if ( remaining === 0 ) {
+					const index = Array.prototype.indexOf.call(
+						node.childNodes,
+						child
+					);
+					return { node, offset: index };
+				}
+				remaining -= 1;
+			} else {
+				const found = walk( child );
+				if ( found ) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	return (
+		walk( element ) ?? {
+			node: element,
+			offset: element.childNodes.length,
+		}
+	);
+}
+
+function getRichTextElement( ownerDocument, point ) {
+	return ownerDocument.querySelector(
+		`[data-block="${ point.clientId }"] [data-wp-block-attribute-key="${ point.attributeKey }"]`
+	);
+}
+
+/**
+ * Restores a selection on the DOM from the store. When blocks move, React
+ * remounts them and the native selection that spanned the old nodes collapses.
+ * The store keeps the selection, so the native range is rebuilt on the new
+ * nodes once they are in place.
+ *
+ * @param {Document} ownerDocument The document the blocks live in.
+ * @param {Object}   start         The selection start from the store.
+ * @param {Object}   end           The selection end from the store.
+ */
+export function restoreSelection( ownerDocument, start, end ) {
+	if (
+		! ownerDocument ||
+		! start?.clientId ||
+		! end?.clientId ||
+		start.offset === undefined ||
+		end.offset === undefined
+	) {
+		return;
+	}
+
+	const { defaultView } = ownerDocument;
+	// The blocks are about to move, which remounts them. Remember the current
+	// nodes so the selection is only rebuilt once they have been replaced.
+	const previousStart = getRichTextElement( ownerDocument, start );
+	const previousEnd = getRichTextElement( ownerDocument, end );
+	let attempts = 10;
+
+	function apply() {
+		const startElement = getRichTextElement( ownerDocument, start );
+		const endElement = getRichTextElement( ownerDocument, end );
+
+		// Wait until the blocks have re-rendered into fresh nodes; applying to
+		// the old nodes would be undone when they are replaced.
+		if (
+			! startElement ||
+			! endElement ||
+			startElement === previousStart ||
+			endElement === previousEnd
+		) {
+			if ( attempts-- > 0 ) {
+				defaultView.requestAnimationFrame( apply );
+			}
+			return;
+		}
+
+		const startPoint = getPoint( startElement, start.offset );
+		const endPoint = getPoint( endElement, end.offset );
+		// `setBaseAndExtent` keeps the selection direction and orders the
+		// boundaries itself, so a backward selection is not collapsed.
+		defaultView
+			.getSelection()
+			.setBaseAndExtent(
+				startPoint.node,
+				startPoint.offset,
+				endPoint.node,
+				endPoint.offset
+			);
+	}
+
+	apply();
+}

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -1,72 +1,82 @@
-import { useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock, cloneBlock } from '@wordpress/blocks';
+import { useCallback, useRef, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { unlock } from '../../lock-unlock';
+import { restoreSelection } from './restore-selection';
+
+const { useBlockElement } = unlock( blockEditorPrivateApis );
 
 export default function useIndentListItem( clientId ) {
-	const { replaceBlocks, selectionChange, multiSelect } =
-		useDispatch( blockEditorStore );
+	const registry = useRegistry();
 	const {
-		getBlock,
+		insertBlock,
+		moveBlocksToPosition,
+		removeBlock,
+		updateBlockListSettings,
+	} = useDispatch( blockEditorStore );
+	const {
 		getPreviousBlockClientId,
+		getBlockRootClientId,
+		getBlockListSettings,
+		getSelectedBlockClientIds,
+		getBlockOrder,
+		getBlockAttributes,
 		getSelectionStart,
 		getSelectionEnd,
-		hasMultiSelection,
-		getMultiSelectedBlockClientIds,
-		getBlockRootClientId,
-		getBlockAttributes,
 	} = useSelect( blockEditorStore );
-	return useCallback( () => {
-		const _hasMultiSelection = hasMultiSelection();
-		const clientIds = _hasMultiSelection
-			? getMultiSelectedBlockClientIds()
-			: [ clientId ];
-		const clonedBlocks = clientIds.map( ( _clientId ) =>
-			cloneBlock( getBlock( _clientId ) )
-		);
-		const previousSiblingId = getPreviousBlockClientId( clientId );
-		const newListItem = cloneBlock( getBlock( previousSiblingId ) );
-		// Get the parent list's attributes to inherit the ordered property
-		const parentListId = getBlockRootClientId( clientId );
-		const parentListAttributes = getBlockAttributes( parentListId );
-		// If the sibling has no innerBlocks, create a new `list` block.
-		if ( ! newListItem.innerBlocks?.length ) {
-			newListItem.innerBlocks = [
-				createBlock( 'core/list', {
-					ordered: parentListAttributes.ordered,
-				} ),
-			];
-		}
-		// A list item usually has one `list`, but it's possible to have
-		// more. So we need to preserve the previous `list` blocks and
-		// merge the new blocks to the last `list`.
-		newListItem.innerBlocks[
-			newListItem.innerBlocks.length - 1
-		].innerBlocks.push( ...clonedBlocks );
 
-		// We get the selection start/end here, because when
-		// we replace blocks, the selection is updated too.
+	// Indenting moves the items, which remounts them and drops the native
+	// selection. Keep the document to rebuild the selection afterwards.
+	const element = useBlockElement( clientId );
+	const ownerDocumentRef = useRef();
+	useEffect( () => {
+		ownerDocumentRef.current = element?.ownerDocument;
+	}, [ element ] );
+
+	return useCallback( () => {
+		const clientIds = getSelectedBlockClientIds();
+		const previousSiblingId = getPreviousBlockClientId( clientId );
+		const rootClientId = getBlockRootClientId( clientId );
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
-		// Replace the previous sibling of the block being indented and the indented blocks,
-		// with a new block whose attributes are equal to the ones of the previous sibling and
-		// whose descendants are the children of the previous sibling, followed by the indented blocks.
-		replaceBlocks( [ previousSiblingId, ...clientIds ], [ newListItem ] );
-		if ( ! _hasMultiSelection ) {
-			selectionChange(
-				clonedBlocks[ 0 ].clientId,
-				selectionEnd.attributeKey,
-				selectionEnd.clientId === selectionStart.clientId
-					? selectionStart.offset
-					: selectionEnd.offset,
-				selectionEnd.offset
-			);
-		} else {
-			multiSelect(
-				clonedBlocks[ 0 ].clientId,
-				clonedBlocks[ clonedBlocks.length - 1 ].clientId
-			);
-		}
+
+		registry.batch( () => {
+			let nestedListId = getBlockOrder( previousSiblingId )[ 0 ];
+			if ( ! nestedListId ) {
+				// The list is inserted with a placeholder item already inside,
+				// otherwise the empty list would scaffold its own item through
+				// the block type's direct insert. The real items are then moved
+				// in, keeping their client IDs, and the placeholder is removed.
+				const placeholder = createBlock( 'core/list-item' );
+				const indentedList = createBlock(
+					'core/list',
+					{ ordered: getBlockAttributes( rootClientId ).ordered },
+					[ placeholder ]
+				);
+				nestedListId = indentedList.clientId;
+				insertBlock( indentedList, 0, previousSiblingId, false );
+				// Immediately update the block list settings, otherwise blocks
+				// can't be moved here due to canInsert checks.
+				updateBlockListSettings(
+					nestedListId,
+					getBlockListSettings( rootClientId )
+				);
+				moveBlocksToPosition( clientIds, rootClientId, nestedListId );
+				removeBlock( placeholder.clientId, false );
+			} else {
+				moveBlocksToPosition( clientIds, rootClientId, nestedListId );
+			}
+		} );
+
+		restoreSelection(
+			ownerDocumentRef.current,
+			selectionStart,
+			selectionEnd
+		);
 
 		return true;
 	}, [ clientId ] );

--- a/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-outdent-list-item.js
@@ -1,9 +1,16 @@
-import { useCallback } from '@wordpress/element';
+import { useCallback, useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { cloneBlock } from '@wordpress/blocks';
+import { unlock } from '../../lock-unlock';
+import { restoreSelection } from './restore-selection';
 
-export default function useOutdentListItem() {
+const { useBlockElement } = unlock( blockEditorPrivateApis );
+
+export default function useOutdentListItem( clientId ) {
 	const registry = useRegistry();
 	const { moveBlocksToPosition, removeBlock, removeBlocks, insertBlock } =
 		useDispatch( blockEditorStore );
@@ -14,7 +21,17 @@ export default function useOutdentListItem() {
 		getBlockIndex,
 		getSelectedBlockClientIds,
 		getBlock,
+		getSelectionStart,
+		getSelectionEnd,
 	} = useSelect( blockEditorStore );
+
+	// Outdenting moves the items, which remounts them and drops the native
+	// selection. Keep the document to rebuild the selection afterwards.
+	const element = useBlockElement( clientId );
+	const ownerDocumentRef = useRef();
+	useEffect( () => {
+		ownerDocumentRef.current = element?.ownerDocument;
+	}, [ element ] );
 
 	function getParentListItemId( id ) {
 		const listId = getBlockRootClientId( id );
@@ -57,6 +74,8 @@ export default function useOutdentListItem() {
 		const followingListItems = order.slice(
 			getBlockIndex( lastClientId ) + 1
 		);
+		const selectionStart = getSelectionStart();
+		const selectionEnd = getSelectionEnd();
 
 		registry.batch( () => {
 			if ( followingListItems.length ) {
@@ -94,6 +113,12 @@ export default function useOutdentListItem() {
 				removeBlock( parentListId, shouldSelectParent );
 			}
 		} );
+
+		restoreSelection(
+			ownerDocumentRef.current,
+			selectionStart,
+			selectionEnd
+		);
 
 		return true;
 	}, [] );

--- a/packages/block-library/src/list-item/hooks/use-space.js
+++ b/packages/block-library/src/list-item/hooks/use-space.js
@@ -13,7 +13,7 @@ export default function useSpace( clientId ) {
 	const { getSelectionStart, getSelectionEnd, getBlockIndex } =
 		useSelect( blockEditorStore );
 	const indentListItem = useIndentListItem( clientId );
-	const outdentListItem = useOutdentListItem();
+	const outdentListItem = useOutdentListItem( clientId );
 
 	return useRefEffect(
 		( element ) => {

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -894,6 +894,112 @@ test.describe( 'List (@firefox)', () => {
 		);
 	} );
 
+	test( 'should keep a partial selection when indenting and outdenting with the toolbar', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/list' } );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'three' );
+
+		// Build a partial selection across the last two items. From the end
+		// of "three", move left to sit after "th", then extend up a line so
+		// the selection runs from after "tw" to after "th".
+		await pageUtils.pressKeys( 'ArrowLeft', { times: 3 } );
+		await pageUtils.pressKeys( 'shift+ArrowUp' );
+
+		const getNativeSelection = () =>
+			page
+				.frame( { name: 'editor-canvas' } )
+				.evaluate( () => document.getSelection().toString() );
+
+		expect( await getNativeSelection() ).toBe( 'o\nth' );
+
+		// Indenting moves both items into a nested list, but keeps their
+		// client IDs, so the exact native selection survives instead of
+		// collapsing or turning into a whole-block selection.
+		await editor.clickBlockToolbarButton( 'Indent' );
+		await expect.poll( getNativeSelection ).toBe( 'o\nth' );
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>one<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>two</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>three</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
+		// Outdenting moves them back and again keeps the selection.
+		await editor.clickBlockToolbarButton( 'Outdent' );
+		await expect.poll( getNativeSelection ).toBe( 'o\nth' );
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>one</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>two</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>three</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+	} );
+
+	test( 'should keep the caret when indenting a single item with the toolbar', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/list' } );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		// Place the caret between "t" and "wo".
+		await pageUtils.pressKeys( 'ArrowLeft', { times: 2 } );
+
+		await editor.clickBlockToolbarButton( 'Indent' );
+
+		// The caret keeps its place inside the moved item.
+		await page.keyboard.type( '‸' );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/list',
+				innerBlocks: [
+					{
+						name: 'core/list-item',
+						attributes: { content: 'one' },
+						innerBlocks: [
+							{
+								name: 'core/list',
+								innerBlocks: [
+									{
+										name: 'core/list-item',
+										attributes: { content: 't‸wo' },
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		] );
+	} );
+
 	test( 'should outdent with children', async ( { editor, page } ) => {
 		await editor.insertBlock( { name: 'core/list' } );
 		await page.keyboard.type( 'a' );


### PR DESCRIPTION
## What?

Indenting or outdenting a list item now keeps the selection. A caret, or a selection that runs partway through several items, stays exactly where it was instead of collapsing or jumping to a whole block selection. This is a preparation step for binding Tab and Shift+Tab to indent and outdent a multi-item selection, split out so the selection behavior can be reviewed on its own.

## Why?

Indent and outdent used to clone the list items and drop new copies in place, which gave the moved items fresh client IDs and threw the selection away. That is fine for a single caret at the start of an item, but any real selection is lost the moment you indent. It also churns the block references, which the follow-up work needs to keep stable.

## How?

1. **Keep the client IDs.** Both actions now move the items with `moveBlocksToPosition` instead of cloning and replacing them, so the blocks keep their identity through the move.
2. **Rebuild the native selection.** Moving a block still remounts it in the DOM, so the live browser selection that spanned the old nodes collapses. A small helper next to the two hooks reads the selection from the store, waits until the remounted nodes are in place, maps each stored offset back to a DOM point, and reapplies the range with `setBaseAndExtent` (which keeps the selection direction). The store is the source of truth; the helper just restores what the DOM lost.
3. **Avoid a stray empty item.** Inserting a fresh nested list would otherwise scaffold its own empty item through the list block's default insertion, so the new list is created already holding the items being moved.

The helper lives beside the indent and outdent hooks for now; it can move somewhere more general if other block moves need the same thing.

## Testing Instructions

1. Add a list with three items, e.g. "one", "two", "three".
2. Put the caret in the middle of "two" and click the Indent button in the toolbar. The caret stays in the same spot in the moved item.
3. Select from the middle of "two" to the middle of "three" (place the caret after "tw", then Shift+ArrowDown, or drag). Click Indent, then Outdent. The same text stays selected through both.

### Testing Instructions for Keyboard

1. With the caret at the start of a nested item, Shift+Tab to outdent, Tab to indent. The caret keeps its place.
2. Select across two items with Shift+ArrowUp or Shift+ArrowDown and press Tab. The selection is preserved.

## Use of AI Tools

This pull request was authored with Claude Code, reviewed and tested by me.
