### PR TITLE
Video block: switch to UI Badge

### DIFF
--- a/packages/block-library/src/video/tracks-editor.jsx
+++ b/packages/block-library/src/video/tracks-editor.jsx
@@ -14,8 +14,8 @@ import {
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import {
 	MediaUpload,
 	MediaUploadCheck,
@@ -25,9 +25,6 @@ import { upload, media } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useState, useRef, useEffect } from '@wordpress/element';
 import { getFilename } from '@wordpress/url';
-import { unlock } from '../lock-unlock';
-
-const { Badge: WCBadge } = unlock( componentsPrivateApis );
 
 const ALLOWED_TYPES = [ 'text/vtt' ];
 
@@ -58,7 +55,9 @@ function TrackList( { tracks, onEditPress } ) {
 			>
 				<span>{ track.label }</span>
 				<HStack justify="flex-end">
-					{ track.default && <WCBadge>{ __( 'Default' ) }</WCBadge> }
+					{ track.default && (
+						<Badge intent="draft">{ __( 'Default' ) }</Badge>
+					) }
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"

--- a/packages/block-library/src/video/tracks-editor.jsx
+++ b/packages/block-library/src/video/tracks-editor.jsx
@@ -56,7 +56,7 @@ function TrackList( { tracks, onEditPress } ) {
 				<span>{ track.label }</span>
 				<HStack justify="flex-end">
 					{ track.default && (
-						<Badge intent="draft">{ __( 'Default' ) }</Badge>
+						<Badge intent="none">{ __( 'Default' ) }</Badge>
 					) }
 					<Button
 						__next40pxDefaultSize


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/82440 <!-- #ISSUE-NUMBER or URL -->

Replace private components Badge with newer UI Badge.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We're deprecating wp-components Badge and migrating to UI Badge.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Simple component switch.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Add video block and uploda video to it.
2. Add "text track" and upload .vtt example:
    ```vtt
    WEBVTT

    00:00:00.000 --> 00:00:05.000
    Gutenberg
    ```
3. Edit track and mark it as "default"
    <img width="282"  alt="image" src="https://github.com/user-attachments/assets/5b9a0a64-9507-42fb-8f5a-b012e86bab09" />
4. Save and note the badge



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="657" height="430" alt="Screenshot 2026-09-04 at 14 16 24" src="https://github.com/user-attachments/assets/435f3205-846f-4677-99a5-973ea8459e23" />

### After
<img width="677" height="447" alt="image" src="https://github.com/user-attachments/assets/8e2cd2b1-4f83-41fb-9899-3f16e3c43c47" />


## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the video track editor’s default-track indicator to use the standard draft badge styling.
  * Improved compatibility by using the publicly supported badge component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->