### PR TITLE
Media editor: Lock the editing tools while a save is running

### DIFF
--- a/packages/media-editor/src/components/media-editor-canvas/index.tsx
+++ b/packages/media-editor/src/components/media-editor-canvas/index.tsx
@@ -14,6 +14,11 @@ export interface MediaEditorCanvasProps {
 	onGestureStart?: () => void;
 	/** Fires when a canvas cropper gesture ends. */
 	onGestureEnd?: () => void;
+	/**
+	 * Disable crop interaction on the canvas. Set while the edit is saving,
+	 * so a drag cannot change the crop after the request was built.
+	 */
+	disabled?: boolean;
 }
 
 /**
@@ -28,11 +33,13 @@ export interface MediaEditorCanvasProps {
  * @param props.isPlacementActive
  * @param props.onGestureStart
  * @param props.onGestureEnd
+ * @param props.disabled
  */
 export default function MediaEditorCanvas( {
 	isPlacementActive = false,
 	onGestureStart,
 	onGestureEnd,
+	disabled = false,
 }: MediaEditorCanvasProps ) {
 	const { media } = useMediaEditorContext();
 	const controller = useMediaEditor();
@@ -159,6 +166,7 @@ export default function MediaEditorCanvas( {
 					isPlacementActive={ isPlacementActive }
 					onGestureStart={ handleGestureStart }
 					onGestureEnd={ handleGestureEnd }
+					disabled={ disabled }
 				/>
 			</div>
 		</div>

--- a/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
+++ b/packages/media-editor/src/components/media-editor-crop-panel/index.tsx
@@ -16,6 +16,8 @@ export interface MediaEditorCropPanelProps {
 	onAspectRatioChange: ( value: string ) => void;
 	/** Aspect-ratio presets to display in the selector. */
 	aspectRatioOptions: AspectRatioPreset[];
+	/** Disable every control in the panel while the edit is saving. */
+	disabled?: boolean;
 }
 
 /**
@@ -26,11 +28,13 @@ export interface MediaEditorCropPanelProps {
  * @param props.aspectRatioValue
  * @param props.onAspectRatioChange
  * @param props.aspectRatioOptions
+ * @param props.disabled
  */
 export default function MediaEditorCropPanel( {
 	aspectRatioValue,
 	onAspectRatioChange,
 	aspectRatioOptions,
+	disabled = false,
 }: MediaEditorCropPanelProps ) {
 	return (
 		// Tag the whole panel as a crop-control region so the modal's
@@ -44,11 +48,12 @@ export default function MediaEditorCropPanel( {
 			<VisuallyHidden render={ <h2 /> }>
 				{ __( 'Crop options' ) }
 			</VisuallyHidden>
-			<MediaEditorImageControls withLabels />
+			<MediaEditorImageControls withLabels disabled={ disabled } />
 			<SelectControl
 				label={ __( 'Aspect ratio' ) }
 				value={ aspectRatioValue }
 				onChange={ onAspectRatioChange }
+				disabled={ disabled }
 				options={ aspectRatioOptions.map( ( preset ) => ( {
 					label: preset.label,
 					value: preset.value.toString(),

--- a/packages/media-editor/src/components/media-editor-fine-rotation/index.tsx
+++ b/packages/media-editor/src/components/media-editor-fine-rotation/index.tsx
@@ -7,6 +7,11 @@ import RotationRuler from '../rotation-ruler';
 export interface MediaEditorFineRotationProps {
 	/** Signal that a placement-oriented control is being adjusted. */
 	onPlacementControlInteraction?: () => void;
+	/**
+	 * Disable the ruler. Set while the edit is saving; `RotationRuler`
+	 * cancels an in-flight drag when this flips.
+	 */
+	disabled?: boolean;
 }
 
 /**
@@ -17,9 +22,11 @@ export interface MediaEditorFineRotationProps {
  *
  * @param props
  * @param props.onPlacementControlInteraction
+ * @param props.disabled
  */
 export default function MediaEditorFineRotation( {
 	onPlacementControlInteraction,
+	disabled = false,
 }: MediaEditorFineRotationProps ) {
 	const { state, setRotation } = useMediaEditor();
 	// `commitOnKeyUp: false` lets rapid arrow-key adjustments coalesce
@@ -62,6 +69,7 @@ export default function MediaEditorFineRotation( {
 				max={ MAX_ROTATION_OFFSET }
 				value={ fineOffset }
 				onChange={ handleRotationSlider }
+				disabled={ disabled }
 			/>
 		</div>
 	);

--- a/packages/media-editor/src/components/media-editor-image-controls/index.tsx
+++ b/packages/media-editor/src/components/media-editor-image-controls/index.tsx
@@ -191,7 +191,11 @@ export default function MediaEditorImageControls( {
 								role="menuitemradio"
 								isSelected={ isSelected }
 								icon={ isSelected ? check : undefined }
+								disabled={ disabled }
 								onClick={ () => {
+									if ( disabled ) {
+										return;
+									}
 									setAspectRatioValue( value );
 									onClose();
 								} }

--- a/packages/media-editor/src/components/media-editor-image-controls/index.tsx
+++ b/packages/media-editor/src/components/media-editor-image-controls/index.tsx
@@ -54,6 +54,11 @@ export interface MediaEditorImageControlsProps {
 	 * `DEFAULT_ZOOM_FACTOR` (1.2).
 	 */
 	zoomFactor?: number;
+	/**
+	 * Disable every control. Set while the edit is saving, so the crop the
+	 * request was built from cannot change under it.
+	 */
+	disabled?: boolean;
 }
 
 /**
@@ -67,12 +72,14 @@ export interface MediaEditorImageControlsProps {
  * @param props.showAspectRatioControl
  * @param props.aspectRatioPresets
  * @param props.zoomFactor
+ * @param props.disabled
  */
 export default function MediaEditorImageControls( {
 	withLabels = false,
 	showAspectRatioControl = false,
 	aspectRatioPresets,
 	zoomFactor = DEFAULT_ZOOM_FACTOR,
+	disabled = false,
 }: MediaEditorImageControlsProps ) {
 	const { state, setFlip, snapRotate90, setZoom } = useMediaEditor();
 	const { aspectRatioValue, setAspectRatioValue, aspectRatioOptions } =
@@ -92,6 +99,8 @@ export default function MediaEditorImageControls( {
 				icon={ rotateLeft }
 				label={ __( 'Rotate 90° counter-clockwise' ) }
 				showTooltip
+				disabled={ disabled }
+				accessibleWhenDisabled
 				onClick={ () => snapRotate90( -1 ) }
 			/>
 			<Button
@@ -99,6 +108,8 @@ export default function MediaEditorImageControls( {
 				icon={ rotateRight }
 				label={ __( 'Rotate 90° clockwise' ) }
 				showTooltip
+				disabled={ disabled }
+				accessibleWhenDisabled
 				onClick={ () => snapRotate90( 1 ) }
 			/>
 		</>
@@ -112,6 +123,8 @@ export default function MediaEditorImageControls( {
 				label={ __( 'Flip horizontal' ) }
 				showTooltip
 				isPressed={ state.flip.horizontal }
+				disabled={ disabled }
+				accessibleWhenDisabled
 				onClick={ () =>
 					setFlip( {
 						horizontal: ! state.flip.horizontal,
@@ -125,6 +138,8 @@ export default function MediaEditorImageControls( {
 				label={ __( 'Flip vertical' ) }
 				showTooltip
 				isPressed={ state.flip.vertical }
+				disabled={ disabled }
+				accessibleWhenDisabled
 				onClick={ () =>
 					setFlip( {
 						horizontal: state.flip.horizontal,
@@ -142,7 +157,7 @@ export default function MediaEditorImageControls( {
 				icon={ plus }
 				label={ __( 'Zoom in' ) }
 				showTooltip
-				disabled={ state.zoom >= MAX_ZOOM }
+				disabled={ disabled || state.zoom >= MAX_ZOOM }
 				accessibleWhenDisabled
 				onClick={ () => zoomByFactor( zoomFactor ) }
 			/>
@@ -151,7 +166,7 @@ export default function MediaEditorImageControls( {
 				icon={ lineSolid }
 				label={ __( 'Zoom out' ) }
 				showTooltip
-				disabled={ state.zoom <= minZoom }
+				disabled={ disabled || state.zoom <= minZoom }
 				accessibleWhenDisabled
 				onClick={ () => zoomByFactor( 1 / zoomFactor ) }
 			/>
@@ -163,7 +178,7 @@ export default function MediaEditorImageControls( {
 			icon={ aspectRatioIcon }
 			label={ __( 'Aspect ratio' ) }
 			popoverProps={ { placement: 'top' } }
-			toggleProps={ { size: 'compact' } }
+			toggleProps={ { size: 'compact', disabled } }
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup label={ __( 'Aspect ratio' ) }>

--- a/packages/media-editor/src/components/media-editor-image-controls/test/index.jsdom.test.tsx
+++ b/packages/media-editor/src/components/media-editor-image-controls/test/index.jsdom.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from '@wordpress/element';
 import MediaEditorImageControls from '..';
 import type { MediaEditorImageControlsProps } from '..';
 import { MediaEditorStateProvider, useMediaEditor } from '../../../state';
@@ -127,6 +128,41 @@ describe( 'MediaEditorImageControls', () => {
 			expect(
 				screen.getByTestId( 'current-aspect-ratio' )
 			).toHaveTextContent( '1' )
+		);
+	} );
+
+	it( 'ignores an aspect ratio chosen from a menu left open when disabled', async () => {
+		function Harness() {
+			const [ locked, setLocked ] = useState( false );
+			return (
+				<MediaEditorStateProvider>
+					<MediaEditorImageControls
+						showAspectRatioControl
+						disabled={ locked }
+					/>
+					<button onClick={ () => setLocked( true ) }>lock</button>
+					<CurrentState />
+				</MediaEditorStateProvider>
+			);
+		}
+		render( <Harness /> );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Aspect ratio' } )
+		);
+		const before = screen.getByTestId( 'current-aspect-ratio' ).textContent;
+
+		// The popover stays mounted when the toggle becomes disabled, so
+		// the items have to refuse the change themselves.
+		fireEvent.click( screen.getByRole( 'button', { name: 'lock' } ) );
+		fireEvent.click(
+			screen.getByRole( 'menuitemradio', { name: 'Square (1:1)' } )
+		);
+
+		await waitFor( () =>
+			expect(
+				screen.getByTestId( 'current-aspect-ratio' )
+			).toHaveTextContent( before ?? '' )
 		);
 	} );
 

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -610,6 +610,14 @@ function MediaEditorContent( {
 	} );
 
 	const handleChange = ( updates: Partial< Media > ) => {
+		// A save reads the pending edits once and then waits. An edit
+		// arriving after that read misses the request, and a crop save
+		// then clears the edits for this id, so it would be lost rather
+		// than merely late. It would also land on the attachment being
+		// replaced, not the new one the modal moves to.
+		if ( isSaving ) {
+			return;
+		}
 		editEntityRecord( 'postType', 'attachment', id, updates );
 	};
 
@@ -729,7 +737,16 @@ function MediaEditorContent( {
 		<MediaEditorProvider
 			value={ media ?? undefined }
 			onChange={ handleChange }
-			settings={ { fields } }
+			settings={ {
+				// Show the fields as read-only while saving, so the guard
+				// in `handleChange` is not silently swallowing typing.
+				fields: isSaving
+					? fields.map( ( field ) => ( {
+							...field,
+							readOnly: true,
+					  } ) )
+					: fields,
+			} }
 		>
 			<div className="media-editor">
 				{ ! media ? (

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -116,12 +116,15 @@ interface MediaEditorSidebarProps {
 	/** The open panel's id. Always one of `tabs`. */
 	activeTab: string;
 	onSelectTab: ( tab: string ) => void;
+	/** Freeze the open panel while the edit is saving. */
+	disabled?: boolean;
 }
 
 function MediaEditorSidebar( {
 	tabs,
 	activeTab,
 	onSelectTab,
+	disabled = false,
 }: MediaEditorSidebarProps ) {
 	return (
 		<NavigableRegion
@@ -146,7 +149,11 @@ function MediaEditorSidebar( {
 				<div className="media-editor__tablist">
 					<Tabs.List variant="minimal">
 						{ tabs.map( ( tab ) => (
-							<Tabs.Tab key={ tab.id } value={ tab.id }>
+							<Tabs.Tab
+								key={ tab.id }
+								value={ tab.id }
+								disabled={ disabled }
+							>
 								{ tab.title }
 							</Tabs.Tab>
 						) ) }
@@ -320,6 +327,9 @@ function HistoryActions() {
 		redoCrop();
 	};
 	const handleReset = () => {
+		if ( isUndoRedoDisabled ) {
+			return;
+		}
 		beginGesture();
 		reset();
 		onReset();
@@ -334,7 +344,7 @@ function HistoryActions() {
 			<Button
 				size="compact"
 				variant="tertiary"
-				disabled={ ! isDirty }
+				disabled={ isUndoRedoDisabled || ! isDirty }
 				accessibleWhenDisabled
 				onClick={ handleReset }
 			>
@@ -634,7 +644,7 @@ function MediaEditorContent( {
 				! target.closest( `[${ CROP_CONTROL_ATTR }]` );
 			if ( ! isMetadataField ) {
 				event.preventDefault();
-				if ( isCropInteractionActive ) {
+				if ( isCropInteractionActive || isSaving ) {
 					return;
 				}
 				if ( isRedoShortcut ) {
@@ -677,6 +687,7 @@ function MediaEditorContent( {
 			<MediaEditorImageControls
 				showAspectRatioControl
 				aspectRatioPresets={ aspectRatioPresets }
+				disabled={ isSaving }
 			/>
 		) : null;
 
@@ -694,6 +705,7 @@ function MediaEditorContent( {
 								aspectRatioValue={ aspectRatioValue }
 								onAspectRatioChange={ setAspectRatioValue }
 								aspectRatioOptions={ aspectRatioOptions }
+								disabled={ isSaving }
 							/>
 						),
 					},
@@ -709,6 +721,7 @@ function MediaEditorContent( {
 	const ruler = isImage ? (
 		<MediaEditorFineRotation
 			onPlacementControlInteraction={ signalPlacementControlInteraction }
+			disabled={ isSaving }
 		/>
 	) : null;
 
@@ -745,6 +758,7 @@ function MediaEditorContent( {
 											handleCanvasGestureStart
 										}
 										onGestureEnd={ handleCanvasGestureEnd }
+										disabled={ isSaving }
 									/>
 								) : (
 									<MediaPreview />
@@ -773,6 +787,7 @@ function MediaEditorContent( {
 										: DETAILS_PANEL
 								}
 								onSelectTab={ selectPanel }
+								disabled={ isSaving }
 							/>
 						) }
 					</div>
@@ -805,7 +820,10 @@ function MediaEditorContent( {
 		isSaving,
 		hasMedia: !! media,
 		hasChanges,
-		isUndoRedoDisabled: isCropInteractionActive,
+		// Saving freezes the whole edit surface: `save()` reads the
+		// modifiers once and then awaits, so anything changed after that
+		// would be silently dropped when the save resolves.
+		isUndoRedoDisabled: isCropInteractionActive || isSaving,
 		aspectRatioPresets,
 		isWide,
 		activePanel,

--- a/packages/media-editor/src/components/media-editor/index.tsx
+++ b/packages/media-editor/src/components/media-editor/index.tsx
@@ -738,12 +738,14 @@ function MediaEditorContent( {
 			value={ media ?? undefined }
 			onChange={ handleChange }
 			settings={ {
-				// Show the fields as read-only while saving, so the guard
-				// in `handleChange` is not silently swallowing typing.
+				// Disable the fields while saving, so the guard in
+				// `handleChange` is not silently swallowing typing.
+				// `readOnly` would swap the field's layout mid-save;
+				// disabled keeps it in place and greys it out.
 				fields: isSaving
 					? fields.map( ( field ) => ( {
 							...field,
-							readOnly: true,
+							isDisabled: true,
 					  } ) )
 					: fields,
 			} }

--- a/packages/media-editor/src/components/rotation-ruler/index.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/index.tsx
@@ -194,6 +194,7 @@ export default function RotationRuler( props: RotationRulerProps ) {
 		<div
 			className={ clsx( 'rotation-ruler', className ) }
 			role="presentation"
+			data-testid="rotation-ruler"
 			data-disabled={ disabled || undefined }
 			{ ...dragHandlers }
 		>

--- a/packages/media-editor/src/components/rotation-ruler/test/index.jsdom.test.tsx
+++ b/packages/media-editor/src/components/rotation-ruler/test/index.jsdom.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { pxToValueDelta, clampValue, quantize } from '../use-ruler-drag';
 import RotationRuler from '../index';
@@ -82,6 +82,41 @@ describe( 'RotationRuler', () => {
 		await user.keyboard( '{Shift>}{ArrowRight}{/Shift}' );
 		expect( onChange ).toHaveBeenCalledWith( 0.5 );
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'stops an in-flight drag when it becomes disabled', () => {
+		const onChange = jest.fn();
+		const props = {
+			value: 0,
+			onChange,
+			label: 'Fine rotation',
+		};
+		const { rerender } = render( <RotationRuler { ...props } /> );
+		const strip = screen.getByTestId( 'rotation-ruler' );
+
+		if ( ! strip.hasPointerCapture ) {
+			strip.hasPointerCapture = () => false;
+		}
+		if ( ! strip.setPointerCapture ) {
+			strip.setPointerCapture = () => {};
+		}
+		if ( ! strip.releasePointerCapture ) {
+			strip.releasePointerCapture = () => {};
+		}
+
+		fireEvent.pointerDown( strip, {
+			button: 0,
+			clientX: 0,
+			pointerId: 1,
+		} );
+		fireEvent.pointerMove( strip, { clientX: 40, pointerId: 1 } );
+		expect( onChange ).toHaveBeenCalled();
+
+		rerender( <RotationRuler { ...props } disabled /> );
+		onChange.mockClear();
+
+		fireEvent.pointerMove( strip, { clientX: 90, pointerId: 1 } );
+		expect( onChange ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not fire onChange when disabled', async () => {

--- a/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
+++ b/packages/media-editor/src/components/rotation-ruler/use-ruler-drag.ts
@@ -152,6 +152,14 @@ export function useRulerDrag(
 	// listeners or stale pointer capture.
 	useEffect( () => endDrag, [ endDrag ] );
 
+	// Becoming disabled mid-drag ends it, so a rotation cannot keep
+	// changing after a save has read it.
+	useEffect( () => {
+		if ( disabled ) {
+			endDrag();
+		}
+	}, [ disabled, endDrag ] );
+
 	const onPointerDown = useCallback(
 		( event: React.PointerEvent< HTMLElement > ) => {
 			if ( disabled || event.button !== 0 ) {
@@ -184,7 +192,7 @@ export function useRulerDrag(
 	const onPointerMove = useCallback(
 		( event: React.PointerEvent< HTMLElement > ) => {
 			const state = latestRef.current;
-			if ( ! state.dragging ) {
+			if ( disabled || ! state.dragging ) {
 				return;
 			}
 			// Shift toggles fine mode mid-drag. The drag math computes
@@ -215,7 +223,7 @@ export function useRulerDrag(
 				onChange( next );
 			}
 		},
-		[ onChange, min, max, step, pixelsPerStep ]
+		[ disabled, onChange, min, max, step, pixelsPerStep ]
 	);
 
 	return {

--- a/packages/media-editor/src/image-editor/core/interaction-controller.ts
+++ b/packages/media-editor/src/image-editor/core/interaction-controller.ts
@@ -956,5 +956,13 @@ export class InteractionController {
 		this.drag = null;
 		this.touch = null;
 		this.lastTap = null;
+		// Reset the gesture bookkeeping too. The timers above are cancelled
+		// rather than run, so these flags would otherwise stay set: a stale
+		// `wheelGestureActive` suppresses the next wheel gesture's start,
+		// and `setStatus` dedupes against `isDragging` / `isZooming`, so a
+		// stale value swallows the next real change.
+		this.wheelGestureActive = false;
+		this.isDragging = false;
+		this.isZooming = false;
 	}
 }

--- a/packages/media-editor/src/image-editor/react/components/cropper.tsx
+++ b/packages/media-editor/src/image-editor/react/components/cropper.tsx
@@ -92,6 +92,13 @@ export interface CropperProps {
 	freeformCrop?: boolean;
 	/** Focus the crop area when the cropper mounts. */
 	focusOnMount?: boolean;
+	/**
+	 * Ignore all crop interaction: pointer drags, wheel zoom, keyboard
+	 * pan/zoom and the stencil's resize handles. Any gesture already in
+	 * flight is cancelled. Used while the edit is being saved, so the
+	 * modifiers sent to the server cannot change after the request starts.
+	 */
+	disabled?: boolean;
 	/** Callback fired when the image is loaded. */
 	onImageLoaded?: ( size: Size ) => void;
 	/**
@@ -136,6 +143,7 @@ export interface CropperProps {
  * @param root0.aspectRatio       Fixed aspect ratio (width/height).
  * @param root0.freeformCrop      Enable resize handles.
  * @param root0.focusOnMount      Focus the crop area on mount.
+ * @param root0.disabled          Ignore all crop interaction.
  * @param root0.onImageLoaded     Image load callback.
  * @param root0.onStateChange     Every-frame state callback.
  * @param root0.onGestureStart    Gesture boundary start.
@@ -157,6 +165,7 @@ function CropperInner(
 		aspectRatio,
 		freeformCrop = false,
 		focusOnMount = false,
+		disabled = false,
 		onImageLoaded,
 		onStateChange,
 		onGestureStart,
@@ -585,6 +594,7 @@ function CropperInner(
 		maxZoom,
 		onGestureStart,
 		onGestureEnd,
+		disabled,
 	} );
 
 	// Compose focus-visibility tracking into the canvas event handlers.
@@ -632,6 +642,7 @@ function CropperInner(
 		},
 		onPointerDown: ( event: React.PointerEvent< HTMLDivElement > ) => {
 			if (
+				disabled ||
 				isResizingRef.current ||
 				isTouchPinchingRef.current ||
 				( event.pointerType === 'touch' && event.isPrimary === false )
@@ -1067,7 +1078,7 @@ function CropperInner(
 						onEscape={ handleEscape }
 						aspectRatio={ aspectRatio }
 						freeformCrop={ freeformCrop }
-						isResizeDisabled={ isTouchPinching }
+						isResizeDisabled={ isTouchPinching || disabled }
 						stencilTransition={ settleStencilTransition }
 						cropBounds={ cropBounds }
 						minCropSize={ minCropSize }

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -153,9 +153,22 @@ export function RectangleStencil( {
 	}, [] );
 
 	useEffect( () => {
-		if ( isResizeDisabled ) {
-			activePointerResizeRef.current?.cancel();
+		if ( ! isResizeDisabled ) {
+			return;
 		}
+		activePointerResizeRef.current?.cancel();
+		// A keyboard resize settles on a timer rather than a pointer
+		// release, so close it here too: otherwise the pending timer
+		// fires `onResizeEnd` after the resize was already cancelled.
+		if ( keyboardResizeActiveRef.current ) {
+			clearTimeout( keyboardSettleTimerRef.current );
+			keyboardResizeActiveRef.current = false;
+			onResizeEnd?.();
+		}
+		// Keyed on the disabled flag alone; `onResizeEnd` is only read
+		// when it fires, and re-running on a new callback identity would
+		// close the gesture twice.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isResizeDisabled ] );
 
 	// Latest callbacks for the drag listeners. The drag closure in
@@ -596,6 +609,10 @@ export function RectangleStencil( {
 							}
 						} }
 						onKeyDown={ ( event ) => handleKeyDown( pos, event ) }
+						// The handlers already refuse input, but the
+						// button must say so too, or assistive technology
+						// announces a control that does nothing.
+						disabled={ isResizeDisabled }
 						aria-label={ getHandleLabel( pos ) }
 						aria-describedby={ resizeHandleDescriptionId }
 					/>

--- a/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/rectangle-stencil.tsx
@@ -152,25 +152,6 @@ export function RectangleStencil( {
 		};
 	}, [] );
 
-	useEffect( () => {
-		if ( ! isResizeDisabled ) {
-			return;
-		}
-		activePointerResizeRef.current?.cancel();
-		// A keyboard resize settles on a timer rather than a pointer
-		// release, so close it here too: otherwise the pending timer
-		// fires `onResizeEnd` after the resize was already cancelled.
-		if ( keyboardResizeActiveRef.current ) {
-			clearTimeout( keyboardSettleTimerRef.current );
-			keyboardResizeActiveRef.current = false;
-			onResizeEnd?.();
-		}
-		// Keyed on the disabled flag alone; `onResizeEnd` is only read
-		// when it fires, and re-running on a new callback identity would
-		// close the gesture twice.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isResizeDisabled ] );
-
 	// Latest callbacks for the drag listeners. The drag closure in
 	// handlePointerDown reads from this ref so it always sees current
 	// props without having to re-attach listeners mid-drag. Previously,
@@ -425,6 +406,24 @@ export function RectangleStencil( {
 		onResizeEnd,
 		snapCropRect,
 	};
+
+	// Cancel an in-flight resize when the handles are disabled. Reads
+	// `onResizeEnd` from the ref above so a new callback identity does
+	// not re-run this and close the gesture twice.
+	useEffect( () => {
+		if ( ! isResizeDisabled ) {
+			return;
+		}
+		activePointerResizeRef.current?.cancel();
+		// A keyboard resize settles on a timer rather than a pointer
+		// release, so close it here too: otherwise the pending timer
+		// fires `onResizeEnd` after the resize was already cancelled.
+		if ( keyboardResizeActiveRef.current ) {
+			clearTimeout( keyboardSettleTimerRef.current );
+			keyboardResizeActiveRef.current = false;
+			latestHandlersRef.current?.onResizeEnd?.();
+		}
+	}, [ isResizeDisabled ] );
 
 	/**
 	 * Handle keyboard events on a resize handle.

--- a/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.jsdom.test.tsx
+++ b/packages/media-editor/src/image-editor/react/components/stencils/test/rectangle-stencil.jsdom.test.tsx
@@ -181,6 +181,29 @@ describe( 'RectangleStencil', () => {
 			jest.useRealTimers();
 		} );
 
+		it( 'closes a pending keyboard resize when resizing becomes disabled', () => {
+			jest.useFakeTimers();
+			const { props, rerender, onResizeStart, onResizeEnd } =
+				renderStencil();
+			const eHandle = screen.getAllByRole( 'button' )[ 3 ];
+
+			fireEvent.keyDown( eHandle, { key: 'ArrowRight' } );
+			expect( onResizeStart ).toHaveBeenCalledTimes( 1 );
+			expect( onResizeEnd ).not.toHaveBeenCalled();
+
+			rerender( <RectangleStencil { ...props } isResizeDisabled /> );
+
+			// Closed straight away, not left to the settle timer.
+			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
+
+			// And the cancelled timer must not fire a second one.
+			act( () => {
+				jest.advanceTimersByTime( 500 );
+			} );
+			expect( onResizeEnd ).toHaveBeenCalledTimes( 1 );
+			jest.useRealTimers();
+		} );
+
 		it( 'moves the right edge right by KEYBOARD_STEP on ArrowRight (no Shift)', () => {
 			const { onCropChange } = renderStencil();
 			// 'e' handle is the 4th button in clockwise order (nw, n, ne, e).

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.jsdom.test.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.jsdom.test.tsx
@@ -640,6 +640,276 @@ describe( 'Cropper', () => {
 		expect( controller.setPan ).not.toHaveBeenCalled();
 	} );
 
+	it( 'ignores pointer drags on the canvas while disabled', async () => {
+		const controller = createController();
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming
+				showGrid="interactive"
+				freeformCrop
+				disabled
+			/>
+		);
+
+		await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+
+		fireEvent.pointerDown( canvas, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+		fireEvent.pointerMove( canvas, {
+			button: 0,
+			clientX: 150,
+			clientY: 120,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+
+		await act( async () => {
+			await new Promise( ( resolve ) =>
+				requestAnimationFrame( () => resolve( undefined ) )
+			);
+		} );
+		expect( controller.setPan ).not.toHaveBeenCalled();
+	} );
+
+	it( 'pans again after disabled is lifted, as when a save fails', async () => {
+		const controller = createController();
+		const props = {
+			src: 'test.jpg',
+			controller,
+			showDimming: true,
+			showGrid: 'interactive' as const,
+			freeformCrop: true,
+		};
+		const { rerender } = render( <Cropper { ...props } disabled /> );
+
+		await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+
+		rerender( <Cropper { ...props } /> );
+
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+		fireEvent.pointerDown( canvas, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+		fireEvent.pointerMove( canvas, {
+			button: 0,
+			clientX: 150,
+			clientY: 120,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+
+		await waitFor( () => expect( controller.setPan ).toHaveBeenCalled() );
+	} );
+
+	it( 'ends the gesture when a drag is cancelled by disabling', async () => {
+		const controller = createController();
+		const onGestureStart = jest.fn();
+		const onGestureEnd = jest.fn();
+		const props = {
+			src: 'test.jpg',
+			controller,
+			showDimming: true,
+			showGrid: 'interactive' as const,
+			freeformCrop: true,
+			onGestureStart,
+			onGestureEnd,
+		};
+		const { rerender } = render( <Cropper { ...props } /> );
+
+		await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+
+		fireEvent.pointerDown( canvas, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+		fireEvent.pointerMove( canvas, {
+			button: 0,
+			clientX: 150,
+			clientY: 120,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+		await waitFor( () => expect( onGestureStart ).toHaveBeenCalled() );
+
+		rerender( <Cropper { ...props } disabled /> );
+
+		// Without this the caller is left believing a gesture is still
+		// running, which keeps undo/redo disabled after a failed save.
+		expect( onGestureEnd ).toHaveBeenCalled();
+	} );
+
+	it( 'does not signal a gesture end when disabling with no gesture running', async () => {
+		const onGestureEnd = jest.fn();
+		const props = {
+			src: 'test.jpg',
+			controller: createController(),
+			showDimming: true,
+			showGrid: 'interactive' as const,
+			freeformCrop: true,
+			onGestureEnd,
+		};
+		const { rerender } = render( <Cropper { ...props } /> );
+
+		await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+
+		rerender( <Cropper { ...props } disabled /> );
+
+		expect( onGestureEnd ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores wheel zoom while disabled', async () => {
+		const controller = createController();
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming
+				showGrid="interactive"
+				freeformCrop
+				disabled
+			/>
+		);
+
+		await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+
+		fireEvent.wheel( canvas, { deltaY: -120, clientX: 100, clientY: 100 } );
+
+		await act( async () => {
+			await new Promise( ( resolve ) =>
+				requestAnimationFrame( () => resolve( undefined ) )
+			);
+		} );
+		expect( controller.setZoomAtPoint ).not.toHaveBeenCalled();
+		expect( controller.setZoom ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores keyboard pan while disabled', async () => {
+		const controller = createController();
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming
+				showGrid="interactive"
+				freeformCrop
+				disabled
+			/>
+		);
+
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+		fireEvent.keyDown( canvas, { key: 'ArrowRight' } );
+
+		expect( controller.setPan ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stops an in-flight canvas drag when disabled flips mid-gesture', async () => {
+		const controller = createController();
+		const props = {
+			src: 'test.jpg',
+			controller,
+			showDimming: true,
+			showGrid: 'interactive' as const,
+			freeformCrop: true,
+		};
+		const { rerender } = render( <Cropper { ...props } /> );
+
+		await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+
+		fireEvent.pointerDown( canvas, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+
+		rerender( <Cropper { ...props } disabled /> );
+		( controller.setPan as jest.Mock ).mockClear();
+
+		fireEvent.pointerMove( canvas, {
+			button: 0,
+			clientX: 180,
+			clientY: 140,
+			pointerId: 1,
+			isPrimary: true,
+		} );
+
+		await act( async () => {
+			await new Promise( ( resolve ) =>
+				requestAnimationFrame( () => resolve( undefined ) )
+			);
+		} );
+		expect( controller.setPan ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not resize the crop from a handle drag while disabled', async () => {
+		const controller = createController();
+		render(
+			<Cropper
+				src="test.jpg"
+				controller={ controller }
+				showDimming
+				showGrid="interactive"
+				freeformCrop
+				disabled
+			/>
+		);
+
+		const handle = await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+
+		fireEvent.pointerDown( handle, {
+			button: 0,
+			clientX: 100,
+			clientY: 100,
+			pointerId: 1,
+		} );
+		fireEvent.pointerMove( handle, {
+			button: 0,
+			clientX: 160,
+			clientY: 150,
+			pointerId: 1,
+		} );
+
+		await act( async () => {
+			await new Promise( ( resolve ) =>
+				requestAnimationFrame( () => resolve( undefined ) )
+			);
+		} );
+		expect( controller.setCropRect ).not.toHaveBeenCalled();
+	} );
+
 	it( 'cancels handle resize when a touch gesture becomes a pinch', async () => {
 		const originalRAF = globalThis.requestAnimationFrame;
 		const originalCAF = globalThis.cancelAnimationFrame;

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.jsdom.test.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.jsdom.test.tsx
@@ -781,6 +781,38 @@ describe( 'Cropper', () => {
 		expect( onGestureEnd ).not.toHaveBeenCalled();
 	} );
 
+	it( 'signals a fresh gesture on wheel zoom after a save interrupted one', async () => {
+		const controller = createController();
+		const onGestureStart = jest.fn();
+		const props = {
+			src: 'test.jpg',
+			controller,
+			showDimming: true,
+			showGrid: 'interactive' as const,
+			freeformCrop: true,
+			onGestureStart,
+		};
+		const { rerender } = render( <Cropper { ...props } /> );
+
+		await screen.findByRole( 'button', {
+			name: 'Resize from top-left corner',
+		} );
+		const canvas = screen.getByRole( 'group', { name: 'Crop area' } );
+
+		// A wheel zoom opens a debounced gesture.
+		fireEvent.wheel( canvas, { deltaY: -120, clientX: 100, clientY: 100 } );
+		await waitFor( () => expect( onGestureStart ).toHaveBeenCalled() );
+
+		// Saving cancels it, then the save fails and tools come back.
+		rerender( <Cropper { ...props } disabled /> );
+		rerender( <Cropper { ...props } /> );
+		onGestureStart.mockClear();
+
+		// The next wheel zoom must open a gesture of its own.
+		fireEvent.wheel( canvas, { deltaY: -120, clientX: 100, clientY: 100 } );
+		await waitFor( () => expect( onGestureStart ).toHaveBeenCalled() );
+	} );
+
 	it( 'ignores wheel zoom while disabled', async () => {
 		const controller = createController();
 		render(

--- a/packages/media-editor/src/image-editor/react/components/test/cropper.jsdom.test.tsx
+++ b/packages/media-editor/src/image-editor/react/components/test/cropper.jsdom.test.tsx
@@ -757,7 +757,9 @@ describe( 'Cropper', () => {
 
 		// Without this the caller is left believing a gesture is still
 		// running, which keeps undo/redo disabled after a failed save.
-		expect( onGestureEnd ).toHaveBeenCalled();
+		// Exactly once: a second call would close a gesture that is no
+		// longer open.
+		expect( onGestureEnd ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'does not signal a gesture end when disabling with no gesture running', async () => {

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -46,6 +46,11 @@ export interface UseInteractionOptions {
 	onGestureStart?: () => void;
 	/** Fires when a continuous gesture ends (pointer release). */
 	onGestureEnd?: () => void;
+	/**
+	 * Ignore all interaction. Any gesture already in flight is torn down,
+	 * so a drag started before this flipped cannot keep moving the image.
+	 */
+	disabled?: boolean;
 }
 
 /** How long keyboard placement stays active after the latest handled key. */
@@ -200,12 +205,51 @@ export function useInteraction(
 		};
 	}, [ startPlacementGesture, stopPlacementGesture ] );
 
+	// Cancel any gesture already in flight when interaction is switched off,
+	// so a drag that started before the flip cannot keep moving the image.
+	// `destroy()` releases the pointer/touch listeners and the pending rAF;
+	// the controller keeps working for later gestures once re-enabled.
+	//
+	// It does not signal the end of the gesture it just cut short, so that
+	// is done here: a caller told a gesture began is otherwise left waiting
+	// for an end that never comes, which keeps undo/redo disabled and leaves
+	// the cropper's history batch open after a failed save.
+	const isDisabled = options?.disabled ?? false;
+	useEffect( () => {
+		if ( ! isDisabled ) {
+			return;
+		}
+		controllerRef.current?.destroy();
+		setIsDragging( false );
+		setIsZooming( false );
+		setIsKeyboardPanning( false );
+		const wasGestureOpen =
+			isGestureActive || isKeyboardGestureActiveRef.current;
+		if ( isKeyboardGestureActiveRef.current ) {
+			isKeyboardGestureActiveRef.current = false;
+			clearTimeout( keyboardInteractionTimerRef.current );
+		}
+		stopPlacementGesture();
+		if ( wasGestureOpen ) {
+			optionsRef.current?.onGestureEnd?.();
+		}
+		// `isGestureActive` is read to decide whether a gesture was open;
+		// it must not re-run this effect, which keys off `isDisabled`.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isDisabled, stopPlacementGesture ] );
+
 	const onPointerDown = useCallback( ( e: React.PointerEvent ) => {
+		if ( optionsRef.current?.disabled ) {
+			return;
+		}
 		const el = e.currentTarget as HTMLElement;
 		controllerRef.current?.handlePointerDown( e.nativeEvent, el );
 	}, [] );
 
 	const onTouchStart = useCallback( ( e: React.TouchEvent ) => {
+		if ( optionsRef.current?.disabled ) {
+			return;
+		}
 		const el = e.currentTarget as HTMLElement;
 		const rect = el.getBoundingClientRect();
 		controllerRef.current?.handleTouchStart(
@@ -217,6 +261,9 @@ export function useInteraction(
 
 	const onKeyDown = useCallback(
 		( e: React.KeyboardEvent ) => {
+			if ( optionsRef.current?.disabled ) {
+				return;
+			}
 			if ( isHandledKeyboardPan( e.nativeEvent ) ) {
 				setIsKeyboardPanning( true );
 				signalKeyboardGesture();
@@ -229,6 +276,9 @@ export function useInteraction(
 	);
 
 	const onWheelNative = useCallback( ( e: WheelEvent ) => {
+		if ( optionsRef.current?.disabled ) {
+			return;
+		}
 		controllerRef.current?.handleWheel( e );
 	}, [] );
 

--- a/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
+++ b/packages/media-editor/src/image-editor/react/hooks/use-interaction.ts
@@ -233,10 +233,7 @@ export function useInteraction(
 		if ( wasGestureOpen ) {
 			optionsRef.current?.onGestureEnd?.();
 		}
-		// `isGestureActive` is read to decide whether a gesture was open;
-		// it must not re-run this effect, which keys off `isDisabled`.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isDisabled, stopPlacementGesture ] );
+	}, [ isDisabled, isGestureActive, stopPlacementGesture ] );
 
 	const onPointerDown = useCallback( ( e: React.PointerEvent ) => {
 		if ( optionsRef.current?.disabled ) {


### PR DESCRIPTION
## What?

Stop the media editor's crop tools responding while a save is running.

https://github.com/user-attachments/assets/1f799510-14f4-4605-9ea9-7f7f7628e2b9

## Why?

Clicking Save keeps the modal open until the request finishes. Every crop tool stayed live during that window, so the image could still be dragged, rotated, flipped, zoomed, reset or undone.

The save reads the crop once, at the start, then waits. Anything changed after that is thrown away when the save finishes and the modal moves to the new attachment. The user watches their change happen and it does not ship.

This affects saving through the server too. It is easier to hit when the edit is processed in the browser, because that path takes longer.

## How?

Everything freezes off the existing `isSaving` flag: the canvas, the fine rotation ruler, the rotate, flip and zoom buttons, the aspect ratio controls, undo, redo, reset, and the sidebar tabs. That flag already resets when the request settles, so the tools come back on their own if the save fails and the modal stays open.

`Cropper` gains a `disabled` prop. It had no way to refuse interaction, so a drag on the canvas was the one thing a modal-level guard could not reach. It ignores pointer, touch, keyboard and wheel input, and cancels a gesture already in flight.

Cancelling also has to report the gesture as ended. Without that, a drag interrupted by a save leaves the editor believing a gesture is still running, which keeps undo and redo disabled and leaves the cropper's history batch open after a failed save.

New props default to `false`, so existing callers are unaffected.

## Testing Instructions

1. Add an Image block, upload an image, and click "Edit image" in the block toolbar.
2. Drag the crop area, then click Save. While the modal is still open and saving:
    - Try dragging the image on the canvas. It should not move.
    - Try the rotate, flip and zoom buttons, and the aspect ratio control. All disabled.
    - Try the fine rotation ruler. It should not move.
    - Try Undo, Redo and Reset. All disabled.
    - Try `Cmd+Z` / `Ctrl+Z`. Nothing should change.
    - Try switching to the Details tab. It should not switch.
3. Confirm the save completes and the block shows the crop you made.
4. Start a drag on the canvas and click Save without releasing the mouse. The drag should stop where it is, and the image should not keep moving.
5. Do the same with the fine rotation ruler: start dragging it, click Save mid-drag, and confirm the rotation stops where it was.
6. Open the aspect ratio menu, click Save while the menu is still open, then click one of the options. The aspect ratio should not change.
7. Make the save fail (go offline, or block the request in the network panel). When the error appears and the modal stays open, confirm every tool above works again, including undo and redo. Zoom the canvas with the mouse wheel and confirm it still works.
8. Open the Details tab, drag the crop area and click Save, then immediately type in the alt text or caption field. The fields should be disabled, and once the save finishes the new attachment should keep the metadata you had before saving, with nothing lost.
9. With a screen reader, tab to the crop handles while a save is running and confirm they are announced as disabled.
10. Repeat step 2 with the client-side media experiment enabled, where the save takes longer and the window is easier to catch.



## Use of AI

Claude delivered the goods under my instruction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Media editing controls are now disabled while changes are being saved, preventing accidental crop, rotate, zoom, resize, gesture, undo, redo, and keyboard history actions.
  * Metadata fields become read-only during saving, and incoming edits are ignored.
  * Active gestures and drags are safely cancelled when controls become disabled and restart correctly when re-enabled.
  * Prevented changes from menus and controls that remain open while editing is disabled.
* **Tests**
  * Added coverage for disabled-state behavior across cropping, resizing, rotation, gestures, and image controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
