### PR TITLE
Media: route all vips writes through buildSaveOptions

### DIFF
--- a/packages/upload-media/src/store/private-actions.ts
+++ b/packages/upload-media/src/store/private-actions.ts
@@ -1152,6 +1152,7 @@ export function resizeCropItem( id: QueueItemId, args?: ResizeCropItemArgs ) {
 					quality: args.quality,
 					stripMeta: imageStripMeta,
 					maxBitdepth: imageMaxBitDepth,
+					interlaced: args.interlaced,
 				}
 			);
 
@@ -1223,12 +1224,23 @@ export function rotateItem( id: QueueItemId, args?: RotateItemArgs ) {
 
 		const startTime = performance.now();
 
+		// Metadata stripping, quality and bit depth cap from the
+		// `image_strip_meta`, `wp_editor_set_quality` and `image_max_bit_depth`
+		// filters, carried in the editor settings.
+		const { imageStripMeta, imageMaxBitDepth, imageQuality } =
+			select.getSettings();
+
 		try {
 			const file = await vipsRotateImage(
 				item.id,
 				item.file,
 				args.orientation,
-				item.abortController?.signal
+				item.abortController?.signal,
+				{
+					quality: imageQuality ?? DEFAULT_OUTPUT_QUALITY,
+					stripMeta: imageStripMeta,
+					maxBitdepth: imageMaxBitDepth,
+				}
 			);
 
 			measure( {
@@ -1776,7 +1788,7 @@ export function generateThumbnails( id: QueueItemId ) {
 				const thumbnailOperations: Operation[] = [
 					[
 						OperationType.ResizeCrop,
-						{ resize: imageSize, quality: sizeQuality },
+						{ resize: imageSize, quality: sizeQuality, interlaced },
 					],
 				];
 
@@ -1847,6 +1859,7 @@ export function generateThumbnails( id: QueueItemId ) {
 									},
 									isThresholdResize: true,
 									quality: defaultQuality,
+									interlaced,
 								},
 							],
 						];

--- a/packages/upload-media/src/store/types.ts
+++ b/packages/upload-media/src/store/types.ts
@@ -371,6 +371,11 @@ export interface OperationArgs {
 		 * when omitted.
 		 */
 		quality?: number;
+		/**
+		 * Whether to use interlaced/progressive encoding, from the
+		 * `image_save_progressive` filter.
+		 */
+		interlaced?: boolean;
 	};
 	[ OperationType.Rotate ]: {
 		/**

--- a/packages/upload-media/src/store/utils/index.ts
+++ b/packages/upload-media/src/store/utils/index.ts
@@ -57,6 +57,10 @@ interface VipsResizeOptions {
 	 * Maximum output bit depth.
 	 */
 	maxBitdepth?: number;
+	/**
+	 * Whether to use interlaced/progressive mode.
+	 */
+	interlaced?: boolean;
 }
 
 /**
@@ -211,6 +215,7 @@ export async function vipsResizeImage(
 		quality,
 		stripMeta,
 		maxBitdepth,
+		interlaced,
 	} = options;
 
 	if ( signal?.aborted ) {
@@ -224,6 +229,7 @@ export async function vipsResizeImage(
 			quality,
 			stripMeta,
 			maxBitdepth,
+			interlaced,
 		} );
 
 	let fileName = file.name;
@@ -272,13 +278,15 @@ export async function vipsResizeImage(
  * @param file        File object.
  * @param orientation EXIF orientation value (1-8).
  * @param signal      Optional abort signal to cancel the operation.
+ * @param options     Save options for the rotated file.
  * @return Rotated ImageFile with updated dimensions.
  */
 export async function vipsRotateImage(
 	id: QueueItemId,
 	file: File,
 	orientation: number,
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	options: VipsConvertOptions = {}
 ) {
 	if ( signal?.aborted ) {
 		throw new Error( 'Operation aborted' );
@@ -294,7 +302,8 @@ export async function vipsRotateImage(
 		id,
 		await file.arrayBuffer(),
 		file.type,
-		orientation
+		orientation,
+		options
 	);
 
 	// Add '-rotated' suffix to filename, matching WordPress core behavior.

--- a/packages/vips/README.md
+++ b/packages/vips/README.md
@@ -119,6 +119,7 @@ _Parameters_
 -   _buffer_ `ArrayBuffer`: Original file buffer.
 -   _type_ `string`: Mime type.
 -   _orientation_ `number`: EXIF orientation value (1-8).
+-   _options_ `ConvertImageOptions`: Save options for the rotated file.
 
 _Returns_
 
@@ -225,6 +226,7 @@ _Parameters_
 -   _buffer_ `ArrayBuffer`: Original file buffer.
 -   _type_ `string`: Mime type.
 -   _orientation_ `number`: EXIF orientation value (1-8).
+-   _options_ `ConvertImageOptions`: Save options for the rotated file.
 
 _Returns_
 

--- a/packages/vips/src/index.ts
+++ b/packages/vips/src/index.ts
@@ -190,50 +190,22 @@ export async function convertImageFormat(
 			}
 		};
 
-		const saveOptions: SaveOptions< typeof outputType > = {
-			// Strip metadata except ICC color profiles,
-			// matching WordPress core's behavior. The `image_strip_meta`
-			// filter can disable stripping entirely.
-			keep: stripMeta ? 'icc' : 'all',
-		};
+		// Only AVIF carries a source bit depth worth preserving, and the
+		// `image_max_bit_depth` filter can cap it.
+		const sourceBitdepth =
+			'image/avif' === outputType ? getSourceBitdepth( image ) : 8;
 
-		if ( supportsQuality( outputType ) ) {
-			saveOptions.Q = quality * 100;
-		}
-
-		if ( interlaced && supportsInterlace( outputType ) ) {
-			saveOptions.interlace = interlaced;
-		}
-
-		// Keep indexed sources indexed. libvips decodes a palette image into
-		// RGB(A) pixels, so without this a compressed or converted PNG is
-		// written as truecolour and can grow several times larger than the
-		// indexed original.
-		// See https://core.trac.wordpress.org/ticket/65922.
-		if ( 'image/png' === outputType && isPaletteImage( image ) ) {
-			saveOptions.palette = true;
-		}
-
-		// See https://github.com/swissspidy/media-experiments/issues/324.
-		if ( 'image/avif' === outputType ) {
-			saveOptions.effort = 2;
-
-			// Preserve the source bit depth so high-bit-depth (10/12-bit) HDR
-			// images stay high-bit-depth when compressed or converted to AVIF
-			// instead of being flattened to 8-bit. Unlike resizing, this path
-			// keeps the decoded 16-bit image, so no extra handling is needed.
-			// The `image_max_bit_depth` filter can cap the output depth; the
-			// depth is set explicitly whenever the source is high-bit-depth,
-			// since heifsave would otherwise default to 12-bit for 16-bit
-			// pixel data.
-			const sourceBitdepth = getSourceBitdepth( image );
-			if ( sourceBitdepth > 8 ) {
-				saveOptions.bitdepth = resolveSaveBitdepth(
-					sourceBitdepth,
-					maxBitdepth
-				);
-			}
-		}
+		const saveOptions = buildSaveOptions( {
+			type: outputType,
+			quality,
+			bitdepth:
+				sourceBitdepth > 8
+					? resolveSaveBitdepth( sourceBitdepth, maxBitdepth )
+					: undefined,
+			stripMeta,
+			isPalette: isPaletteImage( image ),
+			interlaced,
+		} );
 
 		const outBuffer = image.writeToBuffer( `.${ ext }`, saveOptions );
 		const result = outBuffer.buffer;
@@ -474,29 +446,32 @@ function resolveSaveBitdepth(
 /**
  * Builds save options for writing an image to a buffer.
  *
- * @param options           Save option inputs.
- * @param options.type      Output mime type.
- * @param options.quality   Desired quality (0-1).
- * @param options.bitdepth  Save bit depth; values above 8 are preserved for
- *                          AVIF.
- * @param options.stripMeta Whether to strip metadata (except color
- *                          profiles), from the `image_strip_meta` filter.
- * @param options.isPalette Whether the source image was indexed (palette)
- *                          encoded.
+ * @param options            Save option inputs.
+ * @param options.type       Output mime type.
+ * @param options.quality    Desired quality (0-1).
+ * @param options.bitdepth   Save bit depth; values above 8 are preserved for
+ *                           AVIF.
+ * @param options.stripMeta  Whether to strip metadata (except color
+ *                           profiles), from the `image_strip_meta` filter.
+ * @param options.isPalette  Whether the source image was indexed (palette)
+ *                           encoded.
+ * @param options.interlaced
  * @return Save options object.
  */
 function buildSaveOptions( {
 	type,
 	quality,
-	bitdepth = 8,
+	bitdepth,
 	stripMeta = true,
 	isPalette = false,
+	interlaced = false,
 }: {
 	type: string;
 	quality: number;
 	bitdepth?: number;
 	stripMeta?: boolean;
 	isPalette?: boolean;
+	interlaced?: boolean;
 } ): SaveOptions< string > {
 	const saveOptions: SaveOptions< typeof type > = {
 		// Strip metadata except ICC color profiles or gainmaps,
@@ -507,6 +482,13 @@ function buildSaveOptions( {
 
 	if ( supportsQuality( type ) ) {
 		saveOptions.Q = quality * 100;
+	}
+
+	// Core applies the `image_save_progressive` filter in the image editor's
+	// `_save()`, which every write goes through, so it does not depend on the
+	// operation that produced the image.
+	if ( interlaced && supportsInterlace( type ) ) {
+		saveOptions.interlace = interlaced;
 	}
 
 	// Keep indexed sources indexed. libvips decodes a palette PNG into RGB(A)
@@ -521,9 +503,10 @@ function buildSaveOptions( {
 	if ( 'image/avif' === type ) {
 		saveOptions.effort = 2;
 
-		// Preserve the source bit depth so high-bit-depth (10/12-bit) HDR
-		// images are not flattened to 8-bit on output.
-		if ( bitdepth > 8 ) {
+		// Set for high-bit-depth sources so the output depth is the resolved
+		// one, since heifsave would otherwise default to 12-bit for 16-bit
+		// pixel data and ignore the `image_max_bit_depth` cap.
+		if ( undefined !== bitdepth ) {
 			saveOptions.bitdepth = bitdepth;
 		}
 	}
@@ -634,6 +617,7 @@ export async function resizeImage(
 		quality = 0.82,
 		stripMeta = true,
 		maxBitdepth = 16,
+		interlaced = false,
 	} = options;
 	const ext = type.split( '/' )[ 1 ];
 
@@ -698,9 +682,10 @@ export async function resizeImage(
 		const saveOptions = buildSaveOptions( {
 			type,
 			quality,
-			bitdepth: saveBitdepth,
+			bitdepth: isHighBitDepth ? saveBitdepth : undefined,
 			stripMeta,
 			isPalette: isPaletteImage( sourceImage ),
+			interlaced,
 		} );
 		const outBuffer = image.writeToBuffer( `.${ ext }`, saveOptions );
 
@@ -798,18 +783,26 @@ export async function getUltraHdrInfo(
  * @param buffer      Original file buffer.
  * @param type        Mime type.
  * @param orientation EXIF orientation value (1-8).
+ * @param options     Save options for the rotated file.
  * @return Rotated file data plus the new dimensions.
  */
 export async function rotateImage(
 	id: ItemId,
 	buffer: ArrayBuffer,
 	type: string,
-	orientation: number
+	orientation: number,
+	options: ConvertImageOptions = {}
 ): Promise< {
 	buffer: ArrayBuffer | ArrayBufferLike;
 	width: number;
 	height: number;
 } > {
+	const {
+		quality = 0.82,
+		interlaced = false,
+		stripMeta = true,
+		maxBitdepth = 16,
+	} = options;
 	const ext = type.split( '/' )[ 1 ];
 
 	inProgressOperations.add( id );
@@ -883,15 +876,20 @@ export async function rotateImage(
 		// second time.
 		image.remove( 'orientation' );
 
-		const saveOptions: SaveOptions< typeof type > = {};
+		const sourceBitdepth =
+			'image/avif' === type ? getSourceBitdepth( image ) : 8;
 
-		// Keep indexed sources indexed, as the resize and convert paths do.
-		// Rotating writes the full-size file, so losing the palette here
-		// inflates the image the user actually uploaded.
-		// See https://github.com/WordPress/gutenberg/issues/81895.
-		if ( 'image/png' === type && isPalette ) {
-			saveOptions.palette = true;
-		}
+		const saveOptions = buildSaveOptions( {
+			type,
+			quality,
+			bitdepth:
+				sourceBitdepth > 8
+					? resolveSaveBitdepth( sourceBitdepth, maxBitdepth )
+					: undefined,
+			stripMeta,
+			isPalette,
+			interlaced,
+		} );
 
 		const outBuffer = image.writeToBuffer( `.${ ext }`, saveOptions );
 

--- a/packages/vips/src/test/convert-image-format.ts
+++ b/packages/vips/src/test/convert-image-format.ts
@@ -8,7 +8,10 @@ const { MockVipsImage, mockNewFromBuffer, mockState, mockWriteToBuffer } =
 		 * Controls whether the mocked source image reports the `palette` metadata
 		 * field, which libvips attaches only for indexed sources.
 		 */
-		const state = { hasPalette: false };
+		const state: { bitdepth: number | undefined; hasPalette: boolean } = {
+			bitdepth: undefined,
+			hasPalette: false,
+		};
 
 		// GType of `gint`. Only whether `getTypeof` returns non-zero matters here.
 		const G_TYPE_INT = 24;
@@ -29,6 +32,12 @@ const { MockVipsImage, mockNewFromBuffer, mockState, mockWriteToBuffer } =
 			 * never be exercised.
 			 */
 			getInt = vi.fn( ( name: string ) => {
+				if (
+					'heif-bitdepth' === name &&
+					undefined !== state.bitdepth
+				) {
+					return state.bitdepth;
+				}
 				throw new Error( `${ name }: no such field` );
 			} );
 			/*
@@ -68,6 +77,7 @@ describe( 'convertImageFormat', () => {
 	afterEach( () => {
 		vi.clearAllMocks();
 		mockState.hasPalette = false;
+		mockState.bitdepth = undefined;
 	} );
 
 	it( 'loads only the first frame when converting a GIF to JPEG', async () => {
@@ -196,6 +206,103 @@ describe( 'convertImageFormat', () => {
 			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
 				'.webp',
 				expect.not.objectContaining( { palette: expect.anything() } )
+			);
+		} );
+	} );
+
+	describe( 'image_strip_meta', () => {
+		it( 'keeps color profiles and gain maps by default', async () => {
+			const file = new File( [ '<BLOB>' ], 'example.jpeg', {
+				type: 'image/jpeg',
+			} );
+
+			await compressImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/jpeg'
+			);
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { keep: 'icc|gainmap' } )
+			);
+		} );
+
+		it( 'keeps all metadata when stripping is disabled', async () => {
+			const file = new File( [ '<BLOB>' ], 'example.jpeg', {
+				type: 'image/jpeg',
+			} );
+
+			await compressImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/jpeg',
+				{ stripMeta: false }
+			);
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { keep: 'all' } )
+			);
+		} );
+	} );
+
+	describe( 'image_max_bit_depth', () => {
+		it( 'writes the capped depth when the cap flattens a 12-bit source', async () => {
+			mockState.bitdepth = 12;
+			const file = new File( [ '<BLOB>' ], 'example.avif', {
+				type: 'image/avif',
+			} );
+
+			await compressImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/avif',
+				{ maxBitdepth: 8 }
+			);
+
+			// heifsave defaults to 12-bit for 16-bit pixel data, so the depth
+			// has to be written out even when the cap resolves to 8.
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.avif',
+				expect.objectContaining( { bitdepth: 8 } )
+			);
+		} );
+
+		it( 'writes no bit depth for a standard-depth source', async () => {
+			const file = new File( [ '<BLOB>' ], 'example.avif', {
+				type: 'image/avif',
+			} );
+
+			await compressImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/avif'
+			);
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.avif',
+				expect.not.objectContaining( { bitdepth: expect.anything() } )
+			);
+		} );
+	} );
+
+	describe( 'image_save_progressive', () => {
+		it( 'writes a progressive JPEG when interlacing is requested', async () => {
+			const file = new File( [ '<BLOB>' ], 'example.jpeg', {
+				type: 'image/jpeg',
+			} );
+
+			await compressImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/jpeg',
+				{ interlaced: true }
+			);
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { interlace: true } )
 			);
 		} );
 	} );

--- a/packages/vips/src/test/resize-image.ts
+++ b/packages/vips/src/test/resize-image.ts
@@ -436,6 +436,48 @@ describe( 'resizeImage', () => {
 		} );
 	} );
 
+	describe( 'image_save_progressive', () => {
+		it( 'writes a progressive JPEG when interlacing is requested', async () => {
+			const file = new File( [ '<BLOB>' ], 'example.jpeg', {
+				type: 'image/jpeg',
+			} );
+
+			await resizeImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/jpeg',
+				{ width: 50, height: 50 },
+				{ interlaced: true }
+			);
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { interlace: true } )
+			);
+		} );
+
+		it( 'writes a baseline JPEG otherwise', async () => {
+			const file = new File( [ '<BLOB>' ], 'example.jpeg', {
+				type: 'image/jpeg',
+			} );
+
+			await resizeImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/jpeg',
+				{
+					width: 50,
+					height: 50,
+				}
+			);
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.not.objectContaining( { interlace: expect.anything() } )
+			);
+		} );
+	} );
+
 	describe( 'image_max_bit_depth', () => {
 		it( 'caps a 12-bit AVIF at 10-bit', async () => {
 			mockState.bitdepth = 12;

--- a/packages/vips/src/test/rotate-image.ts
+++ b/packages/vips/src/test/rotate-image.ts
@@ -192,4 +192,88 @@ describe( 'rotateImage', () => {
 			);
 		} );
 	} );
+
+	async function rotateJpeg( options = {} ) {
+		const file = new File( [ '<BLOB>' ], 'example.jpeg', {
+			type: 'image/jpeg',
+		} );
+
+		await rotateImage(
+			'itemId',
+			await file.arrayBuffer(),
+			'image/jpeg',
+			6,
+			options
+		);
+	}
+
+	describe( 'image_strip_meta', () => {
+		it( 'strips metadata except color profiles and gain maps by default', async () => {
+			await rotateJpeg();
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { keep: 'icc|gainmap' } )
+			);
+		} );
+
+		it( 'keeps all metadata when stripping is disabled', async () => {
+			await rotateJpeg( { stripMeta: false } );
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { keep: 'all' } )
+			);
+		} );
+	} );
+
+	describe( 'wp_editor_set_quality', () => {
+		it( 'writes at the requested quality', async () => {
+			await rotateJpeg( { quality: 0.82 } );
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { Q: 82 } )
+			);
+		} );
+
+		it( 'does not pass a quality to a format that has none', async () => {
+			const file = new File( [ '<BLOB>' ], 'example.png', {
+				type: 'image/png',
+			} );
+
+			await rotateImage(
+				'itemId',
+				await file.arrayBuffer(),
+				'image/png',
+				6,
+				{ quality: 0.82 }
+			);
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.png',
+				expect.not.objectContaining( { Q: expect.anything() } )
+			);
+		} );
+	} );
+
+	describe( 'image_save_progressive', () => {
+		it( 'writes a progressive JPEG when interlacing is requested', async () => {
+			await rotateJpeg( { interlaced: true } );
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.objectContaining( { interlace: true } )
+			);
+		} );
+
+		it( 'writes a baseline JPEG otherwise', async () => {
+			await rotateJpeg();
+
+			expect( mockWriteToBuffer ).toHaveBeenCalledWith(
+				'.jpeg',
+				expect.not.objectContaining( { interlace: expect.anything() } )
+			);
+		} );
+	} );
 } );

--- a/packages/vips/src/types.ts
+++ b/packages/vips/src/types.ts
@@ -55,6 +55,11 @@ export interface ResizeImageOptions {
 	 * Defaults to 16.
 	 */
 	maxBitdepth?: number;
+	/**
+	 * Whether to use interlaced/progressive mode. Only used if the output type
+	 * supports it. Defaults to false.
+	 */
+	interlaced?: boolean;
 }
 
 /**

--- a/packages/vips/src/vips-worker.ts
+++ b/packages/vips/src/vips-worker.ts
@@ -154,20 +154,22 @@ export async function vipsGetUltraHdrInfo( buffer: ArrayBuffer ): Promise< {
  * @param buffer      Original file buffer.
  * @param type        Mime type.
  * @param orientation EXIF orientation value (1-8).
+ * @param options     Save options for the rotated file.
  * @return Rotated file data plus the new dimensions.
  */
 export async function vipsRotateImage(
 	id: ItemId,
 	buffer: ArrayBuffer,
 	type: string,
-	orientation: number
+	orientation: number,
+	options: ConvertImageOptions = {}
 ): Promise< {
 	buffer: ArrayBuffer | ArrayBufferLike;
 	width: number;
 	height: number;
 } > {
 	const api = getWorkerAPI();
-	return api.rotateImage( id, buffer, type, orientation );
+	return api.rotateImage( id, buffer, type, orientation, options );
 }
 
 /**


### PR DESCRIPTION
## What?

Closes #81896

Routes all three vips write paths through `buildSaveOptions` and plumbs the missing settings through to the rotate path.

## Why?

`packages/vips` writes an image in three places, and each built its save options separately. That had already produced divergences, two of which are user visible.

**The gain map is dropped on the convert path.** `convertImageFormat` wrote `keep: 'icc'` where `buildSaveOptions` writes `keep: 'icc|gainmap'`. Reproducible end to end: `compressImage` on an UltraHDR source returns a file where `getUltraHdrInfo()` is `null`, while `resizeImage` on the same source preserves it.

**`rotateImage` wrote with an empty options object.** With no `keep`, libvips keeps every metadata field, so the output retains the full EXIF including GPS. Core strips it in `_save()`. That file is sideloaded as `original_image`, which leaves location data in the stored original. With no `Q`, output landed on the libvips default of 75; core's default is 82. On the test image that is 538 KB against 638 KB.

**Interlacing only reached transcoded sub-sizes.** `ResizeImageOptions` had no `interlaced` field, so a sub-size that was only resized was written baseline while one that also changed format was written progressive. Core applies `image_save_progressive` inside `_save()`, which every write goes through, so it does not depend on the operation that produced the image.

## How?

`buildSaveOptions` gains an `interlaced` option, and `convertImageFormat` and `rotateImage` now call it instead of assembling their own options.

`bitdepth` no longer defaults to 8. It is set whenever the caller passes one, because heifsave defaults to 12-bit for 16-bit pixel data and would otherwise ignore an `image_max_bit_depth` cap that resolves to 8. Each caller passes `undefined` when no depth should be written.

`rotateImage` takes save options, and they are plumbed through `vipsRotateImage` in the worker and in `upload-media`, where `rotateItem` reads them from the editor settings the same way `resizeItem` already does. `interlaced` is added to the `ResizeCrop` operation args and passed at both sub-size creation sites, where the value from `image_save_progressive` was already in scope.

One gap I have not covered: `rotateItem` runs before the upload, where `attachment.image_save_progressive` is not available, so the rotate path cannot honour the interlace filter without further plumbing. It is left out rather than guessing a value.

Worth flagging that the stored original grows and loses its EXIF. On my test image it goes from 538 KB with GPS intact to 637 KB with metadata stripped. That matches core, but it is a visible change.

## Testing Instructions

1. Upload a phone photo whose EXIF orientation is not 1, so the rotate path runs.
2. Download the `-rotated` original from the uploads directory and inspect its metadata. Before this change it carries the full EXIF including GPS; after, only the colour profile remains.
3. Upload an UltraHDR JPEG and confirm the gain map survives compression.
4. `npm run test:unit:vitest -- packages/vips`

The suite goes from 81 to 94 tests. The new ones cover the `keep` value on each path, the quality applied when rotating, interlacing on all three paths, and the bit depth written when the cap flattens a high-bit-depth source.

## Use of AI Tools

I used AI assistance on this change, on the implementation and, to a larger extent, on the testing: a harness that runs the package against real wasm-vips rather than mocks, fixtures including an UltraHDR JPEG with an ISO 21496-1 gain map, and a batch of hardening scenarios covering ICC retention, transparency, animation, extreme dimensions and the bit depth cap. The analysis is the one in the issue, and I have reviewed and verified every line here before submitting.

That testing is also what caught the `bitdepth` semantics: an earlier version of this change lost the `image_max_bit_depth` cap, because `buildSaveOptions` only set the depth above 8 while the convert path set it whenever the source was high-bit-depth. The existing suite passed either way, which is why the tests here are part of the change rather than an afterthought.
