### PR TITLE
Query Loop: Fall back to `post` when the query has no `postType`

### DIFF
--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -74,7 +74,11 @@ registerBlockVariation( 'core/query', {
 } );
 ```
 
-In this way, the users won't have to choose the custom `postType` from the dropdown, and be already presented with the correct configuration. However, you might ask, how is a user going to find and insert this variation? Good question! To enable this, you should add:
+In this way, the users won't have to choose the custom `postType` from the dropdown, and be already presented with the correct configuration.
+
+A variation's `query` replaces the block's default `query` object instead of merging into it, so include every property your variation relies on, not only the ones you change. Always set `postType`: when it's missing, the block queries posts, both in the editor and on the front end.
+
+However, you might ask, how is a user going to find and insert this variation? Good question! To enable this, you should add:
 
 ```js
 {

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -22,6 +22,7 @@
 -   Query: Stop writing `excludeCurrent: null` into the `query` attribute of blocks that never had the key. The mount effect that clears a stale exclusion treated the absent key as stale, changing the serialized markup of every pre-existing Query block as soon as the editor opened it ([#82147](https://github.com/WordPress/gutenberg/pull/82147)).
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
 -   Image: Keep the selected image size, and re-point a media file or attachment page link, when an edit in the media editor saves to a new attachment. Cropping, rotating or flipping left the block rendering the full-size file while the size control still reported the size the user had chosen, and left the link pointing at the pre-edit image ([#82316](https://github.com/WordPress/gutenberg/pull/82316)).
+-   Query, Post Template: Treat a `query` attribute that omits `postType` as querying posts, matching `build_query_vars_from_query_block()` ([#82465](https://github.com/WordPress/gutenberg/pull/82465)).
 
 ### Internal
 

--- a/packages/block-library/src/post-template/edit.jsx
+++ b/packages/block-library/src/post-template/edit.jsx
@@ -75,7 +75,9 @@ export default function PostTemplateEdit( {
 		query: {
 			perPage,
 			offset = 0,
-			postType,
+			// Match `build_query_vars_from_query_block()`, which queries posts when
+			// `query` has no post type.
+			postType = 'post',
 			order,
 			orderBy,
 			author,

--- a/packages/block-library/src/query/edit/inspector-controls/index.jsx
+++ b/packages/block-library/src/query/edit/inspector-controls/index.jsx
@@ -42,7 +42,9 @@ export default function QueryInspectorControls( props ) {
 		orderBy,
 		author: authorIds,
 		pages,
-		postType,
+		// Match `build_query_vars_from_query_block()`, which queries posts when
+		// `query` has no post type.
+		postType = 'post',
 		perPage,
 		offset,
 		sticky,
@@ -172,7 +174,7 @@ export default function QueryInspectorControls( props ) {
 		isControlAllowed( allowedControls, 'excludeCurrent' );
 	const postTypeSingularName = useSelect(
 		( select ) =>
-			select( coreStore ).getPostType( postType )?.labels.singular_name,
+			select( coreStore ).getPostType( postType )?.labels?.singular_name,
 		[ postType ]
 	);
 


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/82453

A Query Loop variation that sets `query` without a `postType` crashes the block inspector, and the Post Template preview never loads. `postType` is the most fundamental property of a query and shouldn't be left out, but the editor shouldn't crash for it either. On the front end `build_query_vars_from_query_block` already queries posts in this case, so this PR does the same in the editor by defaulting `postType` to `post` in the inspector controls and in the Post Template edit.

It also adds the missing `?.` guard for `labels` in the inspector, and a note in the extending guide that a variation's `query` replaces the block's default object, so `postType` should always be set.



## Testing Instructions
1. Paste this in the code editor of a post:
```
<!-- wp:query {"query":{"perPage":3,"inherit":false}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title {"isLink":true} /-->
<!-- /wp:post-template --></div>
<!-- /wp:query -->
```
2. Select the Query Loop block. It shouldn't crash and the post type control should show `Post`.
3. The Post Template should render posts in the editor and on the front end.
4. Everything else should work as before.

## Use of AI Tools
Fable 5.1 with direction, changes and review