### PR TITLE
CI: Automate the "Tested up to" bump in readme.txt

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -55,6 +55,42 @@ jobs:
                     echo "next_stable_branch=release/${LATEST_STABLE_MAJOR}.$((LATEST_STABLE_MINOR + 1))" >> "$GITHUB_OUTPUT"
                   fi
 
+    warn-stale-tested-up-to:
+        name: Warn when readme.txt trails the latest WordPress release
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        # Purely informational: nothing depends on this job and it must never
+        # block or fail a release, even when the check itself breaks.
+        continue-on-error: true
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  sparse-checkout: readme.txt
+                  sparse-checkout-cone-mode: false
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Compare readme.txt with the latest stable WordPress version
+              run: |
+                  curl \
+                    --fail --silent --show-error \
+                    -H "Accept: application/json" \
+                    -o versions.json \
+                    "https://api.wordpress.org/core/stable-check/1.0/"
+                  LATEST="$(jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' versions.json | cut -d. -f1,2)"
+                  rm versions.json
+                  TESTED="$(sed -n 's/^Tested up to: \([0-9]*\.[0-9]*\).*/\1/p' readme.txt)"
+                  # readme.txt may legitimately run ahead of the API when it already
+                  # names an upcoming release; only an older value is worth a warning.
+                  if [[ -n "$LATEST" && -n "$TESTED" ]] &&
+                    [[ "$(printf '%s\n' "$TESTED" "$LATEST" | sort --version-sort | tail -n 1)" != "$TESTED" ]]; then
+                    echo "::warning::readme.txt says \"Tested up to: ${TESTED}\" but the latest stable WordPress version is ${LATEST}. Merge the pending \"Tested up to\" bump pull request (or bump readme.txt manually) so the next release ships the current version."
+                  fi
+
     preflight-release-token:
         name: Preflight release token
         runs-on: 'ubuntu-24.04'

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -55,42 +55,6 @@ jobs:
                     echo "next_stable_branch=release/${LATEST_STABLE_MAJOR}.$((LATEST_STABLE_MINOR + 1))" >> "$GITHUB_OUTPUT"
                   fi
 
-    warn-stale-tested-up-to:
-        name: Warn when readme.txt trails the latest WordPress release
-        runs-on: 'ubuntu-24.04'
-        permissions:
-            contents: read
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        # Purely informational: nothing depends on this job and it must never
-        # block or fail a release, even when the check itself breaks.
-        continue-on-error: true
-
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-              with:
-                  sparse-checkout: readme.txt
-                  sparse-checkout-cone-mode: false
-                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
-                  persist-credentials: false
-
-            - name: Compare readme.txt with the latest stable WordPress version
-              run: |
-                  curl \
-                    --fail --silent --show-error \
-                    -H "Accept: application/json" \
-                    -o versions.json \
-                    "https://api.wordpress.org/core/stable-check/1.0/"
-                  LATEST="$(jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' versions.json | cut -d. -f1,2)"
-                  rm versions.json
-                  TESTED="$(sed -n 's/^Tested up to: \([0-9]*\.[0-9]*\).*/\1/p' readme.txt)"
-                  # readme.txt may legitimately run ahead of the API when it already
-                  # names an upcoming release; only an older value is worth a warning.
-                  if [[ -n "$LATEST" && -n "$TESTED" ]] &&
-                    [[ "$(printf '%s\n' "$TESTED" "$LATEST" | sort --version-sort | tail -n 1)" != "$TESTED" ]]; then
-                    echo "::warning::readme.txt says \"Tested up to: ${TESTED}\" but the latest stable WordPress version is ${LATEST}. Merge the pending \"Tested up to\" bump pull request (or bump readme.txt manually) so the next release ships the current version."
-                  fi
-
     preflight-release-token:
         name: Preflight release token
         runs-on: 'ubuntu-24.04'

--- a/.github/workflows/bump-tested-up-to.yml
+++ b/.github/workflows/bump-tested-up-to.yml
@@ -29,13 +29,16 @@ jobs:
             pull-requests: read
 
         steps:
