### PR TITLE
UI: Keep borderless InputLayout chrome when disabled

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bug Fixes
 
+-   `Select` (`variant="minimal"`): Keep the trigger borderless and unfilled when disabled. InputLayout no longer applies disabled field chrome to `.is-borderless`. ([#82468](https://github.com/WordPress/gutenberg/pull/82468))
 -   `Link`: Show the new-tab indicator and accessible notice when `target` is an ASCII case-insensitive match for `"_blank"`. ([#82447](https://github.com/WordPress/gutenberg/pull/82447))
 -   `AlertDialog`, `Dialog`, `Drawer`: Keep descendant focus rings visible at pinned header and footer edges. ([#82443](https://github.com/WordPress/gutenberg/pull/82443))
 -   `Menu.LinkItem`: Show the new-tab indicator and accessible notice when `target` is an ASCII case-insensitive match for `"_blank"`. ([#82442](https://github.com/WordPress/gutenberg/pull/82442))

--- a/packages/ui/src/form/primitives/input-layout/style.module.css
+++ b/packages/ui/src/form/primitives/input-layout/style.module.css
@@ -34,14 +34,20 @@
 
 			&.is-disabled,
 			&:has([data-can-disable-input-layout][data-disabled]) {
-				/* stylelint-disable-next-line plugin-wpds/no-token-fallback-values -- Preserve custom background theming with older @wordpress/theme runtimes that do not set this token. */
-				background-color: var(--wpds-color-background-interactive-neutral-disabled, var(--wpds-color-background-surface-neutral-strong));
-				border-color: var(--wpds-color-stroke-interactive-neutral-disabled);
 				color: var(--wpds-color-foreground-interactive-neutral-disabled);
 
 				@media (forced-colors: active) {
-					border-color: GrayText;
 					color: GrayText;
+				}
+
+				&:not(.is-borderless) {
+					/* stylelint-disable-next-line plugin-wpds/no-token-fallback-values -- Preserve custom background theming with older @wordpress/theme runtimes that do not set this token. */
+					background-color: var(--wpds-color-background-interactive-neutral-disabled, var(--wpds-color-background-surface-neutral-strong));
+					border-color: var(--wpds-color-stroke-interactive-neutral-disabled);
+
+					@media (forced-colors: active) {
+						border-color: GrayText;
+					}
 				}
 			}
 


### PR DESCRIPTION
## What?

Keep disabled borderless `InputLayout` fields, including `Select` `variant="minimal"`, from painting a disabled border and solid fill.

## Why?

`Select` with `variant="minimal"` is supposed to stay chrome-less. Disabled styles still come from `InputLayout`'s `:has([data-can-disable-input-layout][data-disabled])` rule, which outranks `.is-borderless`. A disabled minimal trigger picked up the default field's disabled stroke and fill.

## How?

Keep the disabled text color on all `InputLayout` fields. Apply the disabled background and border only when the layout is not `.is-borderless`.

## Testing Instructions

1. Open Design System / Components / Form / Primitives / Select → Disabled. The default trigger still has the disabled border and solid fill.
2. Open Minimal and turn on `disabled` in the controls. The trigger stays borderless and unfilled. Text uses the disabled color.
3. Repeat in both Font only and WordPress Global CSS modes.

## Screenshots or screencast

Disabled `variant="minimal"` on a pink canvas so a gray border or white fill would show.

|Before|After|
|-|-|
|<img width="178" height="140" alt="select-minimal-disabled-before" src="https://github.com/user-attachments/assets/dbd170e9-322c-41a8-b3e1-0cac9dd3cd59" />|<img width="178" height="140" alt="select-minimal-disabled-after" src="https://github.com/user-attachments/assets/5435a072-8e4d-4385-9278-e06955b86a43" />|