### PR TITLE
feat: Introduce 'Add Media' in the block controls for media-text block

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.jsx
+++ b/packages/block-editor/src/components/media-replace-flow/index.jsx
@@ -96,13 +96,18 @@ const MediaReplaceFlow = ( {
 	};
 
 	const selectMedia = ( media, closeMenu ) => {
+		const hasMedia = !! ( mediaURL || mediaId || mediaIds?.length );
 		if ( useFeaturedImage && onToggleFeaturedImage ) {
 			onToggleFeaturedImage();
 		}
 		closeMenu();
 		// Calling `onSelect` after the state update since it might unmount the component.
 		onSelect( media );
-		speak( __( 'The media file has been replaced' ) );
+		speak(
+			hasMedia
+				? __( 'The media file has been replaced' )
+				: __( 'The media file has been added' )
+		);
 		removeNotice( errorNoticeID );
 	};
 

--- a/packages/block-library/src/media-text/media-container.jsx
+++ b/packages/block-library/src/media-text/media-container.jsx
@@ -53,6 +53,7 @@ function ToolbarEditButton( {
 				onSelect={ onSelectMedia }
 				onToggleFeaturedImage={ toggleUseFeaturedImage }
 				useFeaturedImage={ useFeaturedImage }
+				name={ mediaUrl ? __( 'Replace' ) : __( 'Add media' ) }
 				onReset={ () => onSelectMedia( undefined ) }
 			/>
 		</BlockControls>
@@ -210,7 +211,18 @@ function MediaContainer( props, ref ) {
 		);
 	}
 
-	return <PlaceholderContainer { ...props } />;
+	return (
+		<>
+			<ToolbarEditButton
+				onSelectMedia={ onSelectMedia }
+				mediaId={ mediaId }
+				mediaUrl={ mediaUrl }
+				toggleUseFeaturedImage={ toggleUseFeaturedImage }
+				useFeaturedImage={ useFeaturedImage }
+			/>
+			<PlaceholderContainer { ...props } />
+		</>
+	);
 }
 
 export default forwardRef( MediaContainer );

--- a/packages/block-library/src/media-text/media-container.jsx
+++ b/packages/block-library/src/media-text/media-container.jsx
@@ -123,6 +123,20 @@ function MediaContainer( props, ref ) {
 
 	const { toggleSelection } = useDispatch( blockEditorStore );
 
+	const toolbarEditButton = (
+		<ToolbarEditButton
+			onSelectMedia={ onSelectMedia }
+			mediaUrl={
+				useFeaturedImage && featuredImageURL
+					? featuredImageURL
+					: mediaUrl
+			}
+			mediaId={ mediaId }
+			toggleUseFeaturedImage={ toggleUseFeaturedImage }
+			useFeaturedImage={ useFeaturedImage }
+		/>
+	);
+
 	if ( mediaUrl || featuredImageURL || useFeaturedImage ) {
 		const onResizeStart = () => {
 			toggleSelection( false );
@@ -186,17 +200,7 @@ function MediaContainer( props, ref ) {
 				isStackedOnMobile={ isStackedOnMobile }
 				ref={ ref }
 			>
-				<ToolbarEditButton
-					onSelectMedia={ onSelectMedia }
-					mediaUrl={
-						useFeaturedImage && featuredImageURL
-							? featuredImageURL
-							: mediaUrl
-					}
-					mediaId={ mediaId }
-					toggleUseFeaturedImage={ toggleUseFeaturedImage }
-					useFeaturedImage={ useFeaturedImage }
-				/>
+				{ toolbarEditButton }
 				{ ( mediaTypeRenderers[ mediaType ] || noop )() }
 				{ isTemporaryMedia && <Spinner /> }
 				{ ! useFeaturedImage && <PlaceholderContainer { ...props } /> }
@@ -213,13 +217,7 @@ function MediaContainer( props, ref ) {
 
 	return (
 		<>
-			<ToolbarEditButton
-				onSelectMedia={ onSelectMedia }
-				mediaId={ mediaId }
-				mediaUrl={ mediaUrl }
-				toggleUseFeaturedImage={ toggleUseFeaturedImage }
-				useFeaturedImage={ useFeaturedImage }
-			/>
+			{ toolbarEditButton }
 			<PlaceholderContainer { ...props } />
 		</>
 	);


### PR DESCRIPTION
## What?
See [Comment](https://github.com/WordPress/gutenberg/issues/66563#:~:text=Missing%20%22Media%22%20section%2C%20and%20block%20toolbar%20option)

Shows the media replace flow in the Media & Text block toolbar when the block has no media yet.

## Why?
The toolbar option only renders once media is set, so "Replace" appears but "Add media" never does. **Image, Cover and Site Logo offer it in both states**, making Media & Text the only media block missing it. Per the issue, the toolbar matters most when the block is scaled down in a pattern and the placeholder has no room for its buttons.

## How?
Renders the existing toolbar component in the empty state alongside the placeholder, labelled "Add media" when blank and "Replace" once media is set, matching Cover.

## Testing Instructions
1. Insert a **Media & Text** block and select it without adding media.
2. The toolbar shows **"Add media"** and opens the same media flow as the placeholder.
3. Add an image or video — the toolbar reads **"Replace"**, as before.

### Testing Instructions for Keyboard
Insert an empty Media & Text block, press `Escape` to focus the block toolbar, tab to "Add media" and confirm it opens the media flow.

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="629" height="313" alt="image" src="https://github.com/user-attachments/assets/7252bc66-a324-4873-a19c-71229be1152d" /> | <img width="625" height="252" alt="image" src="https://github.com/user-attachments/assets/01586325-ae28-4886-9439-0a7c40ac94e6" /> |


See some other media related blocks and their behaviour 

|Image|Cover|
|-|-|
| <img width="629" height="313" alt="image" src="https://github.com/user-attachments/assets/c8016499-a58f-4b1a-8548-2eceea4ce81b" /> | <img width="625" height="252" alt="image" src="https://github.com/user-attachments/assets/cb24b75f-63e8-4cd9-9000-82cc1a4ae134" /> |



## Use of AI Tools
Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The media toolbar remains available when no media is selected, allowing users to add media directly from the placeholder state.
  - Media editing controls now consistently reference the selected or featured image across media states.
  - Accessibility announcements now distinguish between adding new media and replacing existing media, providing clearer feedback during media selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->