### PR TITLE
wp-env: Fix Docker build errors with Debian Bullseye repositories

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Point the apt sources of the bullseye-based WordPress images (PHP 7.4 and 8.0) at `archive.debian.org`, so building them no longer fails now that Debian 11 has reached end-of-life and left the regular mirrors.
+-   Point the apt sources of the bullseye-based WordPress images (PHP 7.4 and 8.0) at `archive.debian.org`, so building them no longer fails now that Debian 11 has reached end-of-life and left the regular mirrors ([#82478](https://github.com/WordPress/gutenberg/pull/82478)).
 
 ## 11.14.0 (2026-08-26)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Point the apt sources of the bullseye-based WordPress images (PHP 7.4 and 8.0) at `archive.debian.org`, so building them no longer fails now that Debian 11 has reached end-of-life and left the regular mirrors.
+
 ## 11.14.0 (2026-08-26)
 
 ### Bug Fixes

--- a/packages/env/lib/runtime/docker/docker-config.js
+++ b/packages/env/lib/runtime/docker/docker-config.js
@@ -95,6 +95,13 @@ RUN sed -i 's|deb.debian.org/debian buster|archive.debian.org/debian buster|g' /
 RUN sed -i 's|security.debian.org/debian-security buster/updates|archive.debian.org/debian-security buster/updates|g' /etc/apt/sources.list
 RUN sed -i '/buster-updates/d' /etc/apt/sources.list
 
+# bullseye (https://www.debian.org/News/2026/20260831)
+# The security suite is not on archive.debian.org yet, so it is dropped rather
+# than rewritten.
+RUN sed -i 's|deb.debian.org/debian bullseye|archive.debian.org/debian bullseye|g' /etc/apt/sources.list
+RUN sed -i '/bullseye-security/d' /etc/apt/sources.list
+RUN sed -i '/bullseye-updates/d' /etc/apt/sources.list
+
 # Create the host's user so that we can match ownership in the container.
 ARG HOST_USERNAME
 ARG HOST_UID


### PR DESCRIPTION
Related to #70718.

## What?

Recently, Docker startup has been failing in unit tests for the following reasons:

Example: https://github.com/WordPress/gutenberg/actions/runs/33920718443

```
#38 0.740 The following NEW packages will be installed:
#38 0.740   sudo
#38 0.769 Err:1 http://deb.debian.org/debian-security bullseye-security/main amd64 sudo amd64 1.9.5p2-3+deb11u4
#38 0.769   404  Not Found [IP: 146.75.30.132 80]
#38 0.773 E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/s/sudo/sudo_1.9.5p2-3%2bdeb11u4_amd64.deb  404  Not Found [IP: 146.75.30.132 80]
#38 0.773 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
#38 ERROR: process "/bin/sh -c apt-get -qy install sudo" did not complete successfully: exit code: 100
------
 > [wordpress 15/25] RUN apt-get -qy install sudo:
------
target wordpress: failed to solve: process "/bin/sh -c apt-get -qy install sudo" did not complete successfully: exit code: 100
Error: Process completed with exit code 1.
```

## Why?

`bullseye` reached end-of-life on 2026-08-31, and its packages have since left the regular mirrors:

https://www.debian.org/News/2026/20260831

`wordpress:php7.4` and `wordpress:php8.0` are the bullseye-based images, which is why only those two matrix entries fail.

## How?

Point the `bullseye` suite at `archive.debian.org`, the same way `stretch` and `buster` are already handled.

The security suite is dropped rather than rewritten: `archive.debian.org/debian-security` does not carry `bullseye-security` yet, so rewriting it fails `apt-get update` with a 404 on the `Release` file.

There is no `debian-devel-announce` post for the bullseye archival yet, so the comment links to the end-of-life announcement instead of a mailing list message like the `stretch` and `buster` comments do.

## Testing Instructions

All CI checks should pass.

Note that the failure is intermittent. `deb.debian.org` is a CDN and the bullseye packages are being withdrawn node by node, so `trunk` may still build fine from your location even though CI hit a 404 (in run 33920718443 only the `PHP 7.4 multisite (WP previous major version)` job failed). Reproducing the failure locally is not reliable, so verify the fix instead.

The images concerned are the bullseye-based ones, PHP 7.4 and 8.0. Add a `.wp-env.override.json`:

```json
{
	"phpVersion": "7.4"
}
```

Then rebuild the environment:

```
npm run wp-env destroy
docker builder prune -af
npm run wp-env start
```

`npm run wp-env destroy` leaves the BuildKit build cache behind, so `docker builder prune -af` is needed to make `RUN apt-get -qy install sudo` run again instead of being served from cache.

> [!WARNING]
> `docker builder prune -af` deletes the build cache for **every** project on the machine, not just Gutenberg. Unrelated images will be slow to rebuild afterwards. Run `docker builder du` first to see how much you are about to discard.

The environment should start, and the apt sources should now point at the archive:

```
npm run wp-env run wordpress cat /etc/apt/sources.list
```

```
# deb http://snapshot.debian.org/archive/debian/20221114T000000Z bullseye main
deb http://archive.debian.org/debian bullseye main
# deb http://snapshot.debian.org/archive/debian-security/20221114T000000Z bullseye-security main
# deb http://snapshot.debian.org/archive/debian/20221114T000000Z bullseye-updates main
```

The `bullseye-security` and `bullseye-updates` entries are gone, and the remaining suite is served from `archive.debian.org`.

## Use of AI Tools

Claude Code was used to track down the cause and to draft this change. I reviewed it and take responsibility for it.

