### PR TITLE
Site editor v2: template parts take view config from endpoint

### DIFF
--- a/packages/views/CHANGELOG.md
+++ b/packages/views/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `useViewConfig`: request the full configuration under the same cache key as `getViewConfig( kind, name )`, so a route loader that preloads it no longer triggers a second request. ([#82141](https://github.com/WordPress/gutenberg/pull/82141))
+-   `useView`, `loadView`: ignore a persisted layout `type` that `defaultLayouts` does not offer, resolving the type out of the layers below instead. DataViews renders nothing for a layout it is not given, so a preference saved when a screen still offered that layout used to leave the screen empty, with no way to reset it. Such a type does not count as a modification and is written out of the preference on the next update. ([#82457](https://github.com/WordPress/gutenberg/pull/82457))
 
 ## 1.21.0 (2026-08-26)
 

--- a/packages/views/src/resolve-view.ts
+++ b/packages/views/src/resolve-view.ts
@@ -150,6 +150,38 @@ interface ResolveViewArgs extends ViewLayers {
 }
 
 /**
+ * The user's persisted modifications that still apply.
+ *
+ * A persisted `type` that `defaultLayouts` does not offer is dropped: DataViews
+ * renders nothing for a layout it is not given, and the preference may predate
+ * the current set of layouts (a screen that used to offer the list layout, say,
+ * and no longer does). The type then resolves out of the layers below, and the
+ * other modifications are kept. Without `defaultLayouts` every type is offered.
+ *
+ * `true` is a valid entry, so the check mirrors DataViews': an entry counts as
+ * long as it is truthy.
+ *
+ * @param persistedView  The user's persisted modifications.
+ * @param defaultLayouts The layouts on offer, keyed by layout type.
+ * @return The modifications that apply, or `undefined` when there are none.
+ */
+export function getApplicablePersistedView(
+	persistedView: ViewOverrides | undefined,
+	defaultLayouts: SupportedLayouts | undefined
+): ViewOverrides | undefined {
+	if (
+		! persistedView ||
+		persistedView.type === undefined ||
+		! defaultLayouts ||
+		defaultLayouts[ persistedView.type as keyof SupportedLayouts ]
+	) {
+		return persistedView;
+	}
+	const { type, ...rest } = persistedView;
+	return Object.keys( rest ).length > 0 ? rest : undefined;
+}
+
+/**
  * Resolves the layers below the user's modifications — what a modification has
  * to differ from to count as one. The layout type selects which entry of
  * `defaultLayouts` applies, so the base only makes sense relative to a type.
@@ -181,15 +213,19 @@ function resolveBaseView(
  * 1. `defaultView`
  * 2. `defaultLayouts` (for the effective type)
  * 3. `activeViewOverrides`
- * 4. the user's persisted modifications
+ * 4. the user's persisted modifications (see `getApplicablePersistedView`)
  * 5. the URL query params (`page` and `search` only)
  *
  * @param args See `ResolveViewArgs`.
  * @return The resolved `view`.
  */
 export function resolveView( args: ResolveViewArgs ): View {
-	const { defaultView, activeViewOverrides, persistedView, page, search } =
+	const { defaultView, defaultLayouts, activeViewOverrides, page, search } =
 		args;
+	const persistedView = getApplicablePersistedView(
+		args.persistedView,
+		defaultLayouts
+	);
 
 	// Resolve the effective layout type first: it selects which entry of
 	// `defaultLayouts` applies, and the layers above the layouts may change it.
@@ -229,6 +265,10 @@ export function resolveView( args: ResolveViewArgs ): View {
  * already provide, which then linger as phantom modifications after switching
  * back.
  *
+ * A persisted `type` the current layouts do not offer never applied (see
+ * `getApplicablePersistedView`), so it is not carried over either: the
+ * modifications returned replace it with whatever the user picked.
+ *
  * @param newView The view the user produced.
  * @param layers  The layers the view resolves from. See `ViewLayers`.
  * @return The modified properties, or `undefined` when the user modified none.
@@ -237,7 +277,11 @@ export function getUserModifications(
 	newView: View,
 	layers: ViewLayers
 ): ViewOverrides | undefined {
-	const { activeViewOverrides, persistedView } = layers;
+	const { defaultLayouts, activeViewOverrides } = layers;
+	const persistedView = getApplicablePersistedView(
+		layers.persistedView,
+		defaultLayouts
+	);
 	const baseView = resolveBaseView( layers, newView.type );
 
 	const modifications = diffLayer(

--- a/packages/views/src/test/resolve-view.ts
+++ b/packages/views/src/test/resolve-view.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { View } from '@wordpress/dataviews';
-import { getUserModifications, resolveView } from '../resolve-view';
+import {
+	getApplicablePersistedView,
+	getUserModifications,
+	resolveView,
+} from '../resolve-view';
 
 const LOCKED = {
 	field: 'author',
@@ -60,5 +64,104 @@ describe( 'locked filters', () => {
 		expect(
 			getUserModifications( view, { defaultView, activeViewOverrides } )
 		).toBeUndefined();
+	} );
+} );
+
+// A preference may carry a `type` the screen no longer offers, because it
+// predates the current `defaultLayouts` (a screen that used to offer the list
+// layout, say). DataViews renders nothing for a type it is not given, so such a
+// type is ignored and the layers below decide.
+describe( 'persisted type the layouts do not offer', () => {
+	const defaultView = { type: 'table', perPage: 20 } as unknown as View;
+	const defaultLayouts = { table: { perPage: 50 }, grid: true as const };
+
+	it( 'should resolve the type out of the layers below', () => {
+		const view = resolveView( {
+			defaultView,
+			defaultLayouts,
+			persistedView: { type: 'list' },
+		} );
+		expect( view.type ).toBe( 'table' );
+		expect( view.perPage ).toBe( 50 );
+	} );
+
+	it( 'should keep the other persisted modifications', () => {
+		const view = resolveView( {
+			defaultView,
+			defaultLayouts,
+			persistedView: { type: 'list', perPage: 10 },
+		} );
+		expect( view ).toMatchObject( { type: 'table', perPage: 10 } );
+	} );
+
+	it( 'should prefer the type an override sets over the default view', () => {
+		const view = resolveView( {
+			defaultView,
+			defaultLayouts,
+			activeViewOverrides: { type: 'grid' },
+			persistedView: { type: 'list' },
+		} );
+		expect( view.type ).toBe( 'grid' );
+	} );
+
+	it( 'should honor a persisted type with a `true` layout entry', () => {
+		const view = resolveView( {
+			defaultView,
+			defaultLayouts,
+			persistedView: { type: 'grid' },
+		} );
+		expect( view.type ).toBe( 'grid' );
+	} );
+
+	it( 'should honor any persisted type without default layouts', () => {
+		const view = resolveView( {
+			defaultView,
+			persistedView: { type: 'list' },
+		} );
+		expect( view.type ).toBe( 'list' );
+	} );
+
+	it( 'should not carry the type over to the next modifications', () => {
+		const layers = {
+			defaultView,
+			defaultLayouts,
+			persistedView: { type: 'list' as const },
+		};
+		const view = resolveView( layers );
+		expect( getUserModifications( view, layers ) ).toBeUndefined();
+		expect(
+			getUserModifications( { ...view, perPage: 10 } as View, layers )
+		).toEqual( { perPage: 10 } );
+	} );
+
+	describe( 'getApplicablePersistedView', () => {
+		it( 'should drop the type and keep the rest', () => {
+			expect(
+				getApplicablePersistedView(
+					{ type: 'list', perPage: 10 },
+					defaultLayouts
+				)
+			).toEqual( { perPage: 10 } );
+		} );
+
+		it( 'should return `undefined` when the type was the only modification', () => {
+			expect(
+				getApplicablePersistedView( { type: 'list' }, defaultLayouts )
+			).toBeUndefined();
+		} );
+
+		it( 'should return the preference as is when its type is offered', () => {
+			const persistedView = { type: 'grid' as const, perPage: 10 };
+			expect(
+				getApplicablePersistedView( persistedView, defaultLayouts )
+			).toBe( persistedView );
+		} );
+
+		it( 'should return the preference as is without default layouts', () => {
+			const persistedView = { type: 'list' as const };
+			expect(
+				getApplicablePersistedView( persistedView, undefined )
+			).toBe( persistedView );
+		} );
 	} );
 } );

--- a/packages/views/src/test/use-view.jsdom.test.tsx
+++ b/packages/views/src/test/use-view.jsdom.test.tsx
@@ -153,7 +153,10 @@ describe( 'useView', () => {
 			const { result } = renderUseView( registry, {
 				...BASE_PROPS,
 				defaultView: { type: 'list', perPage: 20 },
-				defaultLayouts: { table: { perPage: 50 } },
+				defaultLayouts: {
+					table: { perPage: 50 },
+					grid: { perPage: 40 },
+				},
 				activeViewOverrides: {
 					type: 'table',
 					perPage: 10,
@@ -257,6 +260,62 @@ describe( 'useView', () => {
 				defaultLayouts: { table: true },
 			} as unknown as Parameters< typeof useView >[ 0 ] );
 			expect( result.current.view.perPage ).toBe( 20 );
+		} );
+
+		// DataViews renders nothing for a type it is not given, and the
+		// preference may predate the current layouts.
+		describe( 'a persisted type the default layouts do not offer', () => {
+			const props = {
+				...BASE_PROPS,
+				defaultView: { type: 'table', perPage: 20 },
+				defaultLayouts: { table: { perPage: 50 }, grid: true },
+			} as unknown as Parameters< typeof useView >[ 0 ];
+
+			it( 'should be ignored in favor of the layers below', () => {
+				const registry = createTestRegistry();
+				setPreference( registry, { type: 'list', perPage: 10 } );
+				const { result } = renderUseView( registry, props );
+				expect( result.current.view ).toMatchObject( {
+					type: 'table',
+					perPage: 10,
+				} );
+			} );
+
+			it( 'should not count as a modification', () => {
+				const registry = createTestRegistry();
+				setPreference( registry, { type: 'list' } );
+				const { result } = renderUseView( registry, props );
+				expect( result.current.isModified ).toBe( false );
+			} );
+
+			it( 'should be written out of the preference on the next update', () => {
+				const registry = createTestRegistry();
+				setPreference( registry, { type: 'list' } );
+				const { result, rerender } = renderUseView( registry, props );
+				act( () => {
+					result.current.updateView( {
+						...result.current.view,
+						perPage: 10,
+					} );
+				} );
+				rerender( props );
+
+				expect( getPreference( registry ) ).toEqual( { perPage: 10 } );
+				expect( result.current.isModified ).toBe( true );
+			} );
+
+			it( 'should be cleared from the preference by an update that changes nothing', () => {
+				const registry = createTestRegistry();
+				setPreference( registry, { type: 'list' } );
+				const { result, rerender } = renderUseView( registry, props );
+				act( () => {
+					result.current.updateView( result.current.view );
+				} );
+				rerender( props );
+
+				expect( getPreference( registry ) ).toBeUndefined();
+				expect( result.current.isModified ).toBe( false );
+			} );
 		} );
 
 		it( 'should ignore a missing layout entry for the effective type', () => {

--- a/packages/views/src/use-view.ts
+++ b/packages/views/src/use-view.ts
@@ -4,7 +4,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import type { View } from '@wordpress/dataviews';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { generatePreferenceKey } from './preference-keys';
-import { getUserModifications, resolveView } from './resolve-view';
+import {
+	getApplicablePersistedView,
+	getUserModifications,
+	resolveView,
+} from './resolve-view';
 import type { ViewConfig, ViewOverrides } from './types';
 
 interface UseViewReturn {
@@ -73,8 +77,15 @@ export function useView( config: ViewConfig ): UseViewReturn {
 		]
 	);
 
+	// A persisted `type` the layouts do not offer is ignored on read, so it
+	// does not count as a modification either: there is nothing to reset.
+	const applicablePersistedView = getApplicablePersistedView(
+		persistedView,
+		defaultLayouts
+	);
 	const isModified =
-		!! persistedView && Object.keys( persistedView ).length > 0;
+		!! applicablePersistedView &&
+		Object.keys( applicablePersistedView ).length > 0;
 
 	const updateView = useCallback(
 		( newView: View ) => {
@@ -97,6 +108,8 @@ export function useView( config: ViewConfig ): UseViewReturn {
 				activeViewOverrides,
 				persistedView,
 			} );
+			// Compared against the preference as stored, so a persisted `type`
+			// the layouts do not offer is written out on the first update.
 			if ( ! dequal( modifications, persistedView ) ) {
 				// `undefined` clears the preference: the user reverted every
 				// property they had modified.

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -5,10 +5,10 @@ import {
 	Link,
 	useInvalidate,
 } from '@wordpress/route';
-import { useView } from '@wordpress/views';
+import { useView, useViewConfig } from '@wordpress/views';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { Page } from '@wordpress/admin-ui';
-import type { View, Action } from '@wordpress/dataviews';
+import type { View, Action, SupportedLayouts } from '@wordpress/dataviews';
 import {
 	store as coreStore,
 	privateApis as coreDataPrivateApis,
@@ -24,10 +24,11 @@ import type { WpTemplatePart } from '@wordpress/core-data';
 import { CreateTemplatePartModal } from '@wordpress/fields';
 import { unlock } from '@wordpress/routes-lock-unlock';
 import {
-	DEFAULT_VIEW,
-	getActiveViewOverridesForTab,
-	DEFAULT_VIEWS,
+	getActiveViewOverrides,
+	getAreaFromViewOverrides,
 	viewToQuery,
+	type ViewListEntry,
+	type ViewOverrides,
 } from './view-utils';
 import { previewField } from './fields/preview';
 // Unlock WordPress private APIs
@@ -39,20 +40,73 @@ const { Tabs } = unlock( componentsPrivateApis );
  */
 import './style.scss';
 
+const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
+
 function getItemId( item: WpTemplatePart ) {
 	return item.id.toString();
 }
 
 function TemplatePartList() {
-	const invalidate = useInvalidate();
-	const { area = 'all' } = useParams( {
+	// The `area` param is the slug of the active view: either the "all"
+	// entry of the view list or one of the template part areas.
+	const { area } = useParams( {
 		from: '/template-parts/list/$area',
 	} );
+	const {
+		default_view: defaultView,
+		default_layouts: defaultLayouts,
+		view_list: viewList,
+	} = useViewConfig( {
+		kind: 'postType',
+		name: TEMPLATE_PART_POST_TYPE,
+	} );
+	const activeViewOverrides = useMemo(
+		() => getActiveViewOverrides( viewList, area ),
+		[ viewList, area ]
+	);
+
+	if ( ! defaultView ) {
+		// The route canvas resolves the view configuration before the stage
+		// mounts, so this only guards against the store being reset.
+		return null;
+	}
+
+	return (
+		<TemplatePartListView
+			activeView={ area }
+			defaultView={ defaultView }
+			defaultLayouts={ defaultLayouts }
+			viewList={ viewList }
+			activeViewOverrides={ activeViewOverrides }
+		/>
+	);
+}
+
+function TemplatePartListView( {
+	activeView,
+	defaultView,
+	defaultLayouts,
+	viewList,
+	activeViewOverrides,
+}: {
+	activeView: string;
+	defaultView: View;
+	defaultLayouts: SupportedLayouts | undefined;
+	viewList: ViewListEntry[] | undefined;
+	activeViewOverrides: ViewOverrides;
+} ) {
+	const invalidate = useInvalidate();
 	const navigate = useNavigate();
 	const searchParams = useSearch( { from: '/template-parts/list/$area' } );
 	const postTypeObject = useSelect(
-		( select ) => select( coreStore ).getPostType( 'wp_template_part' ),
+		( select ) =>
+			select( coreStore ).getPostType( TEMPLATE_PART_POST_TYPE ),
 		[]
+	);
+	// The area the active view is locked to, if any.
+	const area = useMemo(
+		() => getAreaFromViewOverrides( activeViewOverrides ),
+		[ activeViewOverrides ]
 	);
 
 	const labels = postTypeObject?.labels;
@@ -60,20 +114,13 @@ function TemplatePartList() {
 		( select ) =>
 			select( coreStore ).canUser( 'create', {
 				kind: 'postType',
-				name: 'wp_template_part',
+				name: TEMPLATE_PART_POST_TYPE,
 			} ),
 		[]
 	);
 
 	const [ showTemplatePartModal, setShowTemplatePartModal ] =
 		useState( false );
-
-	const defaultView = DEFAULT_VIEW;
-
-	const activeViewOverrides = useMemo(
-		() => getActiveViewOverridesForTab( area ),
-		[ area ]
-	);
 
 	// Callback to handle URL query parameter changes
 	const handleQueryParamsChange = useCallback(
@@ -91,9 +138,10 @@ function TemplatePartList() {
 	// Use the new view persistence hook
 	const { view, isModified, updateView, resetToDefault } = useView( {
 		kind: 'postType',
-		name: 'wp_template_part',
+		name: TEMPLATE_PART_POST_TYPE,
 		slug: 'default-new',
 		defaultView,
+		defaultLayouts,
 		activeViewOverrides,
 		queryParams: searchParams,
 		onChangeQueryParams: handleQueryParamsChange,
@@ -116,12 +164,12 @@ function TemplatePartList() {
 	const postTypeQuery = useMemo( () => viewToQuery( view ), [ view ] );
 	const { records, isResolving } = useEntityRecordsWithPermissions(
 		'postType',
-		'wp_template_part',
+		TEMPLATE_PART_POST_TYPE,
 		postTypeQuery
 	);
 
 	const allFields = usePostFields( {
-		postType: 'wp_template_part',
+		postType: TEMPLATE_PART_POST_TYPE,
 	} );
 
 	// Hide area column except in 'All' tab, hide status, and disable area filtering
@@ -130,7 +178,7 @@ function TemplatePartList() {
 			allFields
 				.filter( ( field: { id: string } ) => {
 					// Hide area column in specific area tabs
-					if ( field.id === 'area' && area !== 'all' ) {
+					if ( field.id === 'area' && area ) {
 						return false;
 					}
 					// Hide status - template parts don't use status
@@ -183,7 +231,7 @@ function TemplatePartList() {
 	);
 
 	const postTypeActions: Action< WpTemplatePart >[] = usePostActions( {
-		postType: 'wp_template_part',
+		postType: TEMPLATE_PART_POST_TYPE,
 		context: 'list',
 		onActionPerformed: ( actionId: string, items: WpTemplatePart[] ) => {
 			// Clean up URL when delete actions are performed
@@ -212,9 +260,9 @@ function TemplatePartList() {
 	}, [ postTypeActions ] );
 
 	const handleTabChange = useCallback(
-		( areaSlug: string ) => {
+		( viewSlug: string ) => {
 			navigate( {
-				to: `/template-parts/list/${ areaSlug }`,
+				to: `/template-parts/list/${ viewSlug }`,
 			} );
 		},
 		[ navigate ]
@@ -256,23 +304,21 @@ function TemplatePartList() {
 			}
 			hasPadding={ false }
 		>
-			{ DEFAULT_VIEWS.length > 1 && (
+			{ viewList && viewList.length > 1 && (
 				<div className="routes-template-part-list__tabs-wrapper">
 					<Tabs
 						onSelect={ handleTabChange }
-						selectedTabId={ area ?? 'all' }
+						selectedTabId={ activeView }
 					>
 						<Tabs.TabList>
-							{ DEFAULT_VIEWS.map(
-								( filter: { slug: string; label: string } ) => (
-									<Tabs.Tab
-										tabId={ filter.slug }
-										key={ filter.slug }
-									>
-										{ filter.label }
-									</Tabs.Tab>
-								)
-							) }
+							{ viewList.map( ( entry ) => (
+								<Tabs.Tab
+									tabId={ entry.slug }
+									key={ entry.slug }
+								>
+									{ entry.title }
+								</Tabs.Tab>
+							) ) }
 						</Tabs.TabList>
 					</Tabs>
 				</div>
@@ -285,6 +331,7 @@ function TemplatePartList() {
 				actions={ actions }
 				isLoading={ isResolving }
 				paginationInfo={ paginationInfo }
+				defaultLayouts={ defaultLayouts }
 				getItemId={ getItemId }
 				selection={ selection }
 				onReset={ isModified ? onReset : false }
@@ -332,7 +379,7 @@ function TemplatePartList() {
 						} );
 					} }
 					onError={ () => setShowTemplatePartModal( false ) }
-					defaultArea={ area !== 'all' ? area : 'uncategorized' }
+					defaultArea={ area ?? 'uncategorized' }
 				/>
 			) }
 		</Page>

--- a/routes/template-part-list/stage.tsx
+++ b/routes/template-part-list/stage.tsx
@@ -24,7 +24,6 @@ import type { WpTemplatePart } from '@wordpress/core-data';
 import { CreateTemplatePartModal } from '@wordpress/fields';
 import { unlock } from '@wordpress/routes-lock-unlock';
 import {
-	getActiveViewOverrides,
 	getAreaFromViewOverrides,
 	viewToQuery,
 	type ViewListEntry,
@@ -61,7 +60,7 @@ function TemplatePartList() {
 		name: TEMPLATE_PART_POST_TYPE,
 	} );
 	const activeViewOverrides = useMemo(
-		() => getActiveViewOverrides( viewList, area ),
+		() => viewList?.find( ( v ) => v.slug === area )?.view ?? {},
 		[ viewList, area ]
 	);
 

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -1,86 +1,103 @@
 import { loadView } from '@wordpress/views';
-import type { View, Filter } from '@wordpress/dataviews';
+import { resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import type { View, SupportedLayouts } from '@wordpress/dataviews';
+import { unlock } from '@wordpress/routes-lock-unlock';
+
+const TEMPLATE_PART_POST_TYPE = 'wp_template_part';
 
 /**
- * Navigation overlay template part area constant.
- * This should match NAVIGATION_OVERLAY_TEMPLATE_PART_AREA in
- * packages/block-library/src/navigation/constants.js
+ * A layer merged on top of a view. Mirrors the `ViewOverrides` type of
+ * `@wordpress/views`, which is not exported.
  */
-const NAVIGATION_OVERLAY_TEMPLATE_PART_AREA = 'navigation-overlay';
-
-export const DEFAULT_VIEW: View = {
-	type: 'grid' as const,
-	sort: {
-		field: 'date',
-		direction: 'desc' as const,
-	},
-	fields: [],
-	titleField: 'title',
-	mediaField: 'preview',
+export type ViewOverrides = Partial< Omit< View, 'type' | 'layout' > > & {
+	type?: View[ 'type' ];
+	layout?: Record< string, unknown >;
 };
 
-export const DEFAULT_VIEWS: {
+export interface ViewListEntry {
+	title: string;
 	slug: string;
-	label: string;
-}[] = [
-	{
-		slug: 'all',
-		label: 'All Template Parts',
-	},
-	{
-		slug: 'header',
-		label: 'Headers',
-	},
-	{
-		slug: 'footer',
-		label: 'Footers',
-	},
-	{
-		slug: 'sidebar',
-		label: 'Sidebars',
-	},
-	{
-		slug: NAVIGATION_OVERLAY_TEMPLATE_PART_AREA,
-		label: 'Overlays',
-	},
-	{
-		slug: 'uncategorized',
-		label: 'General',
-	},
-];
+	view?: ViewOverrides;
+}
 
-type ActiveViewOverrides = {
-	filters?: Filter[];
-	sort?: View[ 'sort' ];
-};
+interface EntityViewConfig {
+	default_view: View | undefined;
+	default_layouts: SupportedLayouts | undefined;
+	view_list: ViewListEntry[] | undefined;
+}
 
-export function getActiveViewOverridesForTab(
-	area: string
-): ActiveViewOverrides {
-	if ( area === 'all' ) {
-		return {};
-	}
+/**
+ * Resolves the server-provided view configuration for the template part
+ * post type, for use in the route loader that runs outside React (where
+ * `useViewConfig` is unavailable).
+ *
+ * @return The entity view configuration.
+ */
+export async function loadTemplatePartViewConfig(): Promise< EntityViewConfig > {
+	const config = await unlock( resolveSelect( coreStore ) ).getViewConfig(
+		'postType',
+		TEMPLATE_PART_POST_TYPE
+	);
 	return {
-		filters: [
-			{
-				field: 'area',
-				operator: 'is',
-				value: area,
-			},
-		],
+		default_view: config?.default_view,
+		default_layouts: config?.default_layouts,
+		view_list: config?.view_list,
 	};
 }
 
+/**
+ * Returns the view overrides of the entry in the view list matching the
+ * given slug, or an empty object when there is none.
+ *
+ * @param viewList The `view_list` of an entity view configuration.
+ * @param slug     Slug of the active view.
+ * @return The view overrides for the active view.
+ */
+export function getActiveViewOverrides(
+	viewList: ViewListEntry[] | undefined,
+	slug: string
+): ViewOverrides {
+	return viewList?.find( ( v ) => v.slug === slug )?.view ?? {};
+}
+
+/**
+ * Returns the template part area the given view overrides lock the list to,
+ * or `undefined` when they list every area.
+ *
+ * @param viewOverrides The view overrides of the active view.
+ * @return The template part area, if any.
+ */
+export function getAreaFromViewOverrides(
+	viewOverrides: ViewOverrides
+): string | undefined {
+	const areaFilter = viewOverrides.filters?.find(
+		( filter ) => filter.field === 'area'
+	);
+	return typeof areaFilter?.value === 'string' ? areaFilter.value : undefined;
+}
+
 export async function ensureView(
-	area?: string,
+	area: string,
 	search?: { page?: number; search?: string }
 ) {
+	const {
+		default_view: defaultView,
+		default_layouts: defaultLayouts,
+		view_list: viewList,
+	} = await loadTemplatePartViewConfig();
+	if ( ! defaultView ) {
+		throw new Error(
+			`Missing view configuration for the ${ TEMPLATE_PART_POST_TYPE } post type.`
+		);
+	}
 	return loadView( {
 		kind: 'postType',
-		name: 'wp_template_part',
+		name: TEMPLATE_PART_POST_TYPE,
 		slug: 'default-new',
-		defaultView: DEFAULT_VIEW,
-		activeViewOverrides: getActiveViewOverridesForTab( area ?? 'all' ),
+		defaultView,
+		defaultLayouts,
+		activeViewOverrides: getActiveViewOverrides( viewList, area ),
 		queryParams: search,
 	} );
 }

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -63,7 +63,12 @@ export function getActiveViewOverrides(
 
 /**
  * Returns the template part area the given view overrides lock the list to,
- * or `undefined` when they list every area.
+ * or `undefined` when they do not.
+ *
+ * Only a locked `area` filter counts: it is the one the user cannot change,
+ * so the list can hide the area column and preselect the area for a new
+ * template part. An editable area filter is a starting point the user may
+ * clear or change, not a lock.
  *
  * @param viewOverrides The view overrides of the active view.
  * @return The template part area, if any.
@@ -72,7 +77,7 @@ export function getAreaFromViewOverrides(
 	viewOverrides: ViewOverrides
 ): string | undefined {
 	const areaFilter = viewOverrides.filters?.find(
-		( filter ) => filter.field === 'area'
+		( filter ) => filter.field === 'area' && filter.isLocked
 	);
 	return typeof areaFilter?.value === 'string' ? areaFilter.value : undefined;
 }

--- a/routes/template-part-list/view-utils.ts
+++ b/routes/template-part-list/view-utils.ts
@@ -47,21 +47,6 @@ export async function loadTemplatePartViewConfig(): Promise< EntityViewConfig > 
 }
 
 /**
- * Returns the view overrides of the entry in the view list matching the
- * given slug, or an empty object when there is none.
- *
- * @param viewList The `view_list` of an entity view configuration.
- * @param slug     Slug of the active view.
- * @return The view overrides for the active view.
- */
-export function getActiveViewOverrides(
-	viewList: ViewListEntry[] | undefined,
-	slug: string
-): ViewOverrides {
-	return viewList?.find( ( v ) => v.slug === slug )?.view ?? {};
-}
-
-/**
  * Returns the template part area the given view overrides lock the list to,
  * or `undefined` when they do not.
  *
@@ -102,7 +87,8 @@ export async function ensureView(
 		slug: 'default-new',
 		defaultView,
 		defaultLayouts,
-		activeViewOverrides: getActiveViewOverrides( viewList, area ),
+		activeViewOverrides:
+			viewList?.find( ( v ) => v.slug === area )?.view ?? {},
 		queryParams: search,
 	} );
 }

--- a/routes/template-part/route.ts
+++ b/routes/template-part/route.ts
@@ -9,7 +9,7 @@ export const route = {
 			throw: true,
 			to: '/template-parts/list/$area',
 			params: {
-				area: 'all',
+				area: 'all-parts',
 			},
 		} );
 	},


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/79895

## What?

Ports the extensible site editor's **Template Parts** list screen (`routes/template-part-list`) from hard-coded view defaults to the server-provided view configuration served by `GET /wp/v2/view-config?kind=postType&name=wp_template_part`.

## Why?

See https://github.com/WordPress/gutenberg/issues/79895

## How?

- JS (`routes/template-part-list/`): use the data from the endpoint (`default_view`, `default_layouts`, `view_list`). The tabs are built from `view_list`, so they follow the areas the active theme registers (a theme without a sidebar area has no "Sidebar" tab), and the tab slugs in the URL are now the server ones (`all-parts`, `header`, `footer`, ...). The `/template-parts` redirect points at `all-parts` accordingly.
- The area the list is locked to is read from the active view's locked `area` filter, so the "All template parts" entry no longer needs a hard-coded slug on the client.
- Only the layouts the server declares are offered (table and grid), as in the site editor v1.
- No PHP changes: the `wp_template_part` configuration already ships in core (`_wp_get_entity_view_config_posttype_wp_template_part`).

## Testing Instructions

1. Enable the **Extensible Site Editor** experiment under Gutenberg → Experiments, with a block theme active (e.g. Twenty Twenty-Five).
2. Go to `/wp-admin/admin.php?page=site-editor-v2` and click **Template Parts** in the sidebar.
3. Confirm the URL ends in `/template-parts/list/all-parts` and the list renders with the server defaults: grid layout and the tabs "All template parts, Header, Footer, Navigation Overlay, General".
4. Switch to an area tab and confirm only the parts of that area are listed and the "Area" column is hidden in the table layout. Confirm the layout menu offers table and grid.
5. Click **Add Template Part** from an area tab and confirm the dialog preselects that area.
6. Open DevTools → Network and confirm a request to `/wp/v2/view-config?kind=postType&name=wp_template_part` returning `default_view.type === "grid"`.
7. Add a filter in a plugin or `functions.php` and confirm it's honored, e.g.:
   ```php
   add_filter( 'get_entity_view_config_posttype_wp_template_part', function ( $data ) {
       return $data->merge( array( 'default_view' => array( 'type' => 'table' ) ), 1 );
   } );
   ```
8. Run `npm run test:e2e:site-editor-v2 -- specs/site-editor/template-part.spec.js`.

## Screenshots

The tabs follow the areas the theme registers, and the layout menu offers the server layouts:

|Before|After|
|-|-|
|<img alt="template parts before" src="https://github.com/user-attachments/assets/22f47605-8a6a-4dd7-a0ee-14831cfbb61c" />|<img alt="template parts after" src="https://github.com/user-attachments/assets/8a8005f9-58a6-42b7-987f-de0987568e6c" />|

## Use of AI Tools

Implemented with Claude Code (Claude Fable 5.1). Reviewed and adjusted by the author.
