### PR TITLE
Privacy policy page badge: make it visible in Site Editor > Pages and Editor Inspector

### DIFF
--- a/backport-changelog/7.2/13399.md
+++ b/backport-changelog/7.2/13399.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13399
+
+* https://github.com/WordPress/gutenberg/pull/82422

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -45,8 +45,8 @@ add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_templa
  * lets the editor label the privacy policy page, alongside the homepage and
  * the posts page.
  *
- * Runs after `register_initial_settings`, and skips registration when
- * WordPress Core already exposes the option.
+ * Runs on `rest_api_init` after `register_initial_settings`, and skips
+ * registration when WordPress Core already exposes the option.
  */
 function gutenberg_register_privacy_policy_page_setting() {
 	$registered = get_registered_settings();
@@ -70,4 +70,25 @@ function gutenberg_register_privacy_policy_page_setting() {
 		)
 	);
 }
-add_action( 'init', 'gutenberg_register_privacy_policy_page_setting', 11 );
+add_action( 'rest_api_init', 'gutenberg_register_privacy_policy_page_setting', 11 );
+
+/**
+ * Prevents users without the `manage_privacy_options` capability from
+ * changing the privacy policy page through the REST API.
+ *
+ * The settings endpoint only checks `manage_options`. On multisite the
+ * `manage_privacy_options` capability maps to `manage_network`, so a site
+ * administrator can read the setting but must not change it, matching the
+ * Settings > Privacy screen.
+ *
+ * @param bool   $updated Whether the setting update has already been handled.
+ * @param string $name    Setting name (as shown in REST API responses).
+ * @return bool Whether to short-circuit the update.
+ */
+function gutenberg_restrict_privacy_policy_page_setting_update( $updated, $name ) {
+	if ( 'page_for_privacy_policy' === $name && ! current_user_can( 'manage_privacy_options' ) ) {
+		return true;
+	}
+	return $updated;
+}
+add_filter( 'rest_pre_update_setting', 'gutenberg_restrict_privacy_policy_page_setting_update', 10, 2 );

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -35,3 +35,39 @@ function gutenberg_modify_template_post_type_args_7_2( $args ) {
 }
 add_filter( 'register_wp_template_post_type_args', 'gutenberg_modify_template_post_type_args_7_2' );
 add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_template_post_type_args_7_2' );
+
+/**
+ * Exposes the privacy policy page setting in the REST API.
+ *
+ * WordPress stores the page assigned in Settings > Privacy in the
+ * `wp_page_for_privacy_policy` option, but does not register it with
+ * `show_in_rest`, so the settings endpoint cannot report it. Registering it
+ * lets the editor label the privacy policy page, alongside the homepage and
+ * the posts page.
+ *
+ * Runs after `register_initial_settings`, and skips registration when
+ * WordPress Core already exposes the option.
+ */
+function gutenberg_register_privacy_policy_page_setting() {
+	$registered = get_registered_settings();
+	if (
+		isset( $registered['wp_page_for_privacy_policy'] ) &&
+		! empty( $registered['wp_page_for_privacy_policy']['show_in_rest'] )
+	) {
+		return;
+	}
+
+	register_setting(
+		'reading',
+		'wp_page_for_privacy_policy',
+		array(
+			'show_in_rest' => array(
+				'name' => 'page_for_privacy_policy',
+			),
+			'type'         => 'integer',
+			'description'  => __( 'The ID of the page that should be displayed as the privacy policy page', 'gutenberg' ),
+			'default'      => 0,
+		)
+	);
+}
+add_action( 'init', 'gutenberg_register_privacy_policy_page_setting', 11 );

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Enhancements
 
