### PR TITLE
CodeRabbit: Only review on request, keep PR descriptions untouched

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+    # Post the summary in CodeRabbit's own walkthrough comment rather than
+    # editing the pull request description.
+    high_level_summary_in_walkthrough: true
+    auto_review:
+        # Don't review every pull request. Reviews run when someone comments
+        # `@coderabbitai review`, or when the keyword below is in the description.
+        enabled: false
+        description_keyword: '@coderabbitai review'


### PR DESCRIPTION
## What?

Adds a `.coderabbit.yaml` so CodeRabbit no longer writes into pull request descriptions, and only reviews a pull request when it is asked to.

## Why?

CodeRabbit currently reviews every pull request automatically and edits the author's description to insert its high-level summary. Both are unwanted: the description belongs to the author, and unrequested reviews add noise to pull requests that nobody asked it to look at.

## How?

Three settings, all validated against the published `schema.v2.json`:

- `reviews.high_level_summary_in_walkthrough: true` — the summary is posted in CodeRabbit's own walkthrough comment instead of the pull request body.
- `reviews.auto_review.enabled: false` — no automatic reviews.
- `reviews.auto_review.description_keyword: '@coderabbitai review'` — reviews still run when that keyword appears in the description, alongside the usual `@coderabbitai review` comment.

Two things deliberately left alone. Auto-title needs no change, since `auto_title_placeholder` only rewrites a title that already contains `@coderabbitai`, so it is opt-in already. And `high_level_summary_placeholder` (`<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository configuration for structured code review summaries and walkthroughs.
  * Reviews are now initiated on demand rather than triggered automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->`) still works, so an author who *wants* the summary in their description can ask for it — per the schema this fires even when `high_level_summary` is false, so it is an opt-in escape hatch rather than an oversight.

## Testing Instructions

CodeRabbit reads the config from the branch under review, so this pull request is its own test case:

1. Confirm CodeRabbit did **not** post a review or edit the description of this pull request when it was opened.
2. Comment `@coderabbitai review` here, and confirm a review appears.
3. Confirm the high-level summary lands in CodeRabbit's walkthrough comment, and that the description above is still untouched.

### Testing Instructions for Keyboard

Not applicable — this changes CI tooling configuration only, with no user interface.

## Use of AI Tools

Authored with Claude Code (Opus 5). The configuration keys and their semantics were verified against CodeRabbit's published JSON schema rather than written from memory; I have reviewed the result and take responsibility for it.
