### PR TITLE
Icons: Fix color overrides for stroke-based icons

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Block icons: Color icons with `color` alongside `fill` in forced colors mode, so stroke-based block icons stay visible in high contrast mode. Affects the block icon, list view and inserter icons ([#82477](https://github.com/WordPress/gutenberg/pull/82477)).
 -   Flex layout: Output `flex-direction: row` when a viewport override switches a vertical layout to horizontal, so the base `flex-direction: column` no longer keeps applying on that viewport ([#82364](https://github.com/WordPress/gutenberg/pull/82364)).
 -   `BlockManager`: Color library block icons with `color` while retaining a `fill` fallback for custom icons that do not use `currentColor`. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   Block List Appender: Show the appender button as a drop target when dragging a block over an empty container such as a Column, restoring the reveal that the `visibility`-to-`opacity` migration left behind ([#77852](https://github.com/WordPress/gutenberg/pull/77852)).

--- a/packages/block-editor/src/components/block-icon/content.scss
+++ b/packages/block-editor/src/components/block-icon/content.scss
@@ -19,7 +19,9 @@
 			// Optimize for high contrast modes.
 			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
 			@media (forced-colors: active) {
+				// Keep `fill` as a fallback for custom block icons that do not use `currentColor`.
 				fill: CanvasText;
+				color: CanvasText;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-icon/style.scss
+++ b/packages/block-editor/src/components/block-icon/style.scss
@@ -19,7 +19,9 @@
 			// Optimize for high contrast modes.
 			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
 			@media (forced-colors: active) {
+				// Keep `fill` as a fallback for custom block icons that do not use `currentColor`.
 				fill: CanvasText;
+				color: CanvasText;
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -44,7 +44,7 @@
 	.block-editor-block-lock-modal__lock-icon {
 		flex-shrink: 0;
 		margin-right: $grid-unit-15;
-		fill: $gray-900;
+		color: $gray-900;
 	}
 
 	&:hover {

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -82,7 +82,7 @@
 		height: 24px;
 
 		.block-editor-patterns__pattern-icon {
-			fill: var(--wp-block-synced-color);
+			color: var(--wp-block-synced-color);
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-visibility/style.scss
+++ b/packages/block-editor/src/components/block-visibility/style.scss
@@ -33,7 +33,7 @@
 		}
 
 		&-icon--checked {
-			fill: $gray-300;
+			color: $gray-300;
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -52,7 +52,9 @@
 			// Optimize for high contrast modes.
 			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
 			@media (forced-colors: active) {
+				// Keep `fill` as a fallback for custom block icons that do not use `currentColor`.
 				fill: CanvasText;
+				color: CanvasText;
 			}
 		}
 	}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+-   `Button`, `Placeholder`: Color icons with `color` alongside `fill` in forced colors mode, so stroke-based icons stay visible in high contrast mode ([#82477](https://github.com/WordPress/gutenberg/pull/82477)).
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `BorderBoxControl`: Give the group of border controls an accessible name from the `label` prop, by rendering the wrapper as a `role="group"` associated with the label through `aria-labelledby`. A consumer-supplied `aria-labelledby` or `aria-label` takes precedence over `label` and names the group instead; the wrapper is only given the `group` role when one of the three provides a name. A hidden label (`hideLabelFromVision`) now renders as a `span` rather than a `label` element, matching the visible one ([#82279](https://github.com/WordPress/gutenberg/pull/82279)).

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -372,7 +372,9 @@
 		// Optimize for high contrast modes.
 		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
 		@media (forced-colors: active) {
+			// Keep `fill` as a fallback for custom icons that do not use `currentColor`.
 			fill: CanvasText;
+			color: CanvasText;
 		}
 	}
 }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -54,7 +54,9 @@
 		// Optimize for high contrast modes.
 		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
 		@media (forced-colors: active) {
+			// Keep `fill` as a fallback for custom icons that do not use `currentColor`.
 			fill: CanvasText;
+			color: CanvasText;
 		}
 	}
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -50,11 +50,10 @@
 .dataforms-layouts-panel__field-trigger--edit-always
 .dataforms-layouts-panel__field-trigger-icon {
 	opacity: 1;
-	fill: currentColor;
 
 	&:hover,
 	&:focus-visible {
-		fill: var(--wpds-color-foreground-interactive-brand);
+		color: var(--wpds-color-foreground-interactive-brand);
 	}
 }
 

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -28,11 +28,6 @@
 	}
 }
 
-.edit-site-patterns__pattern-icon {
-	fill: var(--wp-block-synced-color);
-	flex-shrink: 0;
-}
-
 .edit-site-patterns__section-header {
 	border-bottom: 1px solid #f0f0f0;
 	padding: $grid-unit-20 $grid-unit-60;

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -101,7 +101,7 @@
 	display: none;
 	pointer-events: none;
 	svg {
-		fill: $gray-600;
+		color: $gray-600;
 	}
 	@include break-small {
 		display: flex;


### PR DESCRIPTION
- Follow up to #78808.
- Noticed while reviewing #82129.

## What?

This PR makes SVG icons colorable through the `color` property so that color overrides reach stroke-based icons.

## Why?

Since #78808, stroke-based icons render an inline `fill: none` and paint themselves with `stroke="currentColor"`:

```html
<svg class="my-icon" viewBox="0 0 24 24" style="fill: none" stroke="currentColor">
	<path d="…" />
</svg>
```

Any styling that colors an icon via `fill` therefore stops working:

```css
.my-icon {
	fill: #007cba;
}
```

## How?

- Replace `fill` with `color` where the rule exists to color an icon.
- Where a consumer may supply a custom icon that does not use `currentColor`, keep `fill` as a fallback and add `color` alongside it.
- Rules that currently target non-stroke icons are updated the same way, to avoid the same regression when those icons are redrawn.
- Only `@wordpress/block-editor` and `@wordpress/components` get a CHANGELOG entry: they are the packages where an icon is visually fixed. The other packages only receive the preventive change.

## Testing Instructions

I have left an inline comment on each change describing where to look.

## Screenshots or screencast

Screenshots are attached to the inline comments, next to the change they belong to.

## Use of AI Tools

Claude Code was used to locate the affected styles and to draft this change. I reviewed every change and take responsibility for it.