-            # Only readme.txt is inspected and edited. The push and the pull
-            # request authenticate with the app token generated further down,
-            # not with this checkout's credentials.
-            - name: Checkout readme.txt
+            # Only readme.txt (inspected and edited) and the release tooling
+            # that parses it are needed. The push and the pull request
+            # authenticate with the app token generated further down, not with
+            # this checkout's credentials.
+            - name: Checkout readme.txt and the release tooling
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
-                  sparse-checkout: readme.txt
+                  sparse-checkout: |
+                      /readme.txt
+                      /tools/release/
                   sparse-checkout-cone-mode: false
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
@@ -48,14 +51,13 @@ jobs:
                   # The query must stay in sync with the "Compute previous WordPress
                   # version" step in unit-test.yml, which reads the same API.
                   LATEST="$(curl --fail --silent --show-error -H "Accept: application/json" "https://api.wordpress.org/core/stable-check/1.0/" | jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' | cut -d. -f1,2)"
-                  # The pattern must stay in sync with getTestedUpToMajor() in
-                  # tools/release/resolve-performance-branches.mjs, which parses the
-                  # same readme.txt line.
-                  TESTED="$(sed -n 's/^Tested up to: \([0-9]*\.[0-9]*\).*/\1/p' readme.txt)"
-                  if [[ -z "$LATEST" || -z "$TESTED" ]]; then
-                    echo "Could not determine the latest stable version ('${LATEST}') or the readme.txt value ('${TESTED}')."
+                  if [[ -z "$LATEST" ]]; then
+                    echo "Could not determine the latest stable version from the API."
                     exit 1
                   fi
+                  # The same parser the performance workflow relies on; it throws,
+                  # failing this step, when the readme.txt line changes shape.
+                  TESTED="$(node -e 'import("./tools/release/resolve-performance-branches.mjs").then(({ getTestedUpToMajor }) => console.log(getTestedUpToMajor(require("fs").readFileSync("readme.txt", "utf8"))))')"
                   # readme.txt may legitimately run ahead of the API when it already
                   # names an upcoming release; only an older value needs a bump.
                   if [[ "$(printf '%s\n' "$TESTED" "$LATEST" | sort --version-sort | tail -n 1)" == "$TESTED" ]]; then

--- a/.github/workflows/bump-tested-up-to.yml
+++ b/.github/workflows/bump-tested-up-to.yml
@@ -20,38 +20,37 @@ jobs:
     bump-tested-up-to:
         name: Open a pull request when a new WordPress version is stable
         runs-on: 'ubuntu-24.04'
+        # Forks have no app credentials, so a scheduled run there fails daily.
+        if: ${{ github.repository == 'WordPress/gutenberg' }}
         environment: 'GitHub Releases'
-        permissions: {}
+        permissions:
+            contents: read
+            # The check step lists pull requests with the default token.
+            pull-requests: read
 
         steps:
-            - name: Generate application token
-              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-              id: app-token
-              with:
-                  client-id: ${{ vars.APP_CLIENT_ID }}
-                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
-                  permission-contents: write
-                  permission-pull-requests: write
-
-            # The app token lets the push and the pull request trigger CI, which
-            # the default GITHUB_TOKEN would not.
-            - name: Checkout code
+            # Only readme.txt is inspected and edited. The push and the pull
+            # request authenticate with the app token generated further down,
+            # not with this checkout's credentials.
+            - name: Checkout readme.txt
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
-                  token: ${{ steps.app-token.outputs.token }}
+                  sparse-checkout: readme.txt
+                  sparse-checkout-cone-mode: false
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
-                  persist-credentials: true
+                  persist-credentials: false
 
             - name: Check whether readme.txt trails the latest WordPress release
               id: check
+              env:
+                  GH_TOKEN: ${{ github.token }}
               run: |
-                  curl \
-                    --fail --silent --show-error \
-                    -H "Accept: application/json" \
-                    -o versions.json \
-                    "https://api.wordpress.org/core/stable-check/1.0/"
-                  LATEST="$(jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' versions.json | cut -d. -f1,2)"
-                  rm versions.json
+                  # The query must stay in sync with the "Compute previous WordPress
+                  # version" step in unit-test.yml, which reads the same API.
+                  LATEST="$(curl --fail --silent --show-error -H "Accept: application/json" "https://api.wordpress.org/core/stable-check/1.0/" | jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' | cut -d. -f1,2)"
+                  # The pattern must stay in sync with getTestedUpToMajor() in
+                  # tools/release/resolve-performance-branches.mjs, which parses the
+                  # same readme.txt line.
                   TESTED="$(sed -n 's/^Tested up to: \([0-9]*\.[0-9]*\).*/\1/p' readme.txt)"
                   if [[ -z "$LATEST" || -z "$TESTED" ]]; then
                     echo "Could not determine the latest stable version ('${LATEST}') or the readme.txt value ('${TESTED}')."
