### PR TITLE
Search: Give the icon-only search button an accessible name

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -148,7 +148,8 @@ function render_block_core_search( $attributes ) {
 				$button->set_attribute( 'aria-expanded', 'false' );
 				$button->set_attribute( 'type', 'button' );
 			} else {
-				$button->set_attribute( 'aria-label', wp_strip_all_tags( $attributes['buttonText'] ) );
+				$button_label = wp_strip_all_tags( $attributes['buttonText'] );
+				$button->set_attribute( 'aria-label', '' !== trim( $button_label ) ? $button_label : __( 'Search' ) );
 			}
 		}
 	}

--- a/phpunit/blocks/render-block-search-test.php
+++ b/phpunit/blocks/render-block-search-test.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Search block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Search block.
+ *
+ * @group blocks
+ */
+class Render_Block_Search_Test extends WP_UnitTestCase {
+
+	/**
+	 * An icon-only search button must expose an accessible name even when the
+	 * button text has been cleared in the editor.
+	 *
+	 * @dataProvider data_button_text_without_a_name
+	 *
+	 * @param string $button_text The serialized `buttonText` attribute.
+	 */
+	public function test_icon_button_falls_back_to_default_aria_label( $button_text ) {
+		$markup = do_blocks(
+			sprintf(
+				'<!-- wp:search {"buttonText":%s,"buttonUseIcon":true} /-->',
+				wp_json_encode( $button_text )
+			)
+		);
+
+		$this->assertStringContainsString(
+			'aria-label="Search"',
+			$markup,
+			'The icon button should fall back to the default "Search" label.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_button_text_without_a_name() {
+		return array(
+			'empty string'        => array( '' ),
+			'whitespace only'     => array( '   ' ),
+			'markup with no text' => array( '<em></em>' ),
+		);
+	}
+
+	/**
+	 * A button label supplied by the user must be preserved.
+	 */
+	public function test_icon_button_keeps_custom_aria_label() {
+		$markup = do_blocks( '<!-- wp:search {"buttonText":"Find stuff","buttonUseIcon":true} /-->' );
+
+		$this->assertStringContainsString( 'aria-label="Find stuff"', $markup );
+	}
+}


### PR DESCRIPTION
## What?

Gives the Search block's icon-only button an accessible name when the button text has been cleared in the editor.

Fixes the WordPress Trac ticket [#65617](https://core.trac.wordpress.org/ticket/65617).

## Why?

`render_block_core_search()` applies its attribute defaults with `wp_parse_args()`, which only fills in **missing** keys. Clearing the button text in the editor serializes `"buttonText":""` — the key is present, so the `__( 'Search' )` default is never applied.

When `buttonUseIcon` is enabled the button's only content is an SVG, so the rendered markup is:

```html
<button aria-label="" class="wp-block-search__button has-icon wp-element-button" type="submit">
  <svg class="search-icon" viewBox="0 0 24 24" width="24" height="24">…</svg>
</button>
```

The button has no accessible name, which is a WCAG 2.1 SC 4.1.2 (Name, Role, Value) failure — screen reader users hear only "button".

The `label` attribute a few lines above is already guarded against exactly this:

```php
$label_inner_html = empty( $attributes['label'] ) ? __( 'Search' ) : wp_kses_post( $attributes['label'] );
```

so the button path looks like an oversight rather than intent.

## How?

Falls back to the default `Search` label when the stripped button text is blank:

```php
$button_label = wp_strip_all_tags( $attributes['buttonText'] );
$button->set_attribute( 'aria-label', '' !== trim( $button_label ) ? $button_label : __( 'Search' ) );
```

`trim()` also covers whitespace-only values and markup that strips to nothing (e.g. `<em></em>`).

The `button-only` (expandable) branch is untouched — it already sets its own `aria-label` of "Expand search field".

## Testing Instructions

1. Add a Search block to a post.
2. In the block toolbar, switch the button to **Use button with icon**.
3. Select the button and delete its text so it is empty.
4. Save and view the post on the front end.
5. Inspect the `<button>` element.

**Before:** `aria-label=""` — no accessible name.
**After:** `aria-label="Search"`.

Also confirm a custom button label is still respected: set the button text to something else and check `aria-label` matches it.

### Testing Instructions for Keyboard / Screen Reader

Tab to the search button on the front end with a screen reader running. Before this change it is announced only as "button"; after it is announced as "Search, button".

### Automated tests

Adds `phpunit/blocks/render-block-search-test.php`. The Search block had no PHP render coverage at all. Four tests cover the empty, whitespace-only and markup-only cases plus the custom-label case; three of the four fail without the change.

```
npm run test:unit:php -- --filter Render_Block_Search_Test
```
