### PR TITLE
Patterns: Show where a synced pattern is used in its summary panel

### DIFF
--- a/lib/compat/wordpress-7.2/pattern-usage.php
+++ b/lib/compat/wordpress-7.2/pattern-usage.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * REST API endpoint reporting where a synced pattern is used.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Returns the post types that may contain a reference to a synced pattern.
+ *
+ * Any post type editable with the block editor can hold a `core/block` block,
+ * including the design post types (`wp_template`, `wp_template_part`,
+ * `wp_block`, `wp_navigation`).
+ *
+ * @param int $pattern_id The pattern being looked up.
+ * @return string[] List of post type names.
+ */
+function gutenberg_get_pattern_usage_post_types( $pattern_id ) {
+	$post_types = array();
+
+	foreach ( get_post_types( array( 'show_in_rest' => true ) ) as $post_type ) {
+		if ( post_type_supports( $post_type, 'editor' ) ) {
+			$post_types[] = $post_type;
+		}
+	}
+
+	/**
+	 * Filters the post types searched when reporting where a pattern is used.
+	 *
+	 * @param string[] $post_types List of post type names.
+	 * @param int      $pattern_id The pattern being looked up.
+	 */
+	return apply_filters( 'gutenberg_pattern_usage_post_types', $post_types, $pattern_id );
+}
+
+/**
+ * Determines whether a list of parsed blocks references a synced pattern.
+ *
+ * @param array $blocks     Parsed blocks, as returned by `parse_blocks()`.
+ * @param int   $pattern_id The pattern to look for.
+ * @return bool Whether one of the blocks, at any depth, references the pattern.
+ */
+function gutenberg_blocks_reference_pattern( $blocks, $pattern_id ) {
+	foreach ( $blocks as $block ) {
+		if (
+			'core/block' === $block['blockName'] &&
+			isset( $block['attrs']['ref'] ) &&
+			(int) $block['attrs']['ref'] === $pattern_id
+		) {
+			return true;
+		}
+
+		if (
+			! empty( $block['innerBlocks'] ) &&
+			gutenberg_blocks_reference_pattern( $block['innerBlocks'], $pattern_id )
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Checks whether the current user may see where a pattern is used.
+ *
+ * @param WP_REST_Request $request The request.
+ * @return true|WP_Error True if the request has read access, WP_Error otherwise.
+ */
+function gutenberg_get_pattern_usage_permissions_check( $request ) {
+	$pattern = get_post( (int) $request['id'] );
+
+	if ( ! $pattern || 'wp_block' !== $pattern->post_type ) {
+		return new WP_Error(
+			'rest_post_invalid_id',
+			__( 'Invalid pattern ID.', 'gutenberg' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	if ( ! current_user_can( 'edit_post', $pattern->ID ) ) {
+		return new WP_Error(
+			'rest_cannot_read_pattern_usage',
+			__( 'Sorry, you are not allowed to see where this pattern is used.', 'gutenberg' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	return true;
+}
+
+/**
+ * Lists the entries that use a synced pattern, grouped by post type.
+ *
+ * @param WP_REST_Request $request The request.
+ * @return WP_REST_Response The list of entries using the pattern.
+ */
+function gutenberg_get_pattern_usage( $request ) {
+	$pattern_id = (int) $request['id'];
+
+	$query = new WP_Query(
+		array(
+			'post_type'              => gutenberg_get_pattern_usage_post_types( $pattern_id ),
+			'post_status'            => 'any',
+			'post__not_in'           => array( $pattern_id ),
+			// The search is only a cheap way to narrow the table down: it is
+			// capped because every candidate is then parsed to confirm it.
+			'posts_per_page'         => 100,
+			'orderby'                => 'title',
+			'order'                  => 'ASC',
+			's'                      => '"ref":' . $pattern_id,
+			// `sentence` keeps the needle whole instead of splitting it on the
+			// colon and quotes.
+			'sentence'               => true,
+			'search_columns'         => array( 'post_content' ),
+			'no_found_rows'          => true,
+			'ignore_sticky_posts'    => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+		)
+	);
+
+	$groups = array();
+
+	foreach ( $query->posts as $post ) {
+		/*
+		 * The search above also matches `"ref":12` inside `"ref":123`, and
+		 * other blocks such as `core/navigation` carry a `ref` attribute of
+		 * their own, so confirm the reference against the parsed content.
+		 */
+		if ( ! gutenberg_blocks_reference_pattern( parse_blocks( $post->post_content ), $pattern_id ) ) {
+			continue;
+		}
+
+		if ( ! current_user_can( 'read_post', $post->ID ) ) {
+			continue;
+		}
+
+		if ( ! isset( $groups[ $post->post_type ] ) ) {
+			$labels = get_post_type_object( $post->post_type )->labels;
+
+			$groups[ $post->post_type ] = array(
+				'type'   => $post->post_type,
+				'labels' => array(
+					'name'          => $labels->name,
+					'singular_name' => $labels->singular_name,
+				),
+				'items'  => array(),
+			);
+		}
+
+		$groups[ $post->post_type ]['items'][] = array(
+			'id'    => $post->ID,
+			'title' => $post->post_title,
+		);
+	}
+
+	foreach ( $groups as $post_type => $group ) {
+		$groups[ $post_type ]['count'] = count( $group['items'] );
+	}
+
+	return rest_ensure_response(
+		array(
+			'total'  => array_sum( wp_list_pluck( $groups, 'count' ) ),
+			'groups' => array_values( $groups ),
+		)
+	);
+}
+
+/**
+ * Returns the schema of the pattern usage endpoint.
+ *
+ * @return array Item schema data.
+ */
+function gutenberg_get_pattern_usage_schema() {
+	return array(
+		'$schema'    => 'http://json-schema.org/draft-04/schema#',
+		'title'      => 'pattern-usage',
+		'type'       => 'object',
+		'properties' => array(
+			'total'  => array(
+				'description' => __( 'Number of entries using the pattern.', 'gutenberg' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'groups' => array(
+				'description' => __( 'Entries using the pattern, grouped by post type.', 'gutenberg' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'type'   => array(
+							'description' => __( 'Post type of the entries.', 'gutenberg' ),
+							'type'        => 'string',
+						),
+						'labels' => array(
+							'description' => __( 'Singular and plural labels of the post type.', 'gutenberg' ),
+							'type'        => 'object',
+							'properties'  => array(
+								'name'          => array( 'type' => 'string' ),
+								'singular_name' => array( 'type' => 'string' ),
+							),
+						),
+						'count'  => array(
+							'description' => __( 'Number of entries of this post type.', 'gutenberg' ),
+							'type'        => 'integer',
+						),
+						'items'  => array(
+							'description' => __( 'Entries of this post type using the pattern.', 'gutenberg' ),
+							'type'        => 'array',
+							'items'       => array(
+								'type'       => 'object',
+								'properties' => array(
+									'id'    => array( 'type' => 'integer' ),
+									'title' => array( 'type' => 'string' ),
+								),
+							),
+						),
+					),
+				),
+			),
+		),
+	);
+}
+
+/**
+ * Registers the route listing where a synced pattern is used.
+ */
+function gutenberg_register_pattern_usage_route() {
+	register_rest_route(
+		'wp/v2',
+		'/blocks/(?P<id>[\d]+)/usage',
+		array(
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => 'gutenberg_get_pattern_usage',
+				'permission_callback' => 'gutenberg_get_pattern_usage_permissions_check',
+				'args'                => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the pattern.', 'gutenberg' ),
+						'type'        => 'integer',
+					),
+				),
+			),
+			'schema' => 'gutenberg_get_pattern_usage_schema',
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_pattern_usage_route' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -74,6 +74,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	// WordPress 7.2 compat.
 	require __DIR__ . '/compat/wordpress-7.2/view-config-api.php';
 	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php';
+	require __DIR__ . '/compat/wordpress-7.2/pattern-usage.php';
 	require __DIR__ . '/compat/wordpress-7.2/rest-api.php';
 
 	// Real-time collaboration.

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Enhancements
 
+-   Pattern editor: The summary panel reports where a synced pattern is used, listing the entries that would lose it if it were deleted. The counts come from the `wp/v2/blocks/<id>/usage` route the Gutenberg plugin registers, so the section is left out on a plain WordPress install ([#58990](https://github.com/WordPress/gutenberg/issues/58990)).
 -   Post actions: Append an ellipsis (`…`) to the "Set as homepage" and "Set as posts page" action labels, which open a confirmation dialog, following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 
 ### Bug Fixes

--- a/packages/editor/src/components/post-pattern-usage/index.jsx
+++ b/packages/editor/src/components/post-pattern-usage/index.jsx
@@ -1,0 +1,178 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
+import { Collapsible, Icon, Link, Stack, Text } from '@wordpress/ui';
+import { addQueryArgs } from '@wordpress/url';
+import { store as editorStore } from '../../store';
+import { DESIGN_POST_TYPES, PATTERN_POST_TYPE } from '../../store/constants';
+
+/**
+ * Builds the admin URL that edits a given entry.
+ *
+ * @param {number} id   Post ID.
+ * @param {string} type Post type.
+ *
+ * @return {string} URL of the editor for that entry.
+ */
+function getEditUrl( id, type ) {
+	// Design post types are edited in the site editor, which routes on
+	// `/<post type>/<post id>`.
+	if ( DESIGN_POST_TYPES.includes( type ) ) {
+		return addQueryArgs( 'site-editor.php', {
+			p: `/${ type }/${ id }`,
+			canvas: 'edit',
+		} );
+	}
+
+	return addQueryArgs( 'post.php', { post: id, action: 'edit' } );
+}
+
+/**
+ * Reshapes the endpoint payload into what the component renders, discarding
+ * anything unexpected. Counts are derived from the entries themselves so the
+ * summary can never disagree with the list below it.
+ *
+ * @param {Object} response Parsed response body.
+ *
+ * @return {Object} Normalized usage, as a total and a list of groups.
+ */
+function normalizeUsage( response ) {
+	const groups = ( Array.isArray( response?.groups ) ? response.groups : [] )
+		.map( ( group ) => ( {
+			type: group?.type,
+			name: group?.labels?.name || group?.type,
+			singularName: group?.labels?.singular_name || group?.type,
+			items: ( Array.isArray( group?.items ) ? group.items : [] )
+				.filter( ( item ) => !! item?.id )
+				.map( ( item ) => ( {
+					id: item.id,
+					title: typeof item.title === 'string' ? item.title : '',
+				} ) ),
+		} ) )
+		.filter( ( group ) => !! group.type && group.items.length > 0 );
+
+	return {
+		total: groups.reduce( ( sum, group ) => sum + group.items.length, 0 ),
+		groups,
+	};
+}
+
+function usePatternUsage( patternId ) {
+	const [ usage, setUsage ] = useState( null );
+
+	useEffect( () => {
+		if ( ! patternId ) {
+			setUsage( null );
+			return;
+		}
+
+		let isStale = false;
+
+		apiFetch( { path: `/wp/v2/blocks/${ patternId }/usage` } ).then(
+			( response ) => {
+				if ( ! isStale ) {
+					setUsage( normalizeUsage( response ) );
+				}
+			},
+			() => {
+				/*
+				 * The route ships with the Gutenberg plugin, so it is absent on
+				 * a plain WordPress install, and a user without access to the
+				 * entries gets a permission error. Neither is worth an error
+				 * message in a summary panel: the section is left out instead.
+				 */
+				if ( ! isStale ) {
+					setUsage( null );
+				}
+			}
+		);
+
+		return () => {
+			isStale = true;
+		};
+	}, [ patternId ] );
+
+	return usage;
+}
+
+/**
+ * Tells where a synced pattern is used, so that its reach is visible before it
+ * is edited or deleted.
+ *
+ * @return {React.ReactNode} The rendered component.
+ */
+export default function PostPatternUsage() {
+	const patternId = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+		return getCurrentPostType() === PATTERN_POST_TYPE
+			? getCurrentPostId()
+			: null;
+	}, [] );
+	const usage = usePatternUsage( patternId );
+
+	if ( ! usage ) {
+		return null;
+	}
+
+	if ( usage.total === 0 ) {
+		return (
+			<div className="editor-post-pattern-usage">
+				<Text>{ __( 'Not used anywhere.' ) }</Text>
+			</div>
+		);
+	}
+
+	const summary = sprintf(
+		/* translators: %s: list of counts per post type, e.g. "5 Pages, 2 Templates". */
+		__( 'Used in %s.' ),
+		usage.groups
+			.map( ( group ) =>
+				sprintf(
+					/* translators: 1: number of entries. 2: name of a post type, e.g. "Pages". */
+					__( '%1$d %2$s' ),
+					group.items.length,
+					group.items.length === 1 ? group.singularName : group.name
+				)
+			)
+			.join( ', ' )
+	);
+
+	return (
+		<Collapsible.Root className="editor-post-pattern-usage">
+			<Collapsible.Trigger className="editor-post-pattern-usage__trigger">
+				<Text>{ summary }</Text>
+				<Icon
+					className="editor-post-pattern-usage__chevron"
+					icon={ chevronDown }
+					size={ 20 }
+				/>
+			</Collapsible.Trigger>
+			<Collapsible.Panel>
+				<Stack
+					className="editor-post-pattern-usage__list"
+					direction="column"
+					gap="sm"
+				>
+					{ usage.groups.map( ( group ) => (
+						<Stack key={ group.type } direction="column" gap="xs">
+							<Text variant="body-sm">{ group.name }</Text>
+							{ group.items.map( ( item ) => (
+								<Link
+									key={ item.id }
+									href={ getEditUrl( item.id, group.type ) }
+									openInNewTab
+								>
+									{ decodeEntities( item.title ) ||
+										__( '(no title)' ) }
+								</Link>
+							) ) }
+						</Stack>
+					) ) }
+				</Stack>
+			</Collapsible.Panel>
+		</Collapsible.Root>
+	);
+}

--- a/packages/editor/src/components/post-pattern-usage/style.scss
+++ b/packages/editor/src/components/post-pattern-usage/style.scss
@@ -1,0 +1,33 @@
+.editor-post-pattern-usage {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+.editor-post-pattern-usage__trigger {
+	align-items: center;
+	background: none;
+	border: none;
+	color: inherit;
+	cursor: var(--wpds-cursor-control);
+	display: flex;
+	font: inherit;
+	gap: var(--wpds-dimension-gap-xs);
+	padding: 0;
+	text-align: start;
+}
+
+.editor-post-pattern-usage__chevron {
+	fill: currentColor;
+	flex-shrink: 0;
+
+	@media not (prefers-reduced-motion) {
+		transition: rotate 0.15s ease-out;
+	}
+
+	.editor-post-pattern-usage__trigger[data-panel-open] & {
+		rotate: 180deg;
+	}
+}
+
+.editor-post-pattern-usage__list {
+	padding-top: var(--wpds-dimension-gap-xs);
+}

--- a/packages/editor/src/components/post-pattern-usage/test/index.jsdom.test.jsx
+++ b/packages/editor/src/components/post-pattern-usage/test/index.jsdom.test.jsx
@@ -1,0 +1,109 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
+import PostPatternUsage from '../';
+
+jest.mock( '@wordpress/data/src/components/use-select', () => jest.fn() );
+jest.mock( '@wordpress/api-fetch' );
+
+function setupUseSelectMock( postType = 'wp_block' ) {
+	useSelect.mockImplementation( ( cb ) =>
+		cb( () => ( {
+			getCurrentPostType: () => postType,
+			getCurrentPostId: () => 123,
+		} ) )
+	);
+}
+
+const USAGE = {
+	total: 3,
+	groups: [
+		{
+			type: 'page',
+			labels: { name: 'Pages', singular_name: 'Page' },
+			count: 2,
+			items: [
+				{ id: 1, title: 'About' },
+				{ id: 2, title: 'Contact &amp; support' },
+			],
+		},
+		{
+			type: 'wp_template',
+			labels: { name: 'Templates', singular_name: 'Template' },
+			count: 1,
+			items: [ { id: 3, title: 'Single Posts' } ],
+		},
+	],
+};
+
+describe( 'PostPatternUsage', () => {
+	beforeEach( () => {
+		setupUseSelectMock();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( USAGE );
+	} );
+
+	it( 'summarizes the entries the pattern is used in', async () => {
+		render( <PostPatternUsage /> );
+
+		expect(
+			await screen.findByText( 'Used in 2 Pages, 1 Template.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'lists the entries, linking each to its editor', async () => {
+		const user = userEvent.setup();
+		render( <PostPatternUsage /> );
+
+		await user.click( await screen.findByRole( 'button' ) );
+
+		expect( screen.getByRole( 'link', { name: /About/ } ) ).toHaveAttribute(
+			'href',
+			'post.php?post=1&action=edit'
+		);
+		// Titles arrive encoded, as they are stored.
+		expect(
+			screen.getByRole( 'link', { name: /Contact & support/ } )
+		).toBeInTheDocument();
+		// Templates are edited in the site editor.
+		expect(
+			screen.getByRole( 'link', { name: /Single Posts/ } )
+		).toHaveAttribute(
+			'href',
+			'site-editor.php?p=%2Fwp_template%2F3&canvas=edit'
+		);
+	} );
+
+	it( 'says so when the pattern is not used anywhere', async () => {
+		apiFetch.mockResolvedValue( { total: 0, groups: [] } );
+		render( <PostPatternUsage /> );
+
+		expect(
+			await screen.findByText( 'Not used anywhere.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing for a post that is not a pattern', () => {
+		setupUseSelectMock( 'page' );
+		const { container } = render( <PostPatternUsage /> );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when the endpoint is unavailable', async () => {
+		// A plain WordPress install, without the Gutenberg plugin.
+		apiFetch.mockRejectedValue( {
+			code: 'rest_no_route',
+			message: 'No route was found matching the URL and request method.',
+		} );
+
+		let container;
+		await act( async () => {
+			( { container } = render( <PostPatternUsage /> ) );
+		} );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/packages/editor/src/components/sidebar/post-summary.jsx
+++ b/packages/editor/src/components/sidebar/post-summary.jsx
@@ -11,6 +11,7 @@ import PostFeaturedImagePanel from '../post-featured-image/panel';
 import PostFormatPanel from '../post-format/panel';
 import PostLastEditedPanel from '../post-last-edited-panel';
 import PostPanelSection from '../post-panel-section';
+import PostPatternUsage from '../post-pattern-usage';
 import ReadingSettingsLink from '../reading-settings-link';
 import PostSchedulePanel from '../post-schedule/panel';
 import PostStatusPanel from '../post-status';
@@ -64,6 +65,7 @@ export default function PostSummary( { onActionPerformed } ) {
 							<Stack direction="column" gap="xs">
 								<PostContentInformation />
 								<PostLastEditedPanel />
+								<PostPatternUsage />
 							</Stack>
 							{ ! isRemovedPostStatusPanel && (
 								<Stack direction="column" gap="lg">

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -40,6 +40,7 @@
 @use "./components/post-locked-modal/style.scss" as *;
 @use "./components/post-panel-row/style.scss" as *;
 @use "./components/post-panel-section/style.scss" as *;
+@use "./components/post-pattern-usage/style.scss" as *;
 @use "./components/post-publish-panel/style.scss" as *;
 @use "./components/post-revisions-preview/style.scss" as *;
 @use "./components/post-revisions-timeline/style.scss" as *;

--- a/phpunit/pattern-usage-test.php
+++ b/phpunit/pattern-usage-test.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Unit tests covering the pattern usage endpoint.
+ *
+ * @package gutenberg
+ *
+ * @covers ::gutenberg_get_pattern_usage
+ */
+class Gutenberg_Pattern_Usage_Test extends WP_Test_REST_TestCase {
+
+	protected static $admin_id;
+	protected static $subscriber_id;
+	protected static $pattern_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		self::$pattern_id = $factory->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_title'   => 'Joe testimonial',
+				'post_content' => '<!-- wp:paragraph -->A testimonial.<!-- /wp:paragraph -->',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$pattern_id, true );
+		self::delete_user( self::$admin_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	/**
+	 * Dispatches a request for the pattern created for this test class.
+	 *
+	 * @param int|null $pattern_id Pattern to look up. Defaults to the test pattern.
+	 * @return WP_REST_Response The response.
+	 */
+	private function get_usage( $pattern_id = null ) {
+		$pattern_id = null === $pattern_id ? self::$pattern_id : $pattern_id;
+
+		return rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/wp/v2/blocks/' . $pattern_id . '/usage' )
+		);
+	}
+
+	/**
+	 * Returns the entry IDs the response reports for a given post type.
+	 *
+	 * @param WP_REST_Response $response The response.
+	 * @param string           $type     Post type name.
+	 * @return int[] The reported IDs.
+	 */
+	private function get_reported_ids( $response, $type ) {
+		foreach ( $response->get_data()['groups'] as $group ) {
+			if ( $type === $group['type'] ) {
+				return wp_list_pluck( $group['items'], 'id' );
+			}
+		}
+
+		return array();
+	}
+
+	public function test_reports_entries_grouped_by_post_type() {
+		wp_set_current_user( self::$admin_id );
+
+		$page = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_title'   => 'About',
+				'post_content' => '<!-- wp:block {"ref":' . self::$pattern_id . '} /-->',
+			)
+		);
+		// Nested inside another block, and with sibling attributes.
+		$post = self::factory()->post->create(
+			array(
+				'post_content' => '<!-- wp:group --><!-- wp:block {"align":"wide","ref":' . self::$pattern_id . '} /--><!-- /wp:group -->',
+			)
+		);
+
+		$response = $this->get_usage();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 2, $response->get_data()['total'] );
+		$this->assertSame( array( $page ), $this->get_reported_ids( $response, 'page' ) );
+		$this->assertSame( array( $post ), $this->get_reported_ids( $response, 'post' ) );
+	}
+
+	public function test_reports_templates() {
+		wp_set_current_user( self::$admin_id );
+
+		$template = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_template',
+				'post_title'   => 'Single Posts',
+				'post_content' => '<!-- wp:block {"ref":' . self::$pattern_id . '} /-->',
+			)
+		);
+
+		$response = $this->get_usage();
+
+		$this->assertSame( array( $template ), $this->get_reported_ids( $response, 'wp_template' ) );
+	}
+
+	public function test_ignores_a_reference_to_another_pattern() {
+		wp_set_current_user( self::$admin_id );
+
+		// `"ref":12` is a substring of `"ref":123`, so the database search
+		// matches this post even though it references another pattern.
+		self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:block {"ref":' . self::$pattern_id . '0} /-->',
+			)
+		);
+
+		$response = $this->get_usage();
+
+		$this->assertSame( 0, $response->get_data()['total'] );
+	}
+
+	public function test_ignores_the_ref_attribute_of_other_blocks() {
+		wp_set_current_user( self::$admin_id );
+
+		// `core/navigation` points at a `wp_navigation` post with an attribute
+		// of the same name.
+		self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:navigation {"ref":' . self::$pattern_id . '} /-->',
+			)
+		);
+
+		$response = $this->get_usage();
+
+		$this->assertSame( 0, $response->get_data()['total'] );
+	}
+
+	public function test_ignores_trashed_entries() {
+		wp_set_current_user( self::$admin_id );
+
+		$page = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:block {"ref":' . self::$pattern_id . '} /-->',
+			)
+		);
+		wp_trash_post( $page );
+
+		$response = $this->get_usage();
+
+		$this->assertSame( 0, $response->get_data()['total'] );
+	}
+
+	public function test_reports_no_usage_for_an_unused_pattern() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->get_usage();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 0, $response->get_data()['total'] );
+		$this->assertSame( array(), $response->get_data()['groups'] );
+	}
+
+	public function test_requires_permission_to_edit_the_pattern() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$this->assertErrorResponse( 'rest_cannot_read_pattern_usage', $this->get_usage(), 403 );
+	}
+
+	public function test_returns_404_for_a_post_that_is_not_a_pattern() {
+		wp_set_current_user( self::$admin_id );
+
+		$page = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$this->assertErrorResponse( 'rest_post_invalid_id', $this->get_usage( $page ), 404 );
+	}
+}


### PR DESCRIPTION
## What?

Closes #58990

It's impossible to know where on a site a sync pattern is used and whether it's safe to delete it

## Why?
Deleting a pattern in use can actually cause missing content on the site.

## How?

The summary panel now reports, between last edit date and the status rows: _"Used in 5 Pages, 2 Templates."_ with an expandable section showing each entries + a link. A unused pattern is also shown as such.


Instead of creating a pattern<->post relationship tracking mechanism (that'd have to be kept in sync), it asynchronously query the database search for posts' content `LIKE` that `ref`

## Testing Instructions
- Create a pattern an use it
- Look at the sync pattern list and click that pattern
- On the side-panel, look at the additional information provided


### Testing Instructions for Keyboard
Usuable TAB key move to the next section. Enter expand/collapse the usage drop-down.


## Screenshots

<img width="213" height="312" alt="Screenshot from 2026-09-04 16-04-47" src="https://github.com/user-attachments/assets/ed4cde84-c004-4966-9b86-c34bbc11b1bb" />
<img width="236" height="435" alt="Screenshot from 2026-09-04 16-04-57" src="https://github.com/user-attachments/assets/9539c442-0779-4f00-b189-045ac6ac0e2a" />

## Details

The counts come from a new `wp/v2/blocks/<id>/usage` route. It narrows the posts table with a whole-phrase content search for the reference, then parses each candidate to confirm it: `"ref":12` is a substring of `"ref":123`, and `core/navigation` carries a `ref` attribute of its own, so the search alone, while efficient, must be refined. Every post type that supports the editor is searched, templates and other patterns included. Entries the user cannot read are left out.

In absence of the REST route, the section is simply absent on a plain WordPress install.

Sample SQL request:

`SELECT   wp_posts.ID   FROM wp_posts    WHERE 1=1  AND wp_posts.ID NOT IN (54443) AND (((wp_posts.post_content LIKE '%\"ref\":54443%')))  AND wp_posts.post_password = '' AND wp_posts.post_type IN ( <... post types ...> ) AND ((wp_posts.post_status <> 'trash' AND wp_posts.post_status <> 'auto-draft'))      ORDER BY wp_posts.post_title ASC`


## Use of AI Tools

Opus 5

PHP code reviewed
Result tested
SQL query monitored