--   Add `page_for_privacy_policy` to the `Settings` entity type, exposed by the Gutenberg plugin from the `wp_page_for_privacy_policy` option ([#67517](https://github.com/WordPress/gutenberg/issues/67517)).
+-   Add `page_for_privacy_policy` to the `Settings` entity type, exposed by the Gutenberg plugin from the `wp_page_for_privacy_policy` option ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
 
 ### Bug Fixes
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -9,6 +9,10 @@
 -   The `getGlobalStyles` and `saveGlobalStyles` shortcuts now use `GlobalStyles` instead of the unrelated `GlobalStylesRevision` record. `saveGlobalStyles` requires the record ID and accepts a plain string title, matching the REST API update route and schema. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   `RenderedText` omits `raw` outside the edit context instead of typing it as `never`, so a record requested with `context: 'view'` or `context: 'embed'` no longer exposes `title.raw` or `content.raw`. Read `rendered` in those contexts, or request the record with `context: 'edit'`. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 
+### Enhancements
+
+-   Add `page_for_privacy_policy` to the `Settings` entity type, exposed by the Gutenberg plugin from the `wp_page_for_privacy_policy` option ([#67517](https://github.com/WordPress/gutenberg/issues/67517)).
+
 ### Bug Fixes
 
 -   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).

--- a/packages/core-data/src/entity-types/settings.ts
+++ b/packages/core-data/src/entity-types/settings.ts
@@ -23,6 +23,10 @@ declare module './base-entity-records' {
 			 */
 			page_for_posts: number;
 			/**
+			 * The ID of the page that should be displayed as the privacy policy page
+			 */
+			page_for_privacy_policy: number;
+			/**
 			 * Site title.
 			 */
 			title: string;

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Show a "Privacy Policy Page" badge in the document bar and the post card panel for the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#67517](https://github.com/WordPress/gutenberg/issues/67517)).
+-   Show a "Privacy Policy Page" badge in the document bar and the post card panel for the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
 
 ### Breaking Changes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Show a "Privacy Policy Page" badge in the document bar and the post card panel for the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#67517](https://github.com/WordPress/gutenberg/issues/67517)).
+
 ### Breaking Changes
 
 -   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem`. A link item honors only `target="_blank"` ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).

--- a/packages/editor/src/utils/pageTypeBadge.js
+++ b/packages/editor/src/utils/pageTypeBadge.js
@@ -8,27 +8,33 @@ import { store as coreStore } from '@wordpress/core-data';
  * @param {number|string} postId postId of the current post being edited.
  */
 export default function usePageTypeBadge( postId ) {
-	const { isFrontPage, isPostsPage } = useSelect( ( select ) => {
-		const { canUser, getEditedEntityRecord } = select( coreStore );
-		const siteSettings = canUser( 'read', {
-			kind: 'root',
-			name: 'site',
-		} )
-			? getEditedEntityRecord( 'root', 'site' )
-			: undefined;
+	const { isFrontPage, isPostsPage, isPrivacyPolicyPage } = useSelect(
+		( select ) => {
+			const { canUser, getEditedEntityRecord } = select( coreStore );
+			const siteSettings = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} )
+				? getEditedEntityRecord( 'root', 'site' )
+				: undefined;
 
-		const _postId = parseInt( postId, 10 );
+			const _postId = parseInt( postId, 10 );
 
-		return {
-			isFrontPage: siteSettings?.page_on_front === _postId,
-			isPostsPage: siteSettings?.page_for_posts === _postId,
-		};
-	} );
+			return {
+				isFrontPage: siteSettings?.page_on_front === _postId,
+				isPostsPage: siteSettings?.page_for_posts === _postId,
+				isPrivacyPolicyPage:
+					siteSettings?.page_for_privacy_policy === _postId,
+			};
+		}
+	);
 
 	if ( isFrontPage ) {
 		return __( 'Homepage' );
 	} else if ( isPostsPage ) {
 		return __( 'Posts Page' );
+	} else if ( isPrivacyPolicyPage ) {
+		return __( 'Privacy Policy Page' );
 	}
 
 	return false;

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Show a "Privacy Policy Page" badge next to the title of the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#67517](https://github.com/WordPress/gutenberg/issues/67517)).
+-   Show a "Privacy Policy Page" badge next to the title of the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
 -   Append an ellipsis (`…`) to the labels of the actions that open a dialog requiring further input or confirmation (`Delete…`, `Trash…`, `Permanently delete…`, `Rename…`, `Duplicate…`, `Reset…`, `Order…`), following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 
 ### Bug Fixes

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Show a "Privacy Policy Page" badge next to the title of the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#67517](https://github.com/WordPress/gutenberg/issues/67517)).
 -   Append an ellipsis (`…`) to the labels of the actions that open a dialog requiring further input or confirmation (`Delete…`, `Trash…`, `Permanently delete…`, `Rename…`, `Duplicate…`, `Reset…`, `Order…`), following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 
 ### Bug Fixes

--- a/packages/fields/src/fields/page-title/view.tsx
+++ b/packages/fields/src/fields/page-title/view.tsx
@@ -9,26 +9,32 @@ import { unlock } from '../../lock-unlock';
 const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
 export default function PageTitleView( { item }: { item: CommonPost } ) {
-	const { frontPageId, postsPageId } = useSelect( ( select ) => {
-		const { getEntityRecord } = select( coreStore );
-		const siteSettings = getEntityRecord(
-			'root',
-			'site'
-		) as Partial< Settings >;
-		return {
-			frontPageId: siteSettings?.page_on_front,
-			postsPageId: siteSettings?.page_for_posts,
-		};
-	}, [] );
+	const { frontPageId, postsPageId, privacyPolicyPageId } = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
+			const siteSettings = getEntityRecord(
+				'root',
+				'site'
+			) as Partial< Settings >;
+			return {
+				frontPageId: siteSettings?.page_on_front,
+				postsPageId: siteSettings?.page_for_posts,
+				privacyPolicyPageId: siteSettings?.page_for_privacy_policy,
+			};
+		},
+		[]
+	);
+	let badge;
+	if ( item.id === frontPageId ) {
+		badge = __( 'Homepage' );
+	} else if ( item.id === postsPageId ) {
+		badge = __( 'Posts Page' );
+	} else if ( item.id === privacyPolicyPageId ) {
+		badge = __( 'Privacy Policy Page' );
+	}
 	return (
 		<BaseTitleView item={ item } className="fields-field__page-title">
-			{ [ frontPageId, postsPageId ].includes( item.id as number ) && (
-				<WCBadge>
-					{ item.id === frontPageId
-						? __( 'Homepage' )
-						: __( 'Posts Page' ) }
-				</WCBadge>
-			) }
+			{ badge && <WCBadge>{ badge }</WCBadge> }
 		</BaseTitleView>
 	);
 }

--- a/phpunit/privacy-policy-page-setting-test.php
+++ b/phpunit/privacy-policy-page-setting-test.php
@@ -7,6 +7,7 @@
 
 /**
  * @covers ::gutenberg_register_privacy_policy_page_setting
+ * @covers ::gutenberg_restrict_privacy_policy_page_setting_update
  */
 class Gutenberg_Privacy_Policy_Page_Setting_Test extends WP_Test_REST_TestCase {
 	protected static $admin_id;
@@ -24,10 +25,28 @@ class Gutenberg_Privacy_Policy_Page_Setting_Test extends WP_Test_REST_TestCase {
 
 	public function tear_down() {
 		delete_option( 'wp_page_for_privacy_policy' );
+		remove_filter( 'map_meta_cap', array( $this, 'deny_manage_privacy_options' ), 10 );
 		parent::tear_down();
 	}
 
+	/**
+	 * Maps `manage_privacy_options` to `do_not_allow`, as happens for a site
+	 * administrator on multisite.
+	 *
+	 * @param string[] $caps Primitive capabilities required.
+	 * @param string   $cap  Capability being checked.
+	 * @return string[] Primitive capabilities required.
+	 */
+	public function deny_manage_privacy_options( $caps, $cap ) {
+		if ( 'manage_privacy_options' === $cap ) {
+			return array( 'do_not_allow' );
+		}
+		return $caps;
+	}
+
 	public function test_setting_is_registered_for_rest() {
+		// Settings are registered on `rest_api_init`, which booting the server fires.
+		rest_get_server();
 		$registered = get_registered_settings();
 
 		$this->assertArrayHasKey( 'wp_page_for_privacy_policy', $registered );
@@ -61,6 +80,23 @@ class Gutenberg_Privacy_Policy_Page_Setting_Test extends WP_Test_REST_TestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( $page_id, (int) get_option( 'wp_page_for_privacy_policy' ) );
+	}
+
+	public function test_update_settings_ignores_privacy_policy_page_without_capability() {
+		wp_set_current_user( self::$admin_id );
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'wp_page_for_privacy_policy', $page_id );
+		$other_page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		add_filter( 'map_meta_cap', array( $this, 'deny_manage_privacy_options' ), 10, 2 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( 'page_for_privacy_policy', $other_page_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $page_id, $data['page_for_privacy_policy'], 'The response should still report the previous page.' );
+		$this->assertSame( $page_id, (int) get_option( 'wp_page_for_privacy_policy' ), 'The option should not change.' );
 	}
 
 	public function test_settings_require_manage_options() {

--- a/phpunit/privacy-policy-page-setting-test.php
+++ b/phpunit/privacy-policy-page-setting-test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Tests for the `page_for_privacy_policy` REST settings field.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * @covers ::gutenberg_register_privacy_policy_page_setting
+ */
+class Gutenberg_Privacy_Policy_Page_Setting_Test extends WP_Test_REST_TestCase {
+	protected static $admin_id;
+	protected static $subscriber_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	public function tear_down() {
+		delete_option( 'wp_page_for_privacy_policy' );
+		parent::tear_down();
+	}
+
+	public function test_setting_is_registered_for_rest() {
+		$registered = get_registered_settings();
+
+		$this->assertArrayHasKey( 'wp_page_for_privacy_policy', $registered );
+		$this->assertSame(
+			'page_for_privacy_policy',
+			$registered['wp_page_for_privacy_policy']['show_in_rest']['name']
+		);
+	}
+
+	public function test_get_settings_includes_privacy_policy_page() {
+		wp_set_current_user( self::$admin_id );
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'wp_page_for_privacy_policy', $page_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'page_for_privacy_policy', $data );
+		$this->assertSame( $page_id, $data['page_for_privacy_policy'] );
+	}
+
+	public function test_update_settings_changes_privacy_policy_page() {
+		wp_set_current_user( self::$admin_id );
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_param( 'page_for_privacy_policy', $page_id );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $page_id, (int) get_option( 'wp_page_for_privacy_policy' ) );
+	}
+
+	public function test_settings_require_manage_options() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+}

--- a/phpunit/privacy-policy-page-setting-test.php
+++ b/phpunit/privacy-policy-page-setting-test.php
@@ -11,16 +11,13 @@
  */
 class Gutenberg_Privacy_Policy_Page_Setting_Test extends WP_Test_REST_TestCase {
 	protected static $admin_id;
-	protected static $subscriber_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
-		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 	}
 
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$admin_id );
-		self::delete_user( self::$subscriber_id );
 	}
 
 	public function tear_down() {
@@ -97,14 +94,5 @@ class Gutenberg_Privacy_Policy_Page_Setting_Test extends WP_Test_REST_TestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( $page_id, $data['page_for_privacy_policy'], 'The response should still report the previous page.' );
 		$this->assertSame( $page_id, (int) get_option( 'wp_page_for_privacy_policy' ), 'The option should not change.' );
-	}
-
-	public function test_settings_require_manage_options() {
-		wp_set_current_user( self::$subscriber_id );
-
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 403, $response->get_status() );
 	}
 }


### PR DESCRIPTION
Closes #67517

## What?

Shows a "Privacy Policy Page" badge next to the page assigned in Settings > Privacy. The badge appears in the pages list (both the site editor and the extensible site editor share the same field), in the document bar of the editor, and in the post card panel. This matches the existing "Homepage" and "Posts Page" badges.

| Site Editor > Pages | Editor Inspector |
| --- | --- |
|<img width="1564" height="1221" alt="Screenshot 2026-09-04 at 10 31 07" src="https://github.com/user-attachments/assets/70fc04bf-8856-4349-8033-18f9d24914bf" /> | <img width="281" height="552" alt="Screenshot 2026-09-04 at 10 31 49" src="https://github.com/user-attachments/assets/7b8cb325-b98d-4832-aa2f-f4610b741c4c" /> |


## Why?

The classic pages list labels the privacy policy page, so users can tell which page it is. The data views pages list does not. The site settings endpoint only exposes the homepage and the posts page, so the editor had no way to know which page is the privacy policy page.

## How?

- **PHP**: expose the existing `page_for_privacy_policy` via REST.
- **`@wordpress/core-data`**: adds `page_for_privacy_policy` to the `Settings` type.
- **`@wordpress/fields`**: the page title field checks the new setting and renders the badge.
- **`@wordpress/editor`**: the `usePageTypeBadge` hook checks the new setting, so the document bar and the post card panel show the badge too.

## Testing Instructions

1. Go to Settings > Privacy and assign a page as the privacy policy page.
2. Open Appearance > Editor > Pages. The assigned page shows a "Privacy Policy Page" badge next to its title.
3. Enable the "Extensible site editor" experiment under Gutenberg > Experiments and repeat step 2. The badge shows there too.
4. Open that page in the editor. The document bar at the top reads "Page title · Privacy Policy Page", and the post card panel in the sidebar shows the badge.
5. Set the homepage or the posts page to the same page. The "Homepage" or "Posts Page" badge wins, as before.
6. Unassign the privacy policy page. The badge disappears.

Run the PHP tests with:

```
npm run test:unit:php:base -- -- --filter Gutenberg_Privacy_Policy_Page_Setting_Test
```

## Use of AI Tools

This PR was written with the help of Claude Code. The author reviewed all changes and tested them manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Privacy Policy Page settings are available through the REST API.
  * Settings data includes the configured Privacy Policy Page.
  * Privacy Policy Page badges appear in the editor document bar, post cards, and page title areas.
  * Existing homepage and posts page badges remain available.

* **Bug Fixes**
  * Users without the required permission can no longer modify the Privacy Policy Page setting through the REST API.

* **Documentation**
  * Updated release notes for Privacy Policy Page settings and badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->