### PR TITLE
UI: Keep disabled minimal Select triggers borderless

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Bug Fixes
 
 -   `Link`: Show the new-tab indicator and accessible notice when `target` is an ASCII case-insensitive match for `"_blank"`. ([#82447](https://github.com/WordPress/gutenberg/pull/82447))
+-   `Select`: Keep disabled minimal triggers borderless. ([#82466](https://github.com/WordPress/gutenberg/pull/82466))
 -   `AlertDialog`, `Dialog`, `Drawer`: Keep descendant focus rings visible at pinned header and footer edges. ([#82443](https://github.com/WordPress/gutenberg/pull/82443))
 -   `Menu.LinkItem`: Show the new-tab indicator and accessible notice when `target` is an ASCII case-insensitive match for `"_blank"`. ([#82442](https://github.com/WordPress/gutenberg/pull/82442))
 -   `Input`, `Textarea`, `InputControl`, `TextareaControl`: Use `--wpds-color-foreground-interactive-neutral-weak` for enabled placeholder text so it meets the 4.5:1 contrast minimum ([#82304](https://github.com/WordPress/gutenberg/pull/82304)).

--- a/packages/ui/src/form/primitives/input-layout/style.module.css
+++ b/packages/ui/src/form/primitives/input-layout/style.module.css
@@ -33,7 +33,7 @@
 			}
 
 			&.is-disabled,
-			&:has([data-can-disable-input-layout][data-disabled]) {
+			&:has(:where([data-can-disable-input-layout][data-disabled])) {
 				/* stylelint-disable-next-line plugin-wpds/no-token-fallback-values -- Preserve custom background theming with older @wordpress/theme runtimes that do not set this token. */
 				background-color: var(--wpds-color-background-interactive-neutral-disabled, var(--wpds-color-background-surface-neutral-strong));
 				border-color: var(--wpds-color-stroke-interactive-neutral-disabled);


### PR DESCRIPTION
Follow-up to #82391.

## What?

Keep disabled minimal `Select` triggers borderless.

## Why?

`InputLayout`'s child-disabled selector is more specific than its borderless modifier. As a result, disabled minimal `Select` triggers show a gray border.

## How?

Wrap the child disabled markers in `:where()` so they do not increase the `:has()` selector's specificity. The later borderless modifier can then keep the border transparent without changing disabled colors.

## Testing Instructions

1. Start Storybook and open **Design System / Components / Form / Primitives / Select / Minimal**.
2. Set the `disabled` control to `true`.
3. Confirm that the trigger remains borderless.
4. Toggle `disabled` off and on. Confirm that the border stays hidden in both states.

### Testing Instructions for Keyboard

With `disabled` off, press Tab to focus the trigger and Space to open it. With `disabled` on, confirm that Tab skips the trigger and that the border remains hidden.

## Screenshots

| Before | After |
|---|---|
| <img width="162" height="118" alt="Screenshot 2026-09-04 at 19 55 02" src="https://github.com/user-attachments/assets/e8201033-5604-4b12-852b-c5bfe6fb211b" /> | <img width="156" height="122" alt="Screenshot 2026-09-04 at 19 57 32" src="https://github.com/user-attachments/assets/d9365fdd-2400-4e9d-90de-989d56cb1409" /> |

## Use of AI Tools

Codex implemented and tested the change. The author will review it before marking the PR ready.
