### PR TITLE
Global Styles: Remove the color randomizer experiment

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -11,9 +11,6 @@
 function gutenberg_enable_experiments() {
 	global $pagenow;
 
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-color-randomizer' ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableColorRandomizer = true', 'before' );
-	}
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-grid-interactivity' ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableGridInteractivity = true', 'before' );
 	}

--- a/lib/experimental/experiments/load.php
+++ b/lib/experimental/experiments/load.php
@@ -100,11 +100,6 @@ function gutenberg_initialize_experiments_settings() {
 			'label' => _x( 'Other', 'experiments group name', 'gutenberg' ),
 			'items' => array(
 				array(
-					'id'          => 'gutenberg-color-randomizer',
-					'label'       => __( 'Color randomizer', 'gutenberg' ),
-					'description' => __( 'Enables the Global Styles color randomizer in the Site Editor; a utility that lets you mix the current color palette pseudo-randomly.', 'gutenberg' ),
-				),
-				array(
 					'id'          => 'gutenberg-workflow-palette',
 					'label'       => __( 'Workflow Palette', 'gutenberg' ),
 					'description' => __( 'Enables the Workflow Palette for running workflows composed of abilities, from a unified interface.', 'gutenberg' ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -52566,8 +52566,7 @@
 				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/ui": "file:../ui",
-				"clsx": "^2.1.1",
-				"colord": "^2.9.3"
+				"clsx": "^2.1.1"
 			},
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",

--- a/packages/global-styles-ui/CHANGELOG.md
+++ b/packages/global-styles-ui/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Internal
 
+-   Remove the experimental color randomizer from the palette editor, along with the `colord` dependency it used ([#82452](https://github.com/WordPress/gutenberg/pull/82452)).
 -   Exclude the JavaScript tests and story from the build project so their declarations are not published. ([#81516](https://github.com/WordPress/gutenberg/pull/81516))
 
 ## 1.20.0 (2026-08-12)

--- a/packages/global-styles-ui/package.json
+++ b/packages/global-styles-ui/package.json
@@ -61,8 +61,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/ui": "file:../ui",
-		"clsx": "^2.1.1",
-		"colord": "^2.9.3"
+		"clsx": "^2.1.1"
 	},
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",

--- a/packages/global-styles-ui/src/color-palette-panel.tsx
+++ b/packages/global-styles-ui/src/color-palette-panel.tsx
@@ -3,11 +3,9 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalPaletteEdit as PaletteEdit,
 	__experimentalVStack as VStack,
-	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { shuffle } from '@wordpress/icons';
-import { useSetting, useColorRandomizer } from './hooks';
+import { useSetting } from './hooks';
 import ColorVariations from './variations/variations-color';
 
 const mobilePopoverProps = { placement: 'bottom-start' as const, offset: 8 };
@@ -48,35 +46,18 @@ export default function ColorPalettePanel( { name }: ColorPalettePanelProps ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
 
-	const [ randomizeThemeColors ] = useColorRandomizer( name );
-
 	return (
 		<VStack className="global-styles-ui-color-palette-panel" spacing={ 8 }>
-			{ /* Both children need theme colors, so without them the wrapper
-			   renders empty and still takes a slot in the parent's gap. */ }
 			{ !! themeColors?.length && (
-				<VStack spacing={ 4 }>
-					<PaletteEdit
-						canReset={ themeColors !== baseThemeColors }
-						canOnlyChangeValues
-						colors={ themeColors }
-						onChange={ setThemeColors }
-						paletteLabel={ __( 'Theme' ) }
-						paletteLabelHeadingLevel={ 3 }
-						popoverProps={ popoverProps }
-					/>
-					{ ( window as any ).__experimentalEnableColorRandomizer &&
-						randomizeThemeColors && (
-							<Button
-								__next40pxDefaultSize
-								variant="secondary"
-								icon={ shuffle }
-								onClick={ randomizeThemeColors }
-							>
-								{ __( 'Randomize colors' ) }
-							</Button>
-						) }
-				</VStack>
+				<PaletteEdit
+					canReset={ themeColors !== baseThemeColors }
+					canOnlyChangeValues
+					colors={ themeColors }
+					onChange={ setThemeColors }
+					paletteLabel={ __( 'Theme' ) }
+					paletteLabelHeadingLevel={ 3 }
+					popoverProps={ popoverProps }
+				/>
 			) }
 			{ !! defaultColors &&
 				!! defaultColors.length &&

--- a/packages/global-styles-ui/src/hooks.ts
+++ b/packages/global-styles-ui/src/hooks.ts
@@ -1,5 +1,3 @@
-import { colord, extend } from 'colord';
-import a11yPlugin from 'colord/plugins/a11y';
 import { useCallback, useContext, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -15,13 +13,9 @@ import {
 import type {
 	GlobalStylesConfig,
 	StyleVariation,
-	Color,
 } from '@wordpress/global-styles-engine';
 import { GlobalStylesContext } from './context';
 import { removePropertiesFromObject, isVariationWithProperties } from './utils';
-
-// Enable colord's a11y plugin.
-extend( [ a11yPlugin ] );
 
 /**
  * Hook to get and set style values with memoization.
@@ -249,45 +243,6 @@ export function useColorVariations(): StyleVariation[] {
 	return useCurrentMergeThemeStyleVariationsWithUserConfig(
 		propertiesToFilter
 	);
-}
-
-/**
- * Hook to randomize theme colors using color rotation.
- *
- * @param blockName The name of the block, if applicable.
- * @return Array containing the randomize function if feature is enabled, empty array otherwise.
- */
-export function useColorRandomizer( blockName?: string ): [ () => void ] | [] {
-	const [ themeColors, setThemeColors ] = useSetting< Color[] >(
-		'color.palette.theme',
-		blockName
-	);
-
-	const randomizeColors = useCallback( () => {
-		if ( ! themeColors || ! themeColors.length ) {
-			return;
-		}
-
-		const randomRotationValue = Math.floor( Math.random() * 225 );
-
-		const newColors = themeColors.map( ( colorObject ) => {
-			const { color } = colorObject;
-			const newColor = colord( color )
-				.rotate( randomRotationValue )
-				.toHex();
-
-			return {
-				...colorObject,
-				color: newColor,
-			};
-		} );
-
-		setThemeColors( newColors );
-	}, [ themeColors, setThemeColors ] );
-
-	return ( window as any ).__experimentalEnableColorRandomizer
-		? [ randomizeColors ]
-		: [];
 }
 
 /**


### PR DESCRIPTION
## What?

Removes the color randomizer experiment and all of the code behind it.

> **Note:** this PR started out as "stabilize the color randomizer". Following the review discussion, it now removes the feature instead.

## Why?

The randomizer has been an experiment since #40988 (Gutenberg 14.6, November 2022) and has not gathered much positive feedback since. Two known issues were never addressed: #47296 and #47292. The mechanism, a single random hue rotation applied to the whole theme palette, also has structural problems that would need real design work before it could ship: it does not preserve contrast between palette colors, it leaves theme gradients and duotone presets out of sync with the rotated palette, and any palette entry colord cannot parse (for example a `var()` reference) is turned into black. Rather than carry an unfinished experiment indefinitely, this removes it. A better-designed version can come back as a fresh proposal.

## How?

- Removes the experiment entry from `lib/experimental/experiments/load.php` and the `window.__experimentalEnableColorRandomizer` inline script from `lib/experimental/editor-settings.php`.
- Removes the `useColorRandomizer` hook from `@wordpress/global-styles-ui` and the "Randomize colors" button from `ColorPalettePanel`. The theme `PaletteEdit` keeps the "only render with theme colors" guard from #81894; the inner wrapper is gone since it only existed to hold the button.
- Drops the `colord` dependency from `@wordpress/global-styles-ui` (the hook was its only consumer) and updates `package-lock.json` accordingly.
- Adds a changelog entry.

The panel lives in `@wordpress/global-styles-ui`, which is shared by both the site editor and the extensible site editor, so both are covered.

## Testing Instructions

1. Confirm "Color randomizer" is no longer listed under Gutenberg > Experiments.
2. Open the site editor, go to Styles > Colors, and open the palette editor.
3. Confirm the Theme, Default, and Custom palettes still render and edit as before, and that no "Randomize colors" button is shown.
4. Confirm the Theme palette is hidden when the active theme defines no palette, with no extra gap left behind.
5. Repeat in the extensible site editor (`gutenberg-extensible-site-editor` experiment).

## Testing Instructions for Keyboard

No new interactions. Tab through the palette editor and confirm focus order is unchanged.

## Screenshots or screencast

None: the only visible change is the removal of an experiment-gated button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
