### PR TITLE
List: indent and outdent a fully selected list item with Tab

### DIFF
--- a/packages/block-library/src/list-item/edit.jsx
+++ b/packages/block-library/src/list-item/edit.jsx
@@ -16,7 +16,7 @@ import {
 import { useMergeRefs } from '@wordpress/compose';
 import { useSelect, useRegistry } from '@wordpress/data';
 import { displayShortcut } from '@wordpress/keycodes';
-import { useEnter, useSpace, useMultiSelectTab, useMerge } from './hooks';
+import { useEnter, useTab, useMultiSelectTab, useMerge } from './hooks';
 import {
 	indentListItems,
 	outdentListItems,
@@ -72,7 +72,7 @@ export default function ListItemEdit( {
 		__unstableDisableDropZone: true,
 	} );
 	const useEnterRef = useEnter( clientId );
-	const useSpaceRef = useSpace();
+	const useTabRef = useTab();
 	const useMultiSelectTabRef = useMultiSelectTab( clientId );
 	const onMerge = useMerge( clientId, mergeBlocks );
 	return (
@@ -81,7 +81,7 @@ export default function ListItemEdit( {
 				<RichText
 					ref={ useMergeRefs( [
 						useEnterRef,
-						useSpaceRef,
+						useTabRef,
 						useMultiSelectTabRef,
 					] ) }
 					identifier="content"

--- a/packages/block-library/src/list-item/hooks/index.js
+++ b/packages/block-library/src/list-item/hooks/index.js
@@ -1,4 +1,4 @@
 export { default as useEnter } from './use-enter';
-export { default as useSpace } from './use-space';
+export { default as useTab } from './use-tab';
 export { default as useMultiSelectTab } from './use-multi-select-tab';
 export { default as useMerge } from './use-merge';

--- a/packages/block-library/src/list-item/hooks/use-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-tab.js
@@ -3,12 +3,13 @@ import { privateApis as richTextPrivateApis } from '@wordpress/rich-text';
 import { SPACE, TAB } from '@wordpress/keycodes';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useRegistry } from '@wordpress/data';
+import { isEntirelySelected } from '@wordpress/dom';
 import { indentListItems, outdentListItems } from '../utils';
 import { unlock } from '../../lock-unlock';
 
 const { subscribeOwnedListener } = unlock( richTextPrivateApis );
 
-export default function useSpace() {
+export default function useTab() {
 	const registry = useRegistry();
 
 	return useRefEffect(
@@ -29,22 +30,31 @@ export default function useSpace() {
 
 				const { getSelectionStart, getSelectionEnd } =
 					registry.select( blockEditorStore );
-				const selectionStart = getSelectionStart();
-				const selectionEnd = getSelectionEnd();
-				if (
-					selectionStart.offset === 0 &&
-					selectionEnd.offset === 0
-				) {
-					if ( shiftKey ) {
-						// Note that backspace behaviour in defined in onMerge.
-						if ( keyCode === TAB ) {
-							if ( outdentListItems( registry ) ) {
-								event.preventDefault();
-							}
-						}
-					} else if ( indentListItems( registry ) ) {
+				const isAtStart =
+					getSelectionStart().offset === 0 &&
+					getSelectionEnd().offset === 0;
+
+				// A leading space at the start of an item indents it. Anywhere
+				// else it just types a space (backspace outdents, see onMerge).
+				if ( keyCode === SPACE ) {
+					if (
+						! shiftKey &&
+						isAtStart &&
+						indentListItems( registry )
+					) {
 						event.preventDefault();
 					}
+					return;
+				}
+
+				// Tab indents and Shift+Tab outdents, both when the caret is at
+				// the start of the item and when its content is fully selected.
+				if ( ! isAtStart && ! isEntirelySelected( element ) ) {
+					return;
+				}
+				const move = shiftKey ? outdentListItems : indentListItems;
+				if ( move( registry ) ) {
+					event.preventDefault();
 				}
 			}
 

--- a/packages/block-library/src/list-item/hooks/use-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-tab.js
@@ -34,9 +34,8 @@ export default function useTab() {
 					getSelectionStart().offset === 0 &&
 					getSelectionEnd().offset === 0;
 
-				// Indent, or outdent when Shift is held. Both Space and Tab
-				// act at the start of an item; Tab also acts when its content
-				// is fully selected. Otherwise the key just types a space.
+				// Both keys act at the start of an item; Tab also acts on a
+				// full selection.
 				if (
 					! isAtStart &&
 					! ( keyCode === TAB && isEntirelySelected( element ) )
@@ -49,8 +48,7 @@ export default function useTab() {
 				}
 			}
 
-			// Capture phase so we run before writing-flow's ancestor-bubble
-			// keydown handlers that gate on `event.defaultPrevented`.
+			// Capture phase to run before writing-flow's keydown handler.
 			return subscribeOwnedListener(
 				element,
 				'keydown',

--- a/packages/block-library/src/list-item/hooks/use-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-tab.js
@@ -34,15 +34,16 @@ export default function useTab() {
 					getSelectionStart().offset === 0 &&
 					getSelectionEnd().offset === 0;
 
-				// A leading space at the start of an item indents it. Anywhere
-				// else it just types a space (backspace outdents, see onMerge).
+				// At the start of an item, Space indents and Shift+Space
+				// outdents. Anywhere else it just types a space.
 				if ( keyCode === SPACE ) {
-					if (
-						! shiftKey &&
-						isAtStart &&
-						indentListItems( registry )
-					) {
-						event.preventDefault();
+					if ( isAtStart ) {
+						const move = shiftKey
+							? outdentListItems
+							: indentListItems;
+						if ( move( registry ) ) {
+							event.preventDefault();
+						}
 					}
 					return;
 				}

--- a/packages/block-library/src/list-item/hooks/use-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-tab.js
@@ -20,7 +20,7 @@ export default function useTab() {
 				if (
 					event.defaultPrevented ||
 					( keyCode !== SPACE && keyCode !== TAB ) ||
-					// Only override when no modifiers are pressed.
+					// Shift selects outdent; other modifiers pass through.
 					altKey ||
 					metaKey ||
 					ctrlKey
@@ -34,23 +34,13 @@ export default function useTab() {
 					getSelectionStart().offset === 0 &&
 					getSelectionEnd().offset === 0;
 
-				// At the start of an item, Space indents and Shift+Space
-				// outdents. Anywhere else it just types a space.
-				if ( keyCode === SPACE ) {
-					if ( isAtStart ) {
-						const move = shiftKey
-							? outdentListItems
-							: indentListItems;
-						if ( move( registry ) ) {
-							event.preventDefault();
-						}
-					}
-					return;
-				}
-
-				// Tab indents and Shift+Tab outdents, both when the caret is at
-				// the start of the item and when its content is fully selected.
-				if ( ! isAtStart && ! isEntirelySelected( element ) ) {
+				// Indent, or outdent when Shift is held. Both Space and Tab
+				// act at the start of an item; Tab also acts when its content
+				// is fully selected. Otherwise the key just types a space.
+				if (
+					! isAtStart &&
+					! ( keyCode === TAB && isEntirelySelected( element ) )
+				) {
 					return;
 				}
 				const move = shiftKey ? outdentListItems : indentListItems;

--- a/packages/block-library/src/list-item/hooks/use-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-tab.js
@@ -48,7 +48,8 @@ export default function useTab() {
 				}
 			}
 
-			// Capture phase to run before writing-flow's keydown handler.
+			// Capture phase so we run before writing-flow's ancestor-bubble
+			// keydown handlers that gate on `event.defaultPrevented`.
 			return subscribeOwnedListener(
 				element,
 				'keydown',

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -859,6 +859,47 @@ test.describe( 'List (@firefox)', () => {
 		);
 	} );
 
+	test( 'should indent with Space and outdent with Shift+Space at the start', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/list' } );
+		await page.keyboard.type( 'a' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'b' );
+
+		// Move the caret to the start of the item and Space to indent it.
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Space' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>b</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
+		// Shift+Space at the start outdents it back to the top level.
+		await page.keyboard.press( 'Shift+Space' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>b</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+	} );
+
 	test( 'should keep the list type when indenting an ordered list item', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -802,6 +802,63 @@ test.describe( 'List (@firefox)', () => {
 		);
 	} );
 
+	test( 'should indent and outdent a list item when its content is fully selected', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/list' } );
+		await page.keyboard.type( 'a' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'b' );
+
+		// Select the whole item and Tab to indent it.
+		await pageUtils.pressKeys( 'primary+a' );
+		await page.keyboard.press( 'Tab' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>b</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
+		// The item stays fully selected, so typing replaces its content.
+		await page.keyboard.type( 'c' );
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>c</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+
+		// Select the whole item again and Shift+Tab to outdent it.
+		await pageUtils.pressKeys( 'primary+a' );
+		await page.keyboard.press( 'Shift+Tab' );
+
+		await expect.poll( editor.getEditedPostContent ).toBe(
+			`<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>a</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>c</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->`
+		);
+	} );
+
 	test( 'should keep the list type when indenting an ordered list item', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?

Tab indents a fully selected list item, and Shift+Tab outdents it.

Also adds Shift+Space to outdent at the start of an item, mirroring Space to indent now that backspace no longer outdents.

## How?

1. Tab and Shift+Tab act when the caret is at the start of the item or its content is fully selected (`isEntirelySelected` from `@wordpress/dom`).
2. At the start of an item, Space indents and Shift+Space outdents.

## Testing Instructions

1. Insert a List block and type a couple of items.
2. In the second item, select all its text and press Tab to indent, then Shift+Tab to outdent.
3. With the caret at the start of a nested item, press Shift+Space to outdent and Space to indent.

## Use of AI Tools

Authored with the assistance of Claude Code.