@@ -63,46 +62,75 @@ jobs:
                     echo "readme.txt lists ${TESTED} and the latest stable version is ${LATEST}. Nothing to do."
                     exit 0
                   fi
-                  # The readme should not claim a WordPress version the plugin has no
-                  # wp/X.Y branch for yet; the branch is cut by the release process.
-                  if ! git ls-remote --exit-code --heads origin "wp/${LATEST}" > /dev/null; then
+                  # The readme should not claim a WordPress version the plugin has
+                  # no wp/X.Y branch for. `--exit-code` reports a missing ref as 2;
+                  # any other failure is an infrastructure problem that must not be
+                  # mistaken for a missing branch.
+                  set +e
+                  git ls-remote --exit-code --heads origin "wp/${LATEST}" > /dev/null
+                  WP_BRANCH_STATUS=$?
+                  set -e
+                  if [[ "$WP_BRANCH_STATUS" -eq 2 ]]; then
                     echo "WordPress ${LATEST} is stable but the wp/${LATEST} branch does not exist yet. Trying again on the next scheduled run."
                     exit 0
+                  elif [[ "$WP_BRANCH_STATUS" -ne 0 ]]; then
+                    echo "Could not determine whether the wp/${LATEST} branch exists (git exited with ${WP_BRANCH_STATUS})."
+                    exit 1
                   fi
-                  if git ls-remote --exit-code --heads origin "update/tested-up-to-${LATEST}" > /dev/null; then
-                    echo "The update/tested-up-to-${LATEST} branch already exists, so a bump was already proposed."
+                  # Deduplicate on the pull request record, not the branch: a closed
+                  # pull request is a human decision this workflow must not repeat,
+                  # while a leftover branch without any pull request is debris from
+                  # an interrupted run that the push below overwrites.
+                  if [[ "$(gh pr list --head "update/tested-up-to-${LATEST}" --state all --json number --jq 'length')" -gt 0 ]]; then
+                    echo "A pull request for the ${LATEST} bump already exists (open, merged, or declined)."
                     exit 0
                   fi
                   echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
 
-            - name: Configure Git user name
+            # The app token lets the push and the pull request trigger CI, which
+            # the default GITHUB_TOKEN would not. It is only minted when the check
+            # found something to push.
+            - name: Generate application token
               if: steps.check.outputs.version
