### PR TITLE
DataViews: Restrict the isAll filter operator to array fields

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -44,7 +44,6 @@
 ### Bug Fixes
 
 -   Operators: Support the `isAny` and `isNone` filter operators for numeric field values, which previously matched nothing ([#77942](https://github.com/WordPress/gutenberg/pull/77942)).
--   Operators: The `isAll` filter operator only matches array values. A scalar value is excluded instead of being substring-matched (strings) or throwing (anything else) ([#82463](https://github.com/WordPress/gutenberg/pull/82463)).
 -   Field types: Drop `isAll` from the valid operators of the `number`, `integer`, `text`, `email`, `url` and `telephone` types. Their values are scalars, so "includes all of" can never hold for more than one selected value ([#82463](https://github.com/WordPress/gutenberg/pull/82463)).
 -   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -44,6 +44,7 @@
 ### Bug Fixes
 
 -   Operators: Support the `isAny` and `isNone` filter operators for numeric field values, which previously matched nothing ([#77942](https://github.com/WordPress/gutenberg/pull/77942)).
+-   Operators: The `isAll` filter operator only matches array values. A scalar value is excluded instead of being substring-matched (strings) or throwing (anything else) ([#82463](https://github.com/WordPress/gutenberg/pull/82463)).
 -   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 
 ### Documentation

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 -   Operators: Support the `isAny` and `isNone` filter operators for numeric field values, which previously matched nothing ([#77942](https://github.com/WordPress/gutenberg/pull/77942)).
 -   Operators: The `isAll` filter operator only matches array values. A scalar value is excluded instead of being substring-matched (strings) or throwing (anything else) ([#82463](https://github.com/WordPress/gutenberg/pull/82463)).
+-   Field types: Drop `isAll` from the valid operators of the `number`, `integer`, `text`, `email`, `url` and `telephone` types. Their values are scalars, so "includes all of" can never hold for more than one selected value ([#82463](https://github.com/WordPress/gutenberg/pull/82463)).
 -   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 
 ### Documentation

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1993,7 +1993,7 @@ Or multi-selection operators:
 		{ value: 'd', label: 'Product D' },
 	],
 	filterBy: {
-		operators: [ `isAny`, `isNone`, `isAll` ];
+		operators: [ `isAny`, `isNone` ];
 	}
 }
 ```
@@ -2033,15 +2033,15 @@ Valid operators per field type:
 -   color: `is`, `isNot`, `isAny`, `isNone`.
 -   date: `on`, `notOn`, `before`, `beforeInc`, `after`, `afterInc`, `inThePast`, `over`, `between`.
 -   datetime: `on`, `notOn`, `before`, `beforeInc`, `after`, `afterInc`, `inThePast`, `over`.
--   email: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`.
--   integer: `is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `between`, `isAny`, `isNone`, `isAll`.
+-   email: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`.
+-   integer: `is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `between`, `isAny`, `isNone`.
 -   media: none.
--   number: `is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `between`, `isAny`, `isNone`, `isAll`.
+-   number: `is`, `isNot`, `lessThan`, `greaterThan`, `lessThanOrEqual`, `greaterThanOrEqual`, `between`, `isAny`, `isNone`.
 -   password: none.
--   email: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`.
--   text: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`.
+-   telephone: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`.
+-   text: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`.
 -   time: `on`, `notOn`, `before`, `beforeInc`, `after`, `afterInc`, `between`.
--   url: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`, `isAll`.
+-   url: `is`, `isNot`, `contains`, `notContains`, `startsWith`, `isAny`, `isNone`.
 -   fields with no type: any operator.
 
 `time` shares the ordering operators with `date` and `datetime`, which compare temporal values generically: a date or datetime compares by its position on the calendar, a time by its position within the day. Comparisons are precision-insensitive, so a filter for `'09:00'` matches a stored `'09:00:00'`.

--- a/packages/dataviews/src/field-types/email.tsx
+++ b/packages/dataviews/src/field-types/email.tsx
@@ -3,7 +3,6 @@ import type { NormalizedField } from '../types';
 import type { FieldType } from '../types/private';
 import {
 	OPERATOR_IS,
-	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
@@ -56,7 +55,6 @@ export default {
 		// Multiple selection
 		OPERATOR_IS_ANY,
 		OPERATOR_IS_NONE,
-		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
 	format: {},

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -10,7 +10,6 @@ import {
 	OPERATOR_GREATER_THAN_OR_EQUAL,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
-	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
 	OPERATOR_BETWEEN,
 } from '../constants';
@@ -100,7 +99,6 @@ export default {
 		// Multiple-selection
 		OPERATOR_IS_ANY,
 		OPERATOR_IS_NONE,
-		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
 	format,

--- a/packages/dataviews/src/field-types/number.tsx
+++ b/packages/dataviews/src/field-types/number.tsx
@@ -10,7 +10,6 @@ import {
 	OPERATOR_GREATER_THAN_OR_EQUAL,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
-	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
 	OPERATOR_BETWEEN,
 } from '../constants';
@@ -104,7 +103,6 @@ export default {
 		// Multiple-selection
 		OPERATOR_IS_ANY,
 		OPERATOR_IS_NONE,
-		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
 	format,

--- a/packages/dataviews/src/field-types/telephone.tsx
+++ b/packages/dataviews/src/field-types/telephone.tsx
@@ -1,7 +1,6 @@
 import type { FieldType } from '../types/private';
 import {
 	OPERATOR_IS,
-	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
@@ -36,7 +35,6 @@ export default {
 		// Multiple selection
 		OPERATOR_IS_ANY,
 		OPERATOR_IS_NONE,
-		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
 	format: {},

--- a/packages/dataviews/src/field-types/test/normalize-fields.ts
+++ b/packages/dataviews/src/field-types/test/normalize-fields.ts
@@ -335,6 +335,36 @@ describe( 'normalizeFields: default getValue', () => {
 				operators: [ 'lessThan' ],
 			} );
 		} );
+
+		it.each( [
+			'integer',
+			'number',
+			'text',
+			'email',
+			'url',
+			'telephone',
+		] as const )(
+			'removes the isAll operator for %s fields, whose values are scalars',
+			( type ) => {
+				const fields: Field< {} >[] = [
+					{
+						id: 'author',
+						type,
+						filterBy: {
+							operators: [ 'isAny', 'isNone', 'isAll' ],
+						},
+					},
+				];
+				const normalizedFields = normalizeFields( fields );
+				expect( normalizedFields[ 0 ].filterBy ).toStrictEqual( {
+					isPrimary: false,
+					operators: [ 'isAny', 'isNone' ],
+				} );
+				expect( normalizedFields[ 0 ].filter ).not.toHaveProperty(
+					'isAll'
+				);
+			}
+		);
 	} );
 
 	describe( 'validation normalization', () => {

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -2,7 +2,6 @@ import type { FieldType } from '../types/private';
 import {
 	OPERATOR_CONTAINS,
 	OPERATOR_IS,
-	OPERATOR_IS_ALL,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
 	OPERATOR_IS_NOT,
@@ -37,7 +36,6 @@ export default {
 		// Multiple selection
 		OPERATOR_IS_ANY,
 		OPERATOR_IS_NONE,
-		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
 	format: {},

--- a/packages/dataviews/src/field-types/url.tsx
+++ b/packages/dataviews/src/field-types/url.tsx
@@ -1,7 +1,6 @@
 import type { FieldType } from '../types/private';
 import {
 	OPERATOR_IS,
-	OPERATOR_IS_ALL,
 	OPERATOR_IS_NOT_ALL,
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
@@ -36,7 +35,6 @@ export default {
 		// Multiple selection
 		OPERATOR_IS_ANY,
 		OPERATOR_IS_NONE,
-		OPERATOR_IS_ALL,
 		OPERATOR_IS_NOT_ALL,
 	],
 	format: {},

--- a/packages/dataviews/src/utils/operators.tsx
+++ b/packages/dataviews/src/utils/operators.tsx
@@ -201,10 +201,6 @@ const OPERATORS: {
 			}
 
 			const fieldValue = field.getValue( { item } );
-
-			// Only an array can include every filter value. Fields with no
-			// type accept any operator, so a scalar can still get here: exclude
-			// it rather than calling a method it may not have.
 			if ( ! Array.isArray( fieldValue ) ) {
 				return false;
 			}

--- a/packages/dataviews/src/utils/operators.tsx
+++ b/packages/dataviews/src/utils/operators.tsx
@@ -116,10 +116,10 @@ const isNoneOperatorDefinition = {
 			return ! filterValue.some( ( fv: any ) =>
 				fieldValue.includes( fv )
 			);
-		}
-
-		const fieldValueType = typeof fieldValue;
-		if ( fieldValueType === 'string' || fieldValueType === 'number' ) {
+		} else if (
+			typeof fieldValue === 'string' ||
+			typeof fieldValue === 'number'
+		) {
 			return ! filterValue.includes( fieldValue );
 		}
 
@@ -164,10 +164,10 @@ const OPERATORS: {
 				return filterValue.some( ( fv: any ) =>
 					fieldValue.includes( fv )
 				);
-			}
-
-			const fieldValueType = typeof fieldValue;
-			if ( fieldValueType === 'string' || fieldValueType === 'number' ) {
+			} else if (
+				typeof fieldValue === 'string' ||
+				typeof fieldValue === 'number'
+			) {
 				return filterValue.includes( fieldValue );
 			}
 

--- a/packages/dataviews/src/utils/operators.tsx
+++ b/packages/dataviews/src/utils/operators.tsx
@@ -200,9 +200,18 @@ const OPERATORS: {
 				return true;
 			}
 
-			return filterValue.every( ( value: any ) => {
-				return field.getValue( { item } )?.includes( value );
-			} );
+			const fieldValue = field.getValue( { item } );
+
+			// Only an array can include every filter value. Fields with no
+			// type accept any operator, so a scalar can still get here: exclude
+			// it rather than calling a method it may not have.
+			if ( ! Array.isArray( fieldValue ) ) {
+				return false;
+			}
+
+			return filterValue.every( ( value: any ) =>
+				fieldValue.includes( value )
+			);
 		},
 		selection: 'multi',
 	},

--- a/packages/dataviews/src/utils/test/filter-sort-and-paginate.js
+++ b/packages/dataviews/src/utils/test/filter-sort-and-paginate.js
@@ -345,6 +345,30 @@ describe( 'filters', () => {
 		expect( result[ 7 ].name.title ).toBe( 'Uranus' );
 	} );
 
+	it.each( [
+		[ 'number', 'satellites', 2 ],
+		[ 'string', 'author', 'lunarian_observer' ],
+	] )(
+		'should exclude a %s value from the IS ALL filter instead of throwing',
+		( _type, fieldId, value ) => {
+			// Fields with no type accept every operator, so an item's scalar
+			// value can reach the IS ALL filter.
+			const untypedFields = fields.map( ( field ) =>
+				field.id === fieldId ? { id: fieldId } : field
+			);
+			const { data: result } = filterSortAndPaginate(
+				data,
+				{
+					filters: [
+						{ field: fieldId, operator: 'isAll', value: [ value ] },
+					],
+				},
+				untypedFields
+			);
+			expect( result ).toHaveLength( 0 );
+		}
+	);
+
 	it( 'should search using IS NOT ALL filter (deprecated operator)', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,


### PR DESCRIPTION
## What?

Follow up to #77942.

Makes the `isAll` filter operator work only with array values. It is removed from the valid operators of the `number`, `integer`, `text`, `email`, `url` and `telephone` field types, and the filter itself now excludes any item whose value is not an array instead of throwing or matching substrings.

## Why?

"Includes all of" only makes sense for a value that can hold several items at once. A number or a string holds one, so the operator could never match more than one selected value. Worse, the filter called `includes` on whatever the field returned: for a number it threw a `TypeError`, and for a string it did substring matching, so "Product includes all: a, b" matched the title "abc". The README still listed `isAll` as valid for all six scalar types, so consumers had no way to know it was unusable.

## How?

The `isAll` filter in `operators.tsx` returns `false` for any non-array value. Fields with no declared type accept every operator, so a scalar can still reach it, and excluding the item matches how `isAny` and `isNone` treat unsupported types. The six scalar field types drop `OPERATOR_IS_ALL` from their `validOperators`, which also stops the filter UI from offering it, and the README lists are updated. While editing those lists I found that the second "email" entry sat where "telephone" belongs and "telephone" was missing, so that entry is renamed. The deprecated `isNotAll` is untouched: it is an alias of `isNone`, which works for scalars.

## Testing Instructions

Run the DataViews unit tests with `npm run test:unit:vitest -- packages/dataviews`. The new cases in `filter-sort-and-paginate.js` check that an untyped number and an untyped string field are excluded by `isAll` instead of throwing, and the new cases in `normalize-fields.ts` check that each of the six scalar types drops `isAll` from a field's operators. To see it in the UI, open the DataViews story in Storybook, temporarily give the `satellites` field in `packages/dataviews/src/dataviews/stories/fixtures.tsx` an `elements` list and `filterBy: { operators: [ 'isAny', 'isNone', 'isAll' ] }`, and add a Satellites filter. On trunk the "Includes all" operator is offered and picking a value throws in the console. On this branch only "Includes" and "Is none of" are offered.

### Testing Instructions for Keyboard

Same as above. The filter operator list is a regular menu, so open it with Enter or Space and move through it with the arrow keys to confirm "Includes all" is not offered for the Satellites field.

## Use of AI Tools

This PR was written with Claude Code, including the code, tests and this description. I reviewed every change and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3JDtk1v34AMMhCWECAc9X
