### PR TITLE
Icons: Remove the obsolete forced colors mode hack

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -24,6 +24,7 @@
 -   Element styles: Register each block's element-style CSS override with the block's `clientId`, so the editor orders them by block position instead of registration order. A parent's link color re-registered after a child's (e.g. by resetting and re-picking it) no longer overrides the child's own link color in the canvas ([#77833](https://github.com/WordPress/gutenberg/pull/77833)).
 -   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 -   `BlockVariationPicker`: Set icon colors with `color` so stroke-based variation icons retain their intended unfilled appearance, while keeping a non-important `fill` fallback for third-party icons that do not use `currentColor`. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
+-   `BlockIcon`, List View: Remove the `fill: CanvasText` override for forced colors mode, so icons follow the forced text color again. Fill-based icons were pinned to `CanvasText` while stroke-based ones followed `currentColor`, which made the list view's icon colors inconsistent. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
 
 ### Internal
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -24,7 +24,7 @@
 -   Element styles: Register each block's element-style CSS override with the block's `clientId`, so the editor orders them by block position instead of registration order. A parent's link color re-registered after a child's (e.g. by resetting and re-picking it) no longer overrides the child's own link color in the canvas ([#77833](https://github.com/WordPress/gutenberg/pull/77833)).
 -   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 -   `BlockVariationPicker`: Set icon colors with `color` so stroke-based variation icons retain their intended unfilled appearance, while keeping a non-important `fill` fallback for third-party icons that do not use `currentColor`. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
--   `BlockIcon`, List View: Remove the `fill: CanvasText` override for forced colors mode, so icons follow the forced text color again. Fill-based icons were pinned to `CanvasText` while stroke-based ones followed `currentColor`, which made the list view's icon colors inconsistent. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
+-   `BlockIcon`, List View: Remove the obsolete `fill: CanvasText` override for forced colors mode. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
 
 ### Internal
 

--- a/packages/block-editor/src/components/block-icon/content.scss
+++ b/packages/block-editor/src/components/block-icon/content.scss
@@ -15,12 +15,6 @@
 	&.has-colors {
 		svg {
 			fill: currentColor;
-
-			// Optimize for high contrast modes.
-			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
-			@media (forced-colors: active) {
-				fill: CanvasText;
-			}
 		}
 	}
 

--- a/packages/block-editor/src/components/block-icon/style.scss
+++ b/packages/block-editor/src/components/block-icon/style.scss
@@ -15,12 +15,6 @@
 	&.has-colors {
 		svg {
 			fill: currentColor;
-
-			// Optimize for high contrast modes.
-			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
-			@media (forced-colors: active) {
-				fill: CanvasText;
-			}
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -49,11 +49,6 @@
 
 		svg {
 			fill: currentColor;
-			// Optimize for high contrast modes.
-			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
-			@media (forced-colors: active) {
-				fill: CanvasText;
-			}
 		}
 	}
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,7 +21,7 @@
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `ItemGroup`: Drop the blanket `path { fill: currentColor }` rule that was overriding stroke-based icons' intended fill via inheritance bypass. Paths without an explicit fill still inherit `currentColor` from the surrounding SVG. Custom paths that specify a fill now retain it instead of being overridden by ItemGroup. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `Tip`: Preserve the intended yellow color after its icon became stroke-based. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
--   `Button`, `Placeholder`: Remove the `fill: CanvasText` override for forced colors mode, so icons follow the forced text color again instead of being pinned to `CanvasText`. The browser bug it worked around is fixed: the UA default of `forced-color-adjust` for the SVG root changed from `none` to `preserve-parent-color`. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
+-   `Button`, `Placeholder`: Remove the obsolete `fill: CanvasText` override for forced colors mode. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `ItemGroup`: Drop the blanket `path { fill: currentColor }` rule that was overriding stroke-based icons' intended fill via inheritance bypass. Paths without an explicit fill still inherit `currentColor` from the surrounding SVG. Custom paths that specify a fill now retain it instead of being overridden by ItemGroup. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `Tip`: Preserve the intended yellow color after its icon became stroke-based. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
+-   `Button`, `Placeholder`: Remove the `fill: CanvasText` override for forced colors mode, so icons follow the forced text color again instead of being pinned to `CanvasText`. The browser bug it worked around is fixed: the UA default of `forced-color-adjust` for the SVG root changed from `none` to `preserve-parent-color` in Chrome/Edge 106. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,7 +21,7 @@
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `ItemGroup`: Drop the blanket `path { fill: currentColor }` rule that was overriding stroke-based icons' intended fill via inheritance bypass. Paths without an explicit fill still inherit `currentColor` from the surrounding SVG. Custom paths that specify a fill now retain it instead of being overridden by ItemGroup. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `Tip`: Preserve the intended yellow color after its icon became stroke-based. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
--   `Button`, `Placeholder`: Remove the `fill: CanvasText` override for forced colors mode, so icons follow the forced text color again instead of being pinned to `CanvasText`. The browser bug it worked around is fixed: the UA default of `forced-color-adjust` for the SVG root changed from `none` to `preserve-parent-color` in Chrome/Edge 106. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
+-   `Button`, `Placeholder`: Remove the `fill: CanvasText` override for forced colors mode, so icons follow the forced text color again instead of being pinned to `CanvasText`. The browser bug it worked around is fixed: the UA default of `forced-color-adjust` for the SVG root changed from `none` to `preserve-parent-color`. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
 
 ### Internal
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -368,12 +368,6 @@
 		fill: currentColor;
 		outline: none;
 		flex-shrink: 0;
-
-		// Optimize for high contrast modes.
-		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
-		@media (forced-colors: active) {
-			fill: CanvasText;
-		}
 	}
 }
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -51,11 +51,6 @@
 	.block-editor-block-icon {
 		margin-right: $grid-unit-05;
 		fill: currentColor;
-		// Optimize for high contrast modes.
-		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
-		@media (forced-colors: active) {
-			fill: CanvasText;
-		}
 	}
 
 	// Don't take up space if the label is empty.