-              run: git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-
-            - name: Configure Git user email
-              if: steps.check.outputs.version
-              env:
-                  APP_USER_ID: ${{ vars.APP_USER_ID }}
-              run: git config user.email "${APP_USER_ID}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              id: app-token
+              with:
+                  client-id: ${{ vars.APP_CLIENT_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
 
             - name: Create the pull request
               if: steps.check.outputs.version
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   VERSION: ${{ steps.check.outputs.version }}
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  APP_USER_ID: ${{ vars.APP_USER_ID }}
               run: |
+                  git config user.name "${APP_SLUG}[bot]"
+                  git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
                   BRANCH="update/tested-up-to-${VERSION}"
                   git checkout -b "$BRANCH"
                   sed -i "s/^Tested up to: .*/Tested up to: ${VERSION}/" readme.txt
                   git add readme.txt
                   git commit -m "Plugin: Bump \"Tested up to\" to WordPress ${VERSION}"
-                  git push --set-upstream origin "$BRANCH"
+                  # --force overwrites debris from a run that pushed the branch but
+                  # failed before creating the pull request; the check step already
+                  # proved no pull request exists for this branch.
+                  git push --force --set-upstream origin "$BRANCH"
                   gh pr create \
                     --base trunk \
                     --head "$BRANCH" \
+                    --label 'Gutenberg Plugin' \
+                    --label '[Type] Enhancement' \
                     --title "Plugin: Bump \"Tested up to\" to WordPress ${VERSION}" \
-                    --body "WordPress ${VERSION} is now the latest stable release according to [the version check API](https://api.wordpress.org/core/stable-check/1.0/), and the \`wp/${VERSION}\` branch exists, so the plugin's \`readme.txt\` should say it is tested up to ${VERSION}.
+                    --body "WordPress ${VERSION} is now the latest stable release according to [the version check API](https://api.wordpress.org/core/stable-check/1.0/), and \`readme.txt\` still names an older version.
 
-                  This pull request was opened automatically by the \`bump-tested-up-to.yml\` workflow. It only changes \`readme.txt\`; the larger follow-up chore of raising the minimum required WordPress version and removing old compatibility code is a separate, manual pull request."
-                  gh pr edit "$BRANCH" --add-label 'Gutenberg Plugin' --add-label '[Type] Enhancement' ||
-                    echo "Could not add labels to the pull request; add them manually."
+                  Merging this pull request is the compatibility attestation, so before merging:
+
+                  - Confirm trunk's CI runs against WordPress ${VERSION} (the unit test workflow tests against the latest stable release).
+                  - Update \`REFERENCE_COMMIT\` in \`tools/release/resolve-performance-branches.mjs\`, here or in a paired pull request. \`docs/explanations/architecture/performance.md\` requires it for every \"Tested up to\" change.
+
+                  This pull request was opened automatically by the \`bump-tested-up-to.yml\` workflow. The larger chore of raising the minimum required WordPress version and removing old compatibility code is a separate, manual pull request."

--- a/.github/workflows/bump-tested-up-to.yml
+++ b/.github/workflows/bump-tested-up-to.yml
@@ -1,0 +1,108 @@
+name: Bump "Tested up to" version
+
+on:
+    schedule:
+        # Once a day. WordPress releases are not announced on a fixed schedule,
+        # so the job polls and exits quietly when there is nothing to do.
+        - cron: '15 4 * * *'
+    workflow_dispatch:
+
+# Queues overlapping runs instead of cancelling one that may be mid-push.
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    bump-tested-up-to:
+        name: Open a pull request when a new WordPress version is stable
+        runs-on: 'ubuntu-24.04'
+        environment: 'GitHub Releases'
+        permissions: {}
+
+        steps:
+            - name: Generate application token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              id: app-token
+              with:
+                  client-id: ${{ vars.APP_CLIENT_ID }}
+                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
+
+            # The app token lets the push and the pull request trigger CI, which
+            # the default GITHUB_TOKEN would not.
+            - name: Checkout code
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: true
+
+            - name: Check whether readme.txt trails the latest WordPress release
+              id: check
+              run: |
+                  curl \
+                    --fail --silent --show-error \
+                    -H "Accept: application/json" \
+                    -o versions.json \
+                    "https://api.wordpress.org/core/stable-check/1.0/"
+                  LATEST="$(jq --raw-output 'with_entries(select(.value=="latest"))|keys[]' versions.json | cut -d. -f1,2)"
+                  rm versions.json
+                  TESTED="$(sed -n 's/^Tested up to: \([0-9]*\.[0-9]*\).*/\1/p' readme.txt)"
+                  if [[ -z "$LATEST" || -z "$TESTED" ]]; then
+                    echo "Could not determine the latest stable version ('${LATEST}') or the readme.txt value ('${TESTED}')."
+                    exit 1
+                  fi
+                  # readme.txt may legitimately run ahead of the API when it already
+                  # names an upcoming release; only an older value needs a bump.
+                  if [[ "$(printf '%s\n' "$TESTED" "$LATEST" | sort --version-sort | tail -n 1)" == "$TESTED" ]]; then
+                    echo "readme.txt lists ${TESTED} and the latest stable version is ${LATEST}. Nothing to do."
+                    exit 0
+                  fi
+                  # The readme should not claim a WordPress version the plugin has no
+                  # wp/X.Y branch for yet; the branch is cut by the release process.
+                  if ! git ls-remote --exit-code --heads origin "wp/${LATEST}" > /dev/null; then
+                    echo "WordPress ${LATEST} is stable but the wp/${LATEST} branch does not exist yet. Trying again on the next scheduled run."
+                    exit 0
+                  fi
+                  if git ls-remote --exit-code --heads origin "update/tested-up-to-${LATEST}" > /dev/null; then
+                    echo "The update/tested-up-to-${LATEST} branch already exists, so a bump was already proposed."
+                    exit 0
+                  fi
+                  echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
+
+            - name: Configure Git user name
+              if: steps.check.outputs.version
+              run: git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+
+            - name: Configure Git user email
+              if: steps.check.outputs.version
+              env:
+                  APP_USER_ID: ${{ vars.APP_USER_ID }}
+              run: git config user.email "${APP_USER_ID}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+            - name: Create the pull request
+              if: steps.check.outputs.version
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  VERSION: ${{ steps.check.outputs.version }}
+              run: |
+                  BRANCH="update/tested-up-to-${VERSION}"
+                  git checkout -b "$BRANCH"
+                  sed -i "s/^Tested up to: .*/Tested up to: ${VERSION}/" readme.txt
+                  git add readme.txt
+                  git commit -m "Plugin: Bump \"Tested up to\" to WordPress ${VERSION}"
+                  git push --set-upstream origin "$BRANCH"
+                  gh pr create \
+                    --base trunk \
+                    --head "$BRANCH" \
+                    --title "Plugin: Bump \"Tested up to\" to WordPress ${VERSION}" \
+                    --body "WordPress ${VERSION} is now the latest stable release according to [the version check API](https://api.wordpress.org/core/stable-check/1.0/), and the \`wp/${VERSION}\` branch exists, so the plugin's \`readme.txt\` should say it is tested up to ${VERSION}.
+
+                  This pull request was opened automatically by the \`bump-tested-up-to.yml\` workflow. It only changes \`readme.txt\`; the larger follow-up chore of raising the minimum required WordPress version and removing old compatibility code is a separate, manual pull request."
+                  gh pr edit "$BRANCH" --add-label 'Gutenberg Plugin' --add-label '[Type] Enhancement' ||
+                    echo "Could not add labels to the pull request; add them manually."


### PR DESCRIPTION
## What

A daily scheduled workflow that opens a pull request bumping the `Tested up to` field in `readme.txt` when a new WordPress version becomes the latest stable release.

## Why

The field only changes today inside the manual "bump minimum required WordPress version" chore, which lands weeks after the WordPress release. In between, nothing notices the gap: the performance workflow reads the field on every trunk push and release, so a stale value quietly pins those runs to the old `wp/X.Y` branch. Right now the [version check API](https://api.wordpress.org/core/stable-check/1.0/) already reports 7.1 while `readme.txt` says 7.0, so the first run after merge will open the 7.1 bump.

## What changed

- New `bump-tested-up-to.yml` workflow: daily cron plus manual dispatch, restricted to `WordPress/gutenberg`.
- The check runs first against a sparse checkout of `readme.txt` with no credentials. The write-scoped app token is only minted when there is something to push, and the app-created pull request triggers CI (the default `GITHUB_TOKEN` would not).
- `readme.txt` may legitimately run ahead of the API (it can name an upcoming release), so only an older value triggers a bump, and only once the `wp/X.Y` branch exists.
- Deduplication keys on the pull request record rather than the branch: a closed pull request counts as a human decision and is never re-proposed, while a leftover branch from an interrupted run is overwritten.
- A network failure in the branch checks fails the run instead of reading as "branch missing".
- The generated pull request body names the merge prerequisites: CI on the new WordPress version, and the `REFERENCE_COMMIT` update that `docs/explanations/architecture/performance.md` requires for every `Tested up to` change.

## Manual testing

The workflow only runs on `WordPress/gutenberg`, so exercise the check logic locally:

1. Run `curl -sf https://api.wordpress.org/core/stable-check/1.0/ | jq -r 'with_entries(select(.value=="latest"))|keys[]' | cut -d. -f1,2` and note it prints `7.1` while `readme.txt` says `Tested up to: 7.0`.
2. Run `git ls-remote --exit-code --heads origin wp/7.1` and confirm it exits 0.
3. Run `gh pr list --head update/tested-up-to-7.1 --state all` and confirm it is empty, meaning a scheduled run today would open the 7.1 bump pull request.
4. After merge, trigger the workflow from the Actions tab and check it opens that pull request with both labels and the prerequisites in its body.

## Notes

- The app needs pull request write permission. The token step fails cleanly if the installed app does not grant it.
- A release-time staleness warning for `build-plugin-zip.yml` was drafted and reverted on this branch to keep concerns separate. It can follow as its own pull request.
