### PR TITLE
Performance Tests: Skip pull requests that only change Storybook stories

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -56,7 +56,7 @@ jobs:
                           # Other test suites, which cannot affect the measurements.
                           - '!test/{integration,php,storybook-playwright,unit}/**'
                           - '!test/e2e/{*,!(assets)/**}'
-                          - '!{packages,tools}/**/{test,tests}/**'
+                          - '!{packages,tools}/**/{test,tests,stories}/**'
                           # Development tooling and its configuration.
                           - '!packages/{create-block,docgen,eslint-plugin,jest-*,npm-package-json-lint-config,prettier-config,project-management-automation,stylelint-config}/**'
                           # The mu-plugins and plugins below it load at run time, so they still count.


### PR DESCRIPTION
## What?
Part of #44679. Adds `stories` to the performance workflow's path filter.

## Why?
Story files never ship in the plugin build, so they cannot move a performance measurement.

## How?
One glob in `detect-relevant-changes`: `{test,tests}` becomes `{test,tests,stories}`.

## Testing Instructions
Open a pull request touching only a `stories/` file. The performance jobs report skipped, and `Performance Tests - Status Check` still passes.

## Use of AI Tools
Drafted with Claude Code; the glob was checked against every story path in the repository.