--- a/routes/guidelines/components/block-guidelines.scss
+++ b/routes/guidelines/components/block-guidelines.scss
@@ -19,11 +19,6 @@
 			min-height: 20px;
 			max-width: 24px;
 			max-height: 24px;
-
-			// Optimize for high contrast modes.
-			@media (forced-colors: active) {
-				fill: CanvasText;
-			}
 		}
 	}
 


### PR DESCRIPTION
## What?

-   See #33062
-   Found while reviewing #82129

Removes the `fill: CanvasText` overrides that were added for Windows High Contrast Mode. As a side effect, this fixes the inconsistent icon colors in the list view.

|Before|After|
|-|-|
| <img width="356" height="368" alt="image" src="https://github.com/user-attachments/assets/ba0888db-21db-4b3e-8b83-f36d8e16b3b0" />|<img width="350" height="360" alt="image" src="https://github.com/user-attachments/assets/0dcb68a3-0304-4db3-b25d-77c740ccbb5a" />|

## Why?

Chromium-based browsers used to treat SVGs as decorative and did not force their colors, so SVG icons could become unreadable in high contrast mode. #33062 worked around that by hardcoding the system color:

```css
@media (forced-colors: active) {
	fill: CanvasText;
}
```

That browser behavior has since been fixed. The UA default of `forced-color-adjust` for the SVG root element changed from `none` to `preserve-parent-color`, so `fill: currentColor` now resolves to the forced color again ([Intent to Ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/zEDgmKsyjTY), [Chrome Platform Status](https://chromestatus.com/feature/4887620095049728)).

<img width="1135" height="508" alt="svg" src="https://github.com/user-attachments/assets/e79be014-4ea5-4fbf-ac84-9cfd04b232cd" />


Worse, keeping the workaround now causes the mismatch. #78808 redrew a number of icons as stroke-based, and their SVG root carries an inline `style="fill: none"`:

```html
<svg ... style="fill: none" stroke="currentColor" stroke-width="1.5">
```

An inline style outranks the stylesheet, so `fill: CanvasText` never applies to those icons — they follow `currentColor`. Icons that are still fill-based do get pinned to `CanvasText`, even where the surrounding text is forced to `LinkText` (list view rows are links) or `HighlightText` (selected row). Dropping the override lets every icon follow the text color again.

## Testing Instructions

On Windows, turn on high contrast mode. On macOS, open Chrome DevTools, open the Rendering panel and set **Emulate CSS media feature forced-colors** to `forced-colors: active`.

The only fix this PR makes visible is the icon color mismatch in the list view. Everywhere else the icons should look exactly as they do now.

Firefox does not support `forced-color-adjust: preserve-parent-color` at all, so there should be no visual change there.

## Use of AI Tools

Claude Code was used to research the browser behavior and to draft the change and this description. The author reviewed and takes responsibility for the result.





