### PR TITLE
Fix privacy policy page setting unit test on multisite

### DIFF
--- a/phpunit/privacy-policy-page-setting-test.php
+++ b/phpunit/privacy-policy-page-setting-test.php
@@ -14,6 +14,9 @@ class Gutenberg_Privacy_Policy_Page_Setting_Test extends WP_Test_REST_TestCase {
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
 	}
 
 	public static function wpTearDownAfterClass() {


### PR DESCRIPTION
## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/82422

The multisite unit tests fail in trunk (https://github.com/WordPress/gutenberg/actions/runs/33886629431/job/101068528274). On multisite `manage_privacy_options` maps to `manage_network`, so the test's admin user can't update the setting and the new `rest_pre_update_setting` guard skips the update. This PR grants super admin on multisite, like we do in other tests.

Multisite tests don't run on PRs, only in trunk, so CI here won't cover this.

## Testing Instructions
1. Run `npm run wp-env-test start` if the test env isn't running.
2. Run `npm run test:unit:php:multisite:base -- --filter Gutenberg_Privacy_Policy_Page_Setting_Test`. It fails in trunk and should pass with this PR.

## Use of AI Tools
Fable 5.1 with direction and review.