### PR TITLE
Editor: Fix disabled and link items of the more menu adapter

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,12 +4,11 @@
 
 ### Breaking Changes
 
--   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem`. A link item honors only `target="_blank"` ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).
+-   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem` ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).
 
 ### Deprecations
 
 -   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`, `PluginPreviewMenuItem`: Deprecate the `as` prop, which reached the item only because these components forward every extra prop. The menu now renders the item itself, so the prop is ignored ([#82319](https://github.com/WordPress/gutenberg/pull/82319)).
--   `PluginPreviewMenuItem`: The View menu renders with the `Menu` component of `@wordpress/ui`, so a link item honors only `target="_blank"`, as in the Options menu ([#82321](https://github.com/WordPress/gutenberg/pull/82321)).
 
 ### Enhancements
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem` ([#81564](https://github.com/WordPress/gutenberg/pull/81564)).
+-   `PluginMoreMenuItem`, `PluginSidebarMoreMenuItem`, `PluginPreviewMenuItem`: Items render with the `Menu` component of `@wordpress/ui` instead of `MenuItem` ([#81564](https://github.com/WordPress/gutenberg/pull/81564), [#82321](https://github.com/WordPress/gutenberg/pull/82321), [#82428](https://github.com/WordPress/gutenberg/pull/82428)).
 
 ### Deprecations
 

--- a/packages/editor/src/components/more-menu/more-menu-item.tsx
+++ b/packages/editor/src/components/more-menu/more-menu-item.tsx
@@ -32,6 +32,11 @@ type MoreMenuItemProps = Omit<
 	children?: ReactNode;
 
 	/**
+	 * Whether the item is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
 	 * Address the item navigates to, which turns it into a link.
 	 */
 	href?: string;
@@ -109,6 +114,7 @@ function UnforwardedMoreMenuItem(
 		'aria-checked': ariaChecked,
 		'aria-label': ariaLabel,
 		children,
+		disabled,
 		href,
 		icon,
 		info,
@@ -145,6 +151,7 @@ function UnforwardedMoreMenuItem(
 				aria-label={ itemAriaLabel }
 				checked={ checked }
 				closeOnClick
+				disabled={ disabled }
 				onClick={ onClick }
 				prefix={ prefix }
 				shortcut={ itemShortcut }
@@ -156,15 +163,19 @@ function UnforwardedMoreMenuItem(
 		);
 	}
 
-	if ( href !== undefined ) {
+	// A link item has no disabled state: it would still render an active
+	// anchor. A disabled one falls through to an inert `Menu.Item`, the way
+	// `PostPreviewMenuItem` renders it.
+	if ( href !== undefined && ! disabled ) {
 		return (
 			<Menu.LinkItem
 				ref={ ref }
 				aria-label={ itemAriaLabel }
+				closeOnClick
 				href={ href }
 				prefix={ prefix }
 				shortcut={ itemShortcut }
-				openInNewTab={ target === '_blank' }
+				target={ target }
 				onClick={ onClick }
 				{ ...props }
 			>
@@ -186,6 +197,7 @@ function UnforwardedMoreMenuItem(
 		<Menu.Item
 			ref={ ref }
 			aria-label={ itemAriaLabel }
+			disabled={ disabled }
 			prefix={ prefix }
 			shortcut={ itemShortcut }
 			onClick={ onClick }

--- a/packages/editor/src/components/more-menu/test/more-menu-item.jsdom.test.tsx
+++ b/packages/editor/src/components/more-menu/test/more-menu-item.jsdom.test.tsx
@@ -185,6 +185,21 @@ describe( 'MoreMenuItem', () => {
 				'_blank'
 			);
 		} );
+
+		it( 'renders a disabled link as an inert item', async () => {
+			const user = userEvent.setup();
+			renderMenu(
+				<MoreMenuItem href="/help" disabled>
+					Help
+				</MoreMenuItem>
+			);
+			await openMenu( user );
+
+			const item = screen.getByRole( 'menuitem', { name: 'Help' } );
+
+			expect( item ).not.toHaveAttribute( 'href' );
+			expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
 	} );
 
 	describe( 'the legacy label', () => {


### PR DESCRIPTION
## What?
Follow-up to #82321

Post merge follow-up to #82321. `MoreMenuItem`, the adapter that plugin fills render through in the Options and View menus, mishandled link fills: `disabled` was ignored, and clicking one left the menu open. Both are fixed in the adapter, so the Options menu gets the fix too.

- A disabled link now renders as `Menu.Item disabled` instead of an active anchor, since `Menu.LinkItem` has no disabled state. Same as `PostPreviewMenuItem`.
- Links set `closeOnClick`; base UI defaults it to `false` for links, and the old `DropdownMenu` slot composed every callback with `onClose`.
- `target` is forwarded now that #82347 added target support to `Menu.LinkItem`, so the two changelog entries saying a link honors only `target="_blank"` are retired. Both were still unreleased.

## Testing Instructions
Covered by unit tests.

## Use of AI Tools
Assisted by Claude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More-menu items can now be disabled.
  * Disabled links appear as inert menu items and are marked as unavailable to assistive technologies.
  * Menu links close the menu after selection while preserving their configured link target.

* **Tests**
  * Added coverage confirming disabled links do not navigate.

* **Documentation**
  * Updated breaking-change information to include `PluginPreviewMenuItem` and related references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->