### PR TITLE
Widgets: Replace {TODO} placeholder with PR number in changelog entries

### DIFF
--- a/packages/customize-widgets/CHANGELOG.md
+++ b/packages/customize-widgets/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Error boundary: Surface debugging details ([#{TODO}](https://github.com/WordPress/gutenberg/pull/{TODO})).
+-   Error boundary: Surface debugging details ([#82099](https://github.com/WordPress/gutenberg/pull/82099)).
 
 ### Internal
 

--- a/packages/edit-widgets/CHANGELOG.md
+++ b/packages/edit-widgets/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Error boundary: Surface debugging details ([#{TODO}](https://github.com/WordPress/gutenberg/pull/{TODO})).
+-   Error boundary: Surface debugging details ([#82099](https://github.com/WordPress/gutenberg/pull/82099)).
 
 ### Bug Fixes
 


### PR DESCRIPTION
## What?

Follow-up to #82099

Replaces the `{TODO}` placeholder left in the `edit-widgets` and `customize-widgets` changelog entries with the actual PR number.

## Use of AI Tools

Claude Code was used to apply the replacement and open this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated unreleased changelog entries with the finalized pull request reference.
  - Recorded the error-boundary debugging-details enhancement in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->