### PR TITLE
Writing Flow: Bail out of Enter handling when no block is selected

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -82,6 +82,10 @@ export default function useInput() {
 					}
 
 					const clientId = getSelectedBlockClientId();
+					if ( ! clientId ) {
+						return;
+					}
+
 					const blockName = getBlockName( clientId );
 					const selectionStart = getSelectionStart();
 					const selectionEnd = getSelectionEnd();


### PR DESCRIPTION
## What?
PR fixes an error triggered by the post title when pressing the <kbd>Enter</kbd> key: `TypeError: Cannot read properties of null (reading 'undefined')`.

This is a regression from #63484, which replaced `if ( event.shiftKey || __unstableIsFullySelected() ) return;` with `if ( event.shiftKey ) return;` and moved the fully-selected check below. 

The `__unstableIsFullySelected()` returns `true` when both endpoints are empty, so it had been incidentally guarding the null client ID.

## Testing Instructions
1. Open the browser console.
2. Create a new post.
3. Type a title.
4. Press Enter. No error is logged, and the caret moves to an empty paragraph.

## Screenshots or screencast <!-- if applicable -->

<img width="1638" height="226" alt="CleanShot 2026-09-04 at 12 07 39" src="https://github.com/user-attachments/assets/55fe10d4-3b31-420b-af5f-500302f25ea2" />


## Use of AI Tools

Assisted by Claude.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Enter-key handling when no block is selected, preventing unintended insertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->