### PR TITLE
Upgrade React 19 to 19.2.8, read version from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56166,8 +56166,8 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"react": "^19.2.7",
-				"react-dom": "^19.2.7"
+				"react": "^19.2.8",
+				"react-dom": "^19.2.8"
 			}
 		},
 		"tools/react-19/node_modules/react": {

--- a/tools/build-scripts/packages/build-vendors.mjs
+++ b/tools/build-scripts/packages/build-vendors.mjs
@@ -2,6 +2,7 @@
 
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import esbuild from 'esbuild';
 import {
@@ -29,34 +30,58 @@ const patchReactDOM = createPatcher(
 	patchInertAttribute
 );
 
+const requireFromWorkspace = createRequire(
+	path.join( WORKSPACE_DIR, 'package.json' )
+);
+
+/**
+ * Read the React version a vendor package resolves to.
+ *
+ * @param {string} pkg Vendor package name, e.g. `@wordpress/react-18`.
+ * @return {Promise<string>} The installed `react` version, e.g. `18.3.1`.
+ */
+async function getReactVersion( pkg ) {
+	const requireFromVendor = createRequire(
+		requireFromWorkspace.resolve( `${ pkg }/package.json` )
+	);
+	const manifest = await readFile(
+		requireFromVendor.resolve( 'react/package.json' ),
+		'utf-8'
+	);
+	return JSON.parse( manifest ).version;
+}
+
+const REACT_18_VERSION = await getReactVersion( '@wordpress/react-18' );
+const REACT_19_VERSION = await getReactVersion( '@wordpress/react-19' );
+
 const VENDOR_SCRIPTS = [
 	{
 		name: '@wordpress/react-18/react',
 		global: 'React',
 		handle: 'react',
 		dependencies: [ 'wp-polyfill' ],
-		version: '18.3.1',
+		version: REACT_18_VERSION,
 	},
 	{
 		name: '@wordpress/react-18/react-dom',
 		global: 'ReactDOM',
 		handle: 'react-dom',
 		dependencies: [ 'react' ],
-		version: '18.3.1',
+		version: REACT_18_VERSION,
 	},
 	{
 		name: '@wordpress/react-18/react-jsx-runtime',
 		global: 'ReactJSXRuntime',
 		handle: 'react-jsx-runtime',
 		dependencies: [ 'react' ],
-		version: '18.3.1',
+		version: REACT_18_VERSION,
 	},
 	{
 		name: '@wordpress/react-19/react',
 		global: 'React',
 		handle: 'react-19',
 		dependencies: [ 'wp-polyfill' ],
-		version: '19.2.7',
+		version: REACT_19_VERSION,
 		patch: patchReact,
 	},
 	{
@@ -64,7 +89,7 @@ const VENDOR_SCRIPTS = [
 		global: 'ReactDOM',
 		handle: 'react-dom-19',
 		dependencies: [ 'react' ],
-		version: '19.2.7',
+		version: REACT_19_VERSION,
 		patch: patchReactDOM,
 	},
 	{
@@ -72,7 +97,7 @@ const VENDOR_SCRIPTS = [
 		global: 'ReactJSXRuntime',
 		handle: 'react-jsx-runtime-19',
 		dependencies: [ 'react' ],
-		version: '19.2.7',
+		version: REACT_19_VERSION,
 	},
 ];
 
@@ -82,7 +107,7 @@ const VENDOR_SCRIPTS = [
  * @param {Object}   config              Vendor script configuration.
  * @param {string}   config.handle       WordPress script handle.
  * @param {string[]} config.dependencies WordPress script dependencies.
- * @param {string}   config.version      Package version (`18` or `19`).
+ * @param {string}   config.version      Bundled React version (e.g. `18.3.1`).
  */
 async function generateAssetFile( config ) {
 	const { handle, version, dependencies } = config;

--- a/tools/react-18/package.json
+++ b/tools/react-18/package.json
@@ -22,7 +22,8 @@
 	"exports": {
 		"./react": "./react.js",
 		"./react-dom": "./react-dom.js",
-		"./react-jsx-runtime": "./react-jsx-runtime.js"
+		"./react-jsx-runtime": "./react-jsx-runtime.js",
+		"./package.json": "./package.json"
 	},
 	"dependencies": {
 		"react": "^18.3.1",

--- a/tools/react-19/package.json
+++ b/tools/react-19/package.json
@@ -22,11 +22,12 @@
 	"exports": {
 		"./react": "./react.js",
 		"./react-dom": "./react-dom.js",
-		"./react-jsx-runtime": "./react-jsx-runtime.js"
+		"./react-jsx-runtime": "./react-jsx-runtime.js",
+		"./package.json": "./package.json"
 	},
 	"dependencies": {
-		"react": "^19.2.7",
-		"react-dom": "^19.2.7"
+		"react": "^19.2.8",
+		"react-dom": "^19.2.8"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
In #81870 we accidentally upgraded React 19 from 19.2.7 to 19.2.8, as a side effect of `npm dedupe`, because we specify `react` as a semver `^19.2.7`. And it got shipped with Gutenberg 23.9.

There is a problem that the `v=19.2.7` string in the URL was hardcoded, both versions share the same URL, and when one of `react` and `react-dom` scripts is cached and the other is not, it leads to an error:

https://react.dev/errors/527?args[]=19.2.8&args[]=19.2.7

This is really happening on a few sites that run the React 19 experiment and have the bad luck of "partial caching".

I think this is worth a point release, 23.9.1.

This PR fixes the issue by upgrading "officially" and it also stops hardcoding the version, it reads it from `package.json` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the React 19 and React DOM packages to version 19.2.8.
  * Improved vendor builds to automatically use the installed React 18 and React 19 versions, helping keep generated assets aligned with the workspace configuration.
  * Package metadata is now available through the React package exports for improved tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->