### PR TITLE
Excerpt and description fields: Use the regular layout in the DataForm post summary

### DIFF
--- a/lib/compat/wordpress-7.2/view-config-api.php
+++ b/lib/compat/wordpress-7.2/view-config-api.php
@@ -25,7 +25,7 @@ function _gutenberg_add_reading_settings_to_wp_template_view_config( $data ) {
 					array(
 						'id'     => 'description',
 						'layout' => array(
-							'type'          => 'panel',
+							'type'          => 'regular',
 							'labelPosition' => 'top',
 						),
 					),
@@ -152,17 +152,48 @@ function _gutenberg_add_group_summaries_to_default_posttype_form( $data ) {
 }
 
 /**
- * Layers the group summaries on top of the view configuration of every post
- * type that uses the default form, including custom post types registered at
- * any point.
+ * Renders the `excerpt` field inline with the regular layout instead of the
+ * panel summary and its edit popover.
  *
- * The callback merges by member id, and a member that is absent would be
+ * The textarea and its placeholder show that the field is editable even when
+ * the excerpt is empty, which the panel summary cannot without a rendered
+ * value. The patch merges into the existing member by id, leaving its position
+ * in the form untouched.
+ *
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
+ */
+function _gutenberg_use_regular_layout_for_excerpt( $data ) {
+	return $data->merge(
+		array(
+			'form' => array(
+				'fields' => array(
+					array(
+						'id'     => 'excerpt',
+						'layout' => array(
+							'type'          => 'regular',
+							'labelPosition' => 'top',
+						),
+					),
+				),
+			),
+		),
+		1
+	);
+}
+
+/**
+ * Layers the group summaries and the regular excerpt layout on top of the view
+ * configuration of every post type that uses the default form, including
+ * custom post types registered at any point.
+ *
+ * The callbacks merge by member id, and a member that is absent would be
  * appended instead, so post types whose base definition provides its own form
  * are skipped.
  *
  * @param string $post_type The post type being registered.
  */
-function gutenberg_register_default_posttype_form_summaries_7_2( $post_type ) {
+function gutenberg_register_default_posttype_form_layers_7_2( $post_type ) {
 	if ( in_array( $post_type, GUTENBERG_VIEW_CONFIG_POST_TYPES_WITH_OWN_FORM, true ) ) {
 		return;
 	}
@@ -173,8 +204,14 @@ function gutenberg_register_default_posttype_form_summaries_7_2( $post_type ) {
 		6,
 		1
 	);
+	add_filter(
+		gutenberg_get_entity_view_config_hook_name( 'postType', $post_type ),
+		'_gutenberg_use_regular_layout_for_excerpt',
+		6,
+		1
+	);
 }
-add_action( 'registered_post_type', 'gutenberg_register_default_posttype_form_summaries_7_2' );
+add_action( 'registered_post_type', 'gutenberg_register_default_posttype_form_layers_7_2' );
 
 /**
  * Registers the entity view configuration filters that layer on top of the base
@@ -187,6 +224,12 @@ function gutenberg_register_entity_view_config_filters_7_2() {
 		gutenberg_get_entity_view_config_hook_name( 'postType', 'wp_navigation' ),
 		'_gutenberg_get_entity_view_config_posttype_wp_navigation',
 		5,
+		1
+	);
+	add_filter(
+		gutenberg_get_entity_view_config_hook_name( 'postType', 'wp_block' ),
+		'_gutenberg_use_regular_layout_for_excerpt',
+		6,
 		1
 	);
 	add_filter(

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Excerpt field: render nothing for an empty excerpt instead of the `Add an excerpt` placeholder text. Start the textarea of the excerpt, description, and pattern description fields at two rows instead of four. ([#82444](https://github.com/WordPress/gutenberg/pull/82444))
 -   Append an ellipsis (`…`) to the labels of the actions that open a dialog requiring further input or confirmation (`Delete…`, `Trash…`, `Permanently delete…`, `Rename…`, `Duplicate…`, `Reset…`, `Order…`), following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 
 ### Bug Fixes

--- a/packages/fields/src/fields/description/index.tsx
+++ b/packages/fields/src/fields/description/index.tsx
@@ -26,7 +26,7 @@ const descriptionField: Field< Template > = {
 	render,
 	Edit: {
 		control: 'textarea',
-		rows: 4,
+		rows: 2,
 	},
 	isVisible: isCustomTemplate,
 	enableSorting: false,

--- a/packages/fields/src/fields/excerpt/index.tsx
+++ b/packages/fields/src/fields/excerpt/index.tsx
@@ -22,23 +22,17 @@ const excerptField: Field< BasePost > = {
 		</ExternalLink>
 	),
 	render: ( { item } ) => {
-		let excerpt;
-		if ( typeof item.excerpt === 'string' ) {
-			excerpt = !! item.excerpt
-				? decodeEntities( item.excerpt )
-				: __( 'Add an excerpt' );
-		} else {
-			excerpt = decodeEntities( item.excerpt?.raw || '' );
-		}
-		return (
+		const excerpt =
+			typeof item.excerpt === 'string' ? item.excerpt : item.excerpt?.raw;
+		return excerpt ? (
 			<WCText align="left" numberOfLines={ 3 } truncate>
-				{ excerpt }
+				{ decodeEntities( excerpt ) }
 			</WCText>
-		);
+		) : null;
 	},
 	Edit: {
 		control: 'textarea',
-		rows: 4,
+		rows: 2,
 	},
 	enableSorting: false,
 	filterBy: false,

--- a/packages/fields/src/fields/pattern-description/index.tsx
+++ b/packages/fields/src/fields/pattern-description/index.tsx
@@ -23,7 +23,7 @@ const patternDescriptionField: Field< Pattern > = {
 	},
 	Edit: {
 		control: 'textarea',
-		rows: 4,
+		rows: 2,
 	},
 	enableSorting: false,
 	enableHiding: false,

--- a/phpunit/view-config-api-test.php
+++ b/phpunit/view-config-api-test.php
@@ -89,7 +89,8 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 
 	/**
 	 * The `status` and `discussion` groups of the default post type form declare
-	 * their panel summary explicitly, for built-in and custom post types alike.
+	 * their panel summary explicitly, and the `excerpt` field renders inline with
+	 * the regular layout, for built-in and custom post types alike.
 	 *
 	 * @dataProvider data_default_form_post_types
 	 *
@@ -115,6 +116,16 @@ class Tests_View_Config_API extends WP_UnitTestCase {
 				"The `{$group}` group summary is explicit."
 			);
 		}
+
+		$excerpt = $this->get_form_field( $config, 'excerpt' );
+		$this->assertSame(
+			array(
+				'type'          => 'regular',
+				'labelPosition' => 'top',
+			),
+			$excerpt['layout'],
+			'The `excerpt` field renders inline with the regular layout.'
+		);
 
 		if ( 'page' !== $post_type && 'post' !== $post_type ) {
 			unregister_post_type( $post_type );

--- a/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/post-summary.spec.js
@@ -52,24 +52,12 @@ test.describe( 'Post Summary', () => {
 					page,
 					tab: 'Pattern',
 				} );
-				const fields = getPatternSummaryFields( { page, summary } );
+				const fields = getPatternSummaryFields( { summary } );
 
-				await expect(
-					fields.description.row.getByText( INITIAL_DESCRIPTION, {
-						exact: true,
-					} )
-				).toBeVisible();
-				await expect( fields.description.textbox ).toHaveCount( 0 );
-
-				await fields.description.editButton.click();
-				await expect( fields.description.textbox ).toBeVisible();
+				await expect( fields.description.textbox ).toHaveValue(
+					INITIAL_DESCRIPTION
+				);
 				await fields.description.textbox.fill( UPDATED_DESCRIPTION );
-				await page.keyboard.press( 'Escape' );
-				await expect(
-					fields.description.row.getByText( UPDATED_DESCRIPTION, {
-						exact: true,
-					} )
-				).toBeVisible();
 
 				await expect( fields.revisions.row ).toBeVisible();
 				await expect(
@@ -90,13 +78,9 @@ test.describe( 'Post Summary', () => {
 					tab: 'Pattern',
 				} );
 				await expect(
-					getPatternSummaryFields( {
-						page,
-						summary: reloadedSummary,
-					} ).description.row.getByText( UPDATED_DESCRIPTION, {
-						exact: true,
-					} )
-				).toBeVisible();
+					getPatternSummaryFields( { summary: reloadedSummary } )
+						.description.textbox
+				).toHaveValue( UPDATED_DESCRIPTION );
 			} );
 		}
 
@@ -113,7 +97,7 @@ test.describe( 'Post Summary', () => {
 				page,
 				tab: 'Pattern',
 			} );
-			const fields = getPatternSummaryFields( { page, summary } );
+			const fields = getPatternSummaryFields( { summary } );
 
 			await expect( fields.title ).toHaveText( title );
 			await expect(
@@ -139,7 +123,7 @@ test.describe( 'Post Summary', () => {
 				page,
 				tab: 'Pattern',
 			} );
-			const fields = getPatternSummaryFields( { page, summary } );
+			const fields = getPatternSummaryFields( { summary } );
 
 			await expect( fields.title ).toHaveText( title );
 			await expect(
@@ -200,27 +184,16 @@ test.describe( 'Post Summary', () => {
 			await expect( modal ).toBeHidden();
 		}
 
-		function getPatternSummaryFields( { page, summary } ) {
+		function getPatternSummaryFields( { summary } ) {
 			return {
 				title: summary.locator( '.editor-post-card-panel__title-name' ),
-				description: getDescriptionField( { page, summary } ),
+				description: {
+					textbox: summary.getByRole( 'textbox', {
+						name: 'Description',
+					} ),
+				},
 				revisions: getRevisionsField( { summary } ),
 				syncStatus: getSyncStatusField( { summary } ),
-			};
-		}
-
-		function getDescriptionField( { page, summary } ) {
-			const editButton = summary.getByRole( 'button', {
-				name: 'Edit Description',
-			} );
-
-			return {
-				// The field row also renders the current value next to the edit button.
-				row: editButton.locator( '..' ),
-				editButton,
-				// The edit popover is portaled outside the summary, so query it
-				// from the page by the textarea's accessible label.
-				textbox: page.getByRole( 'textbox', { name: 'Description' } ),
 			};
 		}
 
@@ -408,22 +381,16 @@ test.describe( 'Post Summary', () => {
 		} ) => {
 			await admin.createNewPost();
 			const summary = await openPostSummary( { editor, page } );
+			const excerpt = summary.getByRole( 'textbox', { name: 'Excerpt' } );
 
-			await expect(
-				summary.getByText( 'Add an excerpt', { exact: true } )
-			).toBeVisible();
+			await expect( excerpt ).toHaveValue( '' );
+			await expect( excerpt ).toHaveAttribute(
+				'placeholder',
+				'Add an excerpt'
+			);
 
-			await summary
-				.getByRole( 'button', { name: 'Edit Excerpt' } )
-				.click();
-			await page
-				.getByRole( 'textbox', { name: 'Excerpt' } )
-				.fill( 'A DataForm excerpt.' );
-			await page.keyboard.press( 'Escape' );
+			await excerpt.fill( 'A DataForm excerpt.' );
 
-			await expect(
-				summary.getByText( 'A DataForm excerpt.', { exact: true } )
-			).toBeVisible();
 			await expect
 				.poll( () =>
 					page.evaluate( () =>
@@ -574,13 +541,13 @@ test.describe( 'Post Summary', () => {
 		} ) => {
 			await admin.createNewPost();
 			const summary = await openPostSummary( { editor, page } );
-			const excerptButton = summary.getByRole( 'button', {
-				name: 'Edit Excerpt',
+			const excerptField = summary.getByRole( 'textbox', {
+				name: 'Excerpt',
 			} );
 			const discussionButton = summary.getByRole( 'button', {
 				name: 'Edit Discussion',
 			} );
-			await expect( excerptButton ).toBeVisible();
+			await expect( excerptField ).toBeVisible();
 			await expect( discussionButton ).toBeVisible();
 
 			await page
@@ -599,7 +566,7 @@ test.describe( 'Post Summary', () => {
 				.uncheck();
 			await preferences.getByRole( 'button', { name: 'Close' } ).click();
 
-			await expect( excerptButton ).toBeHidden();
+			await expect( excerptField ).toBeHidden();
 			await expect( discussionButton ).toBeHidden();
 		} );
 	} );

--- a/test/e2e/specs/editor/various/post-summary-dataform/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/post-summary-dataform/sidebar.spec.js
@@ -36,8 +36,8 @@ test.describe( 'Sidebar (DataForm inspector)', () => {
 			'Tags',
 		] );
 		// Also check 'panels' that are not rendered as TabPanels.
-		const postExcerptPanel = page.getByRole( 'button', {
-			name: 'Edit Excerpt',
+		const postExcerptPanel = page.getByRole( 'textbox', {
+			name: 'Excerpt',
 		} );
 		const postFeaturedImagePanel = page.getByRole( 'button', {
 			name: 'Set featured image',


### PR DESCRIPTION
## What?

Part of: https://github.com/WordPress/gutenberg/issues/76076 (the excerpt field item under "Design tweaks")
Alternative to: https://github.com/WordPress/gutenberg/pull/82423 (see https://github.com/WordPress/gutenberg/pull/82423#issuecomment-5538368735)

With the DataForm inspector, the excerpt field renders `Add an excerpt` as if it were a value when the excerpt is empty, with the same styling as a real excerpt. This is also problematic in cases the `excerpt` field would be rendered in DataViews, although that's not the case right now. The description fields of templates and patterns render nothing when empty, for the use case I mentioned, as it's also used in the site editor (DataViews).

#82423 keeps the panel layout and always shows the pencil. This PR tries the other option from that discussion and renders the `excerpt` and the template `description` fields inline with the regular layout, so what users see is the textarea with its placeholder. Per Joen's feedback the textareas start at 2 rows instead of 4.

The `excerpt` field also renders nothing when there is no value, same as #82423, since `render` is what DataViews would use.



### Notes - Needs design feedback
1. The form gets longer and the "Learn more about manual excerpts" link is now always visible. Do we want to keep the link?
2. The label follows the regular layout's field label (uppercase and darker), which differs from the panel rows. Is this something we should try to address specifically here(overrides)? Should we consider how can we be consistent with labels between different DataForm layouts? Another way to go with this would be to remove the label altogether, kind of relying to the `Learn more about manual excerpts↗` link to make the 'work' for users to understand this is the excerpt field? 🤔  I'm sharing a screenshot for that below:
<img width="268" height="392" alt="Screenshot 2026-09-04 at 2 36 06 PM" src="https://github.com/user-attachments/assets/60f7f7a6-bc75-4889-aef9-b8098f5fb738" />


### This PR 

| Emtpy | With value |
| --- | --- |
|<img width="268" height="540" alt="Screenshot 2026-09-04 at 2 28 18 PM" src="https://github.com/user-attachments/assets/bf0b16b9-daf4-4d8c-97fb-62a5349748ca" />|<img width="268" height="540" alt="Screenshot 2026-09-04 at 2 21 43 PM" src="https://github.com/user-attachments/assets/6d476375-8ede-4bab-a23f-99afaaa35da5" />|




### Trunk

| Emtpy | With value |
| --- | --- |
|<img width="279" height="471" alt="Screenshot 2026-09-04 at 11 37 32 AM" src="https://github.com/user-attachments/assets/ca9c4b9f-4d53-468b-80ce-66421d4d0e4d" />|<img width="279" height="471" alt="Screenshot 2026-09-04 at 11 37 20 AM" src="https://github.com/user-attachments/assets/af442efe-0383-41de-8d62-eeff4233df90" />|

## Testing Instructions

1. Enable the "Editor Inspector: Use DataForm" experiment.
2. Create a new post and open the Post tab in the sidebar. The excerpt should render as a textarea with the `Add an excerpt` placeholder.
4. Add an excerpt, save and reload. The value should persist.
5. Open a pattern in the post editor and a custom template in the site editor. Their description field should render the same way.
6. In Preferences uncheck Excerpt and check the field is hidden.
7. Everything else in the summary should work as before.

## Use of AI Tools

Generated with Fable 5 and adjusted/reviewed manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Post excerpts now appear inline with a regular layout and top labels.
  * Excerpt fields handle empty and non-empty content more consistently, without placeholder text when empty.
  * Description, pattern description, and excerpt text areas are more compact, displaying two rows instead of four.
  * Pattern descriptions and post excerpts can be edited directly in their text fields.
  * Template descriptions now use a regular layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->