### PR TITLE
UI: Fix Menu.LinkItem target detection

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Bug Fixes
 
+-   `Menu.LinkItem`: Show the new-tab indicator and accessible notice when `target` is an ASCII case-insensitive match for `"_blank"`. ([#82442](https://github.com/WordPress/gutenberg/pull/82442))
 -   `Input`, `Textarea`, `InputControl`, `TextareaControl`: Use `--wpds-color-foreground-interactive-neutral-weak` for enabled placeholder text so it meets the 4.5:1 contrast minimum ([#82304](https://github.com/WordPress/gutenberg/pull/82304)).
 -   `SearchableChipSelect`, `SearchableChipSelectControl`: Fix the gray background on disabled search fields in WordPress admin ([#82304](https://github.com/WordPress/gutenberg/pull/82304)).
 -   `ValidityIndicator`: Remove the built-in outer margin. Spacing belongs on the consumer. `ControlWithError` now uses `Stack` with `gap="sm"` so validated controls keep the same gap. ([#82267](https://github.com/WordPress/gutenberg/pull/82267))

--- a/packages/ui/src/menu/link-item.tsx
+++ b/packages/ui/src/menu/link-item.tsx
@@ -30,7 +30,8 @@ const LinkItem = forwardRef< Element, LinkItemProps >( function MenuLinkItem(
 	},
 	ref
 ) {
-	const shouldShowNewTabIndicator = openInNewTab || target === '_blank';
+	const shouldShowNewTabIndicator =
+		openInNewTab || target?.toLowerCase() === '_blank';
 	const externalLinkIndicator = shouldShowNewTabIndicator ? (
 		<span
 			className={ styles[ 'external-link-indicator' ] }

--- a/packages/ui/src/menu/link-item.tsx
+++ b/packages/ui/src/menu/link-item.tsx
@@ -9,6 +9,8 @@ import { MenuItemContentContext } from './context';
 import { ItemContent, useItemContent } from './item';
 import type { LinkItemProps } from './types';
 
+const BLANK_TARGET_PATTERN = /^_[bB][lL][aA][nN][kK]$/;
+
 /**
  * Renders a menu item that navigates to a link target.
  */
@@ -31,7 +33,7 @@ const LinkItem = forwardRef< Element, LinkItemProps >( function MenuLinkItem(
 	ref
 ) {
 	const shouldShowNewTabIndicator =
-		openInNewTab || target?.toLowerCase() === '_blank';
+		openInNewTab || BLANK_TARGET_PATTERN.test( target ?? '' );
 	const externalLinkIndicator = shouldShowNewTabIndicator ? (
 		<span
 			className={ styles[ 'external-link-indicator' ] }

--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -1455,6 +1455,34 @@ describe( 'Menu', () => {
 		).toHaveAttribute( 'target', '_BLANK' );
 	} );
 
+	it( 'does not treat non-ASCII target characters as "_blank"', async () => {
+		const user = userEvent.setup();
+		const nonAsciiTarget = '_blan\u212A';
+
+		render(
+			<Menu.Root>
+				<Menu.Trigger>Actions</Menu.Trigger>
+				<Menu.Popup>
+					<Menu.LinkItem
+						href="https://wordpress.org"
+						target={ nonAsciiTarget }
+					>
+						<Menu.ItemLabel>WordPress.org</Menu.ItemLabel>
+					</Menu.LinkItem>
+				</Menu.Popup>
+			</Menu.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Actions' } ) );
+
+		expect(
+			await screen.findByRole( 'menuitem', { name: 'WordPress.org' } )
+		).toHaveAttribute( 'target', nonAsciiTarget );
+		expect(
+			screen.queryByLabelText( '(opens in a new tab)' )
+		).not.toBeInTheDocument();
+	} );
+
 	it( 'forwards a named target on link items without adding a new tab notice', async () => {
 		const user = userEvent.setup();
 

--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -1363,6 +1363,52 @@ describe( 'Menu', () => {
 		).not.toHaveAttribute( 'aria-labelledby' );
 	} );
 
+	it( 'closes after activating a link item when closeOnClick is true', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Menu.Root>
+				<Menu.Trigger>Actions</Menu.Trigger>
+				<Menu.Popup>
+					<Menu.LinkItem href="#destination" closeOnClick>
+						<Menu.ItemLabel>Destination</Menu.ItemLabel>
+					</Menu.LinkItem>
+				</Menu.Popup>
+			</Menu.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Actions' } ) );
+		await user.click(
+			await screen.findByRole( 'menuitem', { name: 'Destination' } )
+		);
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'menu' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'stays open after activating a link item by default', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Menu.Root>
+				<Menu.Trigger>Actions</Menu.Trigger>
+				<Menu.Popup>
+					<Menu.LinkItem href="#destination">
+						<Menu.ItemLabel>Destination</Menu.ItemLabel>
+					</Menu.LinkItem>
+				</Menu.Popup>
+			</Menu.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Actions' } ) );
+		await user.click(
+			await screen.findByRole( 'menuitem', { name: 'Destination' } )
+		);
+
+		expect( screen.getByRole( 'menu' ) ).toBeVisible();
+	} );
+
 	it( 'treats target="_blank" on link items as opening in a new tab', async () => {
 		const user = userEvent.setup();
 
@@ -1384,6 +1430,29 @@ describe( 'Menu', () => {
 				name: 'WordPress.org (opens in a new tab)',
 			} )
 		).toHaveAttribute( 'target', '_blank' );
+	} );
+
+	it( 'treats target="_BLANK" on link items as opening in a new tab', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<Menu.Root>
+				<Menu.Trigger>Actions</Menu.Trigger>
+				<Menu.Popup>
+					<Menu.LinkItem href="https://wordpress.org" target="_BLANK">
+						<Menu.ItemLabel>WordPress.org</Menu.ItemLabel>
+					</Menu.LinkItem>
+				</Menu.Popup>
+			</Menu.Root>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Actions' } ) );
+
+		expect(
+			await screen.findByRole( 'menuitem', {
+				name: 'WordPress.org (opens in a new tab)',
+			} )
+		).toHaveAttribute( 'target', '_BLANK' );
 	} );
 
 	it( 'forwards a named target on link items without adding a new tab notice', async () => {


### PR DESCRIPTION
Follow-up to #82428

## What?

Fix `Menu.LinkItem` so every ASCII case variation of `target="_blank"` gets the visible indicator and accessible new-tab notice. Add public component coverage for the `closeOnClick` contract.

## Why?

[HTML target keywords](https://html.spec.whatwg.org/multipage/document-sequences.html#valid-navigable-target-name-or-keyword) are ASCII case-insensitive. A target such as `"_BLANK"` opens a new browsing context, but `Menu.LinkItem` did not announce that behavior.

The editor adapter in #82428 relies on `closeOnClick`, but the Menu suite did not verify that link items close only when consumers opt in.

## How?

Compare `target` case-insensitively when deciding whether to render the new-tab indicator. Forward the supplied target unchanged.

The tests also verify that a link with `closeOnClick` closes the popup and that a link without the prop keeps it open.

## Testing Instructions

1. Run `npm run test:unit packages/ui/src/menu/test/index.jsdom.test.tsx -- --runInBand`.
2. Confirm all 45 tests pass.

### Testing Instructions for Keyboard

1. Open Storybook and select `Design System / Components / Menu / LinkItem`.
2. Use Tab to focus "Open menu", then press Enter.
3. Use the arrow keys to move through the links.
4. Activate "In-page destination" with Enter and confirm the menu stays open by default.

## Use of AI Tools

Codex assisted with the implementation, tests, verification, and PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `Menu.LinkItem` now recognizes `target="_blank"` consistently, regardless of letter casing.
  - Links that open in a new tab display the appropriate indicator and accessible notice.
  - Menu links now correctly respect their configured close-on-click behavior.
  - Non-standard Unicode characters are no longer incorrectly treated as equivalent to `_blank`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->