### PR TITLE
Menu: Correct alignment documentation and changelog

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+-   `Menu`: `--wp-ui-menu-selection-indicator-size` now controls the selection indicator width only. Its height follows the item label line height. ([#82346](https://github.com/WordPress/gutenberg/pull/82346))
 -   `Autocomplete.Popup`, `Combobox.Popup`, `Select.Popup`, `SearchableChipSelect`, and `SearchableChipSelectControl`: The popup now defaults to a fixed anchor width. Use `width="content"` on Popups, or `popupWidth="content"` on composites, to restore content-sized width between the anchor and available viewport bounds ([#82087](https://github.com/WordPress/gutenberg/pull/82087), [#82193](https://github.com/WordPress/gutenberg/pull/82193)).
 -   Portaled overlays (`AlertDialog`, `Autocomplete`, `Combobox`, `Dialog`, `Drawer`, `Menu`, `Popover`, and `Select`) now inherit the theme from their portal destination instead of re-emitting the trigger's nearest contextual theme. Default portals use the document root theme; custom portal containers use their DOM ancestry ([#82038](https://github.com/WordPress/gutenberg/pull/82038)).
 
@@ -12,7 +13,6 @@
 -   Add a responsive `Breadcrumb` navigation component. ([#80425](https://github.com/WordPress/gutenberg/pull/80425))
 -   Add `SearchableSelect` form primitive ([#80961](https://github.com/WordPress/gutenberg/pull/80961)).
 -   Add `Field.VisualLabel` for a purely visual label outside `Field.Root` ([#82095](https://github.com/WordPress/gutenberg/pull/82095)).
--   Add a responsive `Breadcrumb` navigation component. ([#80425](https://github.com/WordPress/gutenberg/pull/80425))
 -   `Menu`: Add `PrefixIcon` for label-aligned prefix icons, with a default size of 24px. ([#82346](https://github.com/WordPress/gutenberg/pull/82346))
 
 ### Enhancements

--- a/packages/ui/src/menu/stories/usage-guidelines.mdx
+++ b/packages/ui/src/menu/stories/usage-guidelines.mdx
@@ -71,7 +71,7 @@ import { Menu } from '@wordpress/ui';
 
 The prefix slot already hides its contents from assistive technology. Keep meaningful text in `Menu.ItemLabel` or `Menu.ItemDescription`.
 
-Other non-interactive React content can still be passed directly to `prefix`. It retains its natural height. In described items, it aligns with the top of the label; in single-line items, it remains vertically centered. `Menu.PrefixIcon` does not change the sizing of other prefix content.
+Other non-interactive React content can still be passed directly to `prefix`. It retains its natural height and starts at the top of the item. `Menu.PrefixIcon` does not change the sizing of other prefix content.
 
 ## Use an ellipsis for actions that need more input
 


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/82346

## What?

Corrects the `Menu` usage guidelines and `@wordpress/ui` changelog after post-merge review.

## Why?

The guidelines incorrectly said arbitrary prefix content remains vertically centered in single-line items. The changelog also duplicated the `Breadcrumb` entry and did not classify the changed behavior of a public Menu CSS custom property as breaking.

## How?

States that arbitrary prefix content starts at the top of the item, removes the duplicate changelog entry, and records that `--wp-ui-menu-selection-indicator-size` now controls only the indicator width.

## Testing Instructions

1. Open **Design System > Components > Menu > Usage Guidelines** in Storybook.
2. In **Add prefix icons**, confirm the guidance says arbitrary prefix content keeps its natural height and starts at the top of the item.
3. Check `packages/ui/CHANGELOG.md`. Confirm there is one `Breadcrumb` entry and the Menu custom-property change is listed under **Breaking Changes**.

### Testing Instructions for Keyboard

Not applicable. This PR changes documentation and release notes only.

## Use of AI Tools

Codex was used to assess the feedback, update the documentation and changelog, and run verification.
