### PR TITLE
Theme: Cache luminance for contrast checks

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Internal
 
+-   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))
 -   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
 
 ## 2.0.0 (2026-08-26)

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -4,13 +4,16 @@ import {
 	to,
 	toGamut,
 	serialize,
-	contrastWCAG21,
+	getLuminance,
 	sRGB,
 	OKLCH,
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 
 const ALLOWED_SEED_COLOR_SPACES = [ sRGB ];
+const MAX_CACHED_LUMINANCES = 2_048;
+const luminanceCache = new Map< string, number >();
+const objectLuminanceCache = new WeakMap< PlainColorObject, number >();
 
 /**
  * Get string representation of a color.
@@ -34,8 +37,62 @@ export function getContrast(
 	colorA: string | PlainColorObject,
 	colorB: string | PlainColorObject
 ): number {
+	return getContrastFromLuminances(
+		getRelativeLuminance( colorA ),
+		getRelativeLuminance( colorB )
+	);
+}
+
+/**
+ * Return a color's non-negative relative luminance. Serialized colors use a
+ * bounded cache because ramp calculations often reuse the same colors. Color
+ * objects use a weak cache and must not be mutated after measurement.
+ *
+ * @param color Color to measure.
+ */
+export function getRelativeLuminance(
+	color: string | PlainColorObject
+): number {
+	if ( typeof color !== 'string' ) {
+		const cachedLuminance = objectLuminanceCache.get( color );
+		if ( cachedLuminance !== undefined ) {
+			return cachedLuminance;
+		}
+		const luminance = Math.max( getLuminance( color ), 0 );
+		objectLuminanceCache.set( color, luminance );
+		return luminance;
+	}
+
+	const cachedLuminance = luminanceCache.get( color );
+	if ( cachedLuminance !== undefined ) {
+		return cachedLuminance;
+	}
+
 	ColorSpace.register( sRGB );
-	return contrastWCAG21( colorA, colorB );
+	const luminance = Math.max( getLuminance( color ), 0 );
+	if ( luminanceCache.size >= MAX_CACHED_LUMINANCES ) {
+		const oldestKey = luminanceCache.keys().next().value;
+		if ( oldestKey !== undefined ) {
+			luminanceCache.delete( oldestKey );
+		}
+	}
+	luminanceCache.set( color, luminance );
+	return luminance;
+}
+
+/**
+ * Calculate a WCAG 2.1 contrast ratio from precomputed relative luminances.
+ *
+ * @param first  First relative luminance.
+ * @param second Second relative luminance.
+ */
+export function getContrastFromLuminances(
+	first: number,
+	second: number
+): number {
+	return first > second
+		? ( first + 0.05 ) / ( second + 0.05 )
+		: ( second + 0.05 ) / ( first + 0.05 );
 }
 
 /**

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -50,9 +50,7 @@ export function getContrast(
  *
  * @param color Color to measure.
  */
-export function getRelativeLuminance(
-	color: string | PlainColorObject
-): number {
+function getRelativeLuminance( color: string | PlainColorObject ): number {
 	if ( typeof color !== 'string' ) {
 		const cachedLuminance = objectLuminanceCache.get( color );
 		if ( cachedLuminance !== undefined ) {
@@ -86,10 +84,7 @@ export function getRelativeLuminance(
  * @param first  First relative luminance.
  * @param second Second relative luminance.
  */
-export function getContrastFromLuminances(
-	first: number,
-	second: number
-): number {
+function getContrastFromLuminances( first: number, second: number ): number {
 	return first > second
 		? ( first + 0.05 ) / ( second + 0.05 )
 		: ( second + 0.05 ) / ( first + 0.05 );

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -4,6 +4,8 @@ import {
 	to,
 	toGamut,
 	serialize,
+	clone,
+	equals,
 	getLuminance,
 	sRGB,
 	OKLCH,
@@ -11,13 +13,10 @@ import {
 } from 'colorjs.io/fn';
 
 const ALLOWED_SEED_COLOR_SPACES = [ sRGB ];
-const MAX_CACHED_LUMINANCES = 2_048;
-const luminanceCache = new Map< string, number >();
 const objectLuminanceCache = new WeakMap<
 	PlainColorObject,
 	{
-		space: PlainColorObject[ 'space' ];
-		coords: PlainColorObject[ 'coords' ];
+		color: PlainColorObject;
 		luminance: number;
 	}
 >();
@@ -51,46 +50,27 @@ export function getContrast(
 }
 
 /**
- * Return a color's non-negative relative luminance. Serialized colors use a
- * bounded cache because ramp calculations often reuse the same colors. Color
- * objects use a weak cache with coordinate snapshots to detect mutations.
+ * Return a color's non-negative relative luminance. Color objects use a weak
+ * cache with snapshots to detect mutations.
  *
  * @param color Color to measure.
  */
 function getRelativeLuminance( color: string | PlainColorObject ): number {
-	if ( typeof color !== 'string' ) {
-		const cachedLuminance = objectLuminanceCache.get( color );
-		if (
-			cachedLuminance?.space === color.space &&
-			cachedLuminance.coords.every( ( coordinate, index ) =>
-				Object.is( coordinate, color.coords[ index ] )
-			)
-		) {
-			return cachedLuminance.luminance;
-		}
-		const luminance = Math.max( getLuminance( color ), 0 );
-		objectLuminanceCache.set( color, {
-			space: color.space,
-			coords: [ ...color.coords ],
-			luminance,
-		} );
-		return luminance;
+	if ( typeof color === 'string' ) {
+		ColorSpace.register( sRGB );
+		return Math.max( getLuminance( color ), 0 );
 	}
 
-	const cachedLuminance = luminanceCache.get( color );
-	if ( cachedLuminance !== undefined ) {
-		return cachedLuminance;
+	const cachedLuminance = objectLuminanceCache.get( color );
+	if ( cachedLuminance && equals( cachedLuminance.color, color ) ) {
+		return cachedLuminance.luminance;
 	}
 
-	ColorSpace.register( sRGB );
 	const luminance = Math.max( getLuminance( color ), 0 );
-	if ( luminanceCache.size >= MAX_CACHED_LUMINANCES ) {
-		const oldestKey = luminanceCache.keys().next().value;
-		if ( oldestKey !== undefined ) {
-			luminanceCache.delete( oldestKey );
-		}
-	}
-	luminanceCache.set( color, luminance );
+	objectLuminanceCache.set( color, {
+		color: clone( color ),
+		luminance,
+	} );
 	return luminance;
 }
 

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -13,7 +13,14 @@ import {
 const ALLOWED_SEED_COLOR_SPACES = [ sRGB ];
 const MAX_CACHED_LUMINANCES = 2_048;
 const luminanceCache = new Map< string, number >();
-const objectLuminanceCache = new WeakMap< PlainColorObject, number >();
+const objectLuminanceCache = new WeakMap<
+	PlainColorObject,
+	{
+		space: PlainColorObject[ 'space' ];
+		coords: PlainColorObject[ 'coords' ];
+		luminance: number;
+	}
+>();
 
 /**
  * Get string representation of a color.
@@ -46,18 +53,27 @@ export function getContrast(
 /**
  * Return a color's non-negative relative luminance. Serialized colors use a
  * bounded cache because ramp calculations often reuse the same colors. Color
- * objects use a weak cache and must not be mutated after measurement.
+ * objects use a weak cache with coordinate snapshots to detect mutations.
  *
  * @param color Color to measure.
  */
 function getRelativeLuminance( color: string | PlainColorObject ): number {
 	if ( typeof color !== 'string' ) {
 		const cachedLuminance = objectLuminanceCache.get( color );
-		if ( cachedLuminance !== undefined ) {
-			return cachedLuminance;
+		if (
+			cachedLuminance?.space === color.space &&
+			cachedLuminance.coords.every( ( coordinate, index ) =>
+				Object.is( coordinate, color.coords[ index ] )
+			)
+		) {
+			return cachedLuminance.luminance;
 		}
 		const luminance = Math.max( getLuminance( color ), 0 );
-		objectLuminanceCache.set( color, luminance );
+		objectLuminanceCache.set( color, {
+			space: color.space,
+			coords: [ ...color.coords ],
+			luminance,
+		} );
 		return luminance;
 	}
 

--- a/packages/theme/src/color-ramps/test/color-utils.test.ts
+++ b/packages/theme/src/color-ramps/test/color-utils.test.ts
@@ -1,16 +1,24 @@
-import { contrastWCAG21, sRGB, type PlainColorObject } from 'colorjs.io/fn';
-import { describe, expect, it } from 'vitest';
+import {
+	ColorSpace,
+	contrastWCAG21,
+	sRGB,
+	type PlainColorObject,
+} from 'colorjs.io/fn';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { getContrast } from '../lib/color-utils';
 
 describe( 'getContrast', () => {
+	beforeAll( () => ColorSpace.register( sRGB ) );
+
 	it.each( [
 		[ '#000000', '#ffffff' ],
 		[ '#3858e9', '#f6f7f7' ],
 		[ '#1e1e1e', '#1e1e1e' ],
 	] )( 'matches Color.js for string colors %s and %s', ( first, second ) => {
-		expect( getContrast( first, second ) ).toBe(
-			contrastWCAG21( first, second )
-		);
+		const expected = contrastWCAG21( first, second );
+
+		expect( getContrast( first, second ) ).toBe( expected );
+		expect( getContrast( first, second ) ).toBe( expected );
 	} );
 
 	it( 'matches Color.js for color objects', () => {
@@ -25,8 +33,9 @@ describe( 'getContrast', () => {
 			alpha: 1,
 		};
 
-		expect( getContrast( first, second ) ).toBe(
-			contrastWCAG21( first, second )
-		);
+		const expected = contrastWCAG21( first, second );
+
+		expect( getContrast( first, second ) ).toBe( expected );
+		expect( getContrast( first, second ) ).toBe( expected );
 	} );
 } );

--- a/packages/theme/src/color-ramps/test/color-utils.test.ts
+++ b/packages/theme/src/color-ramps/test/color-utils.test.ts
@@ -33,4 +33,23 @@ describe( 'getContrast', () => {
 		expect( actual ).toBe( expected );
 		expect( getContrast( first, second ) ).toBe( expected );
 	} );
+
+	it( 'recalculates contrast after a color object is mutated', () => {
+		const mutableColor: PlainColorObject = {
+			space: sRGB,
+			coords: [ 0, 0, 0 ],
+			alpha: 1,
+		};
+		const white: PlainColorObject = {
+			space: sRGB,
+			coords: [ 1, 1, 1 ],
+			alpha: 1,
+		};
+
+		expect( getContrast( mutableColor, white ) ).toBe( 21 );
+		mutableColor.coords[ 0 ] = 1;
+		mutableColor.coords[ 1 ] = 1;
+		mutableColor.coords[ 2 ] = 1;
+		expect( getContrast( mutableColor, white ) ).toBe( 1 );
+	} );
 } );

--- a/packages/theme/src/color-ramps/test/color-utils.test.ts
+++ b/packages/theme/src/color-ramps/test/color-utils.test.ts
@@ -1,23 +1,17 @@
-import {
-	ColorSpace,
-	contrastWCAG21,
-	sRGB,
-	type PlainColorObject,
-} from 'colorjs.io/fn';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { contrastWCAG21, sRGB, type PlainColorObject } from 'colorjs.io/fn';
+import { describe, expect, it } from 'vitest';
 import { getContrast } from '../lib/color-utils';
 
 describe( 'getContrast', () => {
-	beforeAll( () => ColorSpace.register( sRGB ) );
-
 	it.each( [
 		[ '#000000', '#ffffff' ],
 		[ '#3858e9', '#f6f7f7' ],
 		[ '#1e1e1e', '#1e1e1e' ],
 	] )( 'matches Color.js for string colors %s and %s', ( first, second ) => {
+		const actual = getContrast( first, second );
 		const expected = contrastWCAG21( first, second );
 
-		expect( getContrast( first, second ) ).toBe( expected );
+		expect( actual ).toBe( expected );
 		expect( getContrast( first, second ) ).toBe( expected );
 	} );
 
@@ -33,9 +27,10 @@ describe( 'getContrast', () => {
 			alpha: 1,
 		};
 
+		const actual = getContrast( first, second );
 		const expected = contrastWCAG21( first, second );
 
-		expect( getContrast( first, second ) ).toBe( expected );
+		expect( actual ).toBe( expected );
 		expect( getContrast( first, second ) ).toBe( expected );
 	} );
 } );

--- a/packages/theme/src/color-ramps/test/color-utils.test.ts
+++ b/packages/theme/src/color-ramps/test/color-utils.test.ts
@@ -12,7 +12,6 @@ describe( 'getContrast', () => {
 		const expected = contrastWCAG21( first, second );
 
 		expect( actual ).toBe( expected );
-		expect( getContrast( first, second ) ).toBe( expected );
 	} );
 
 	it( 'matches Color.js for color objects', () => {

--- a/packages/theme/src/color-ramps/test/color-utils.test.ts
+++ b/packages/theme/src/color-ramps/test/color-utils.test.ts
@@ -1,0 +1,32 @@
+import { contrastWCAG21, sRGB, type PlainColorObject } from 'colorjs.io/fn';
+import { describe, expect, it } from 'vitest';
+import { getContrast } from '../lib/color-utils';
+
+describe( 'getContrast', () => {
+	it.each( [
+		[ '#000000', '#ffffff' ],
+		[ '#3858e9', '#f6f7f7' ],
+		[ '#1e1e1e', '#1e1e1e' ],
+	] )( 'matches Color.js for string colors %s and %s', ( first, second ) => {
+		expect( getContrast( first, second ) ).toBe(
+			contrastWCAG21( first, second )
+		);
+	} );
+
+	it( 'matches Color.js for color objects', () => {
+		const first: PlainColorObject = {
+			space: sRGB,
+			coords: [ 0.22, 0.35, 0.91 ],
+			alpha: 1,
+		};
+		const second: PlainColorObject = {
+			space: sRGB,
+			coords: [ 0.96, 0.97, 0.97 ],
+			alpha: 1,
+		};
+
+		expect( getContrast( first, second ) ).toBe(
+			contrastWCAG21( first, second )
+		);
+	} );
+} );


### PR DESCRIPTION
Extracted from #82294 after [review feedback](https://github.com/WordPress/gutenberg/pull/82294#discussion_r3933640210).

## What?

Caches relative luminance values for reusable color objects used by the `@wordpress/theme` color-ramp contrast checks without changing their WCAG 2.1 results.

## Why?

Color-ramp generation compares the same colors more than once. `contrastWCAG21` recalculates relative luminance for every comparison. Keeping this optimization separate also makes the perceptual color-scale work in #82294 easier to review.

## How?

Calculates the existing WCAG 2.1 ratio from relative luminances. Color objects use a `WeakMap`; a cloned snapshot detects mutations before a cached value is reused. String inputs are recalculated on each call. Regression tests compare string and object results with Color.js and verify that object mutations invalidate cached values.

## Testing Instructions

Run `npm run test:unit:vitest -- packages/theme/src/color-ramps/test/color-utils.test.ts`. All five tests should pass.

## Use of AI Tools

OpenAI Codex helped extract the implementation, add tests, run verification, and draft this description. The author reviewed the result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved color contrast checks by reusing cached luminance calculations when color values remain unchanged.

- **Color Utilities**
  - Contrast calculations continue to support string and object-based colors.
  - Updated calculations now reflect changes made to color object coordinates.
  - Improved consistency of contrast ratios across supported color inputs.

- **Tests**
  - Expanded coverage for contrast results against WCAG 2.1 calculations, including repeated evaluations and mutated color objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
