### PR TITLE
Site Editor: Add a root error boundary to prevent a blank screen

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `Layout`: Add a root `ErrorBoundary`, so a throw outside the per-area ones no longer blanks the screen.
+-   `Layout`: Add a root `ErrorBoundary`, so a throw outside the per-area ones no longer blanks the screen. ([#82486](https://github.com/WordPress/gutenberg/pull/82486))
 -   `WelcomeGuide`: Keep the modal close icon white on hover now that it is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `SidebarNavigationItem`: Stop forcing `style={ { fill: 'currentcolor' } }` on the icon. The explicit override was clobbering stroke-based icons' intrinsic styling. Colour is inherited via CSS `color` and the icon's own declared fills/strokes. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `AddNewTemplate`: Preserve the admin theme color on the Author template icon after it became stroke-based. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))

--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   `Layout`: Add a root `ErrorBoundary`, so a throw outside the per-area ones no longer blanks the screen.
 -   `WelcomeGuide`: Keep the modal close icon white on hover now that it is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `SidebarNavigationItem`: Stop forcing `style={ { fill: 'currentcolor' } }` on the icon. The explicit override was clobbering stroke-based icons' intrinsic styling. Colour is inherited via CSS `color` and the icon's own declared fills/strokes. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `AddNewTemplate`: Preserve the admin theme color on the Author template icon after it became stroke-based. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))

--- a/packages/edit-site/src/components/layout/index.jsx
+++ b/packages/edit-site/src/components/layout/index.jsx
@@ -322,7 +322,9 @@ export default function LayoutWithGlobalStylesProvider( props ) {
 					} }
 				>
 					<ThemeProvider color={ themeColors }>
-						<Layout { ...props } />
+						<ErrorBoundary>
+							<Layout { ...props } />
+						</ErrorBoundary>
 					</ThemeProvider>
 				</ThemeProvider>
 			</Tooltip.Provider>

--- a/packages/edit-site/src/components/layout/index.jsx
+++ b/packages/edit-site/src/components/layout/index.jsx
@@ -322,7 +322,7 @@ export default function LayoutWithGlobalStylesProvider( props ) {
 					} }
 				>
 					<ThemeProvider color={ themeColors }>
-						<ErrorBoundary>
+						<ErrorBoundary canCopyContent>
 							<Layout { ...props } />
 						</ErrorBoundary>
 					</ThemeProvider>

--- a/packages/edit-site/src/components/layout/index.jsx
+++ b/packages/edit-site/src/components/layout/index.jsx
@@ -322,7 +322,7 @@ export default function LayoutWithGlobalStylesProvider( props ) {
 					} }
 				>
 					<ThemeProvider color={ themeColors }>
-						<ErrorBoundary canCopyContent>
+						<ErrorBoundary>
 							<Layout { ...props } />
 						</ErrorBoundary>
 					</ThemeProvider>

--- a/packages/editor/src/components/error-boundary/index.jsx
+++ b/packages/editor/src/components/error-boundary/index.jsx
@@ -17,12 +17,7 @@ function getContent() {
 		// application.
 		return select( editorStore ).getEditedPostContent();
 	} catch {}
-	// Only reached when the retrieval itself throws: the selector already returns
-	// '' of its own accord when no post is loaded. Serializing the blocks can
-	// fail, and the blocks are exactly what tends to be broken once a boundary
-	// has caught something. Returning nothing here would put the string
-	// 'undefined' on the clipboard, as `useCopyToClipboard` hands the value to
-	// `writeText` unchanged.
+	// Rather than copying the string 'undefined'.
 	return '';
 }
 

--- a/packages/editor/src/components/error-boundary/index.jsx
+++ b/packages/editor/src/components/error-boundary/index.jsx
@@ -17,6 +17,8 @@ function getContent() {
 		// application.
 		return select( editorStore ).getEditedPostContent();
 	} catch {}
+	// The site editor has routes that never mount an editor.
+	return '';
 }
 
 // A boundary catches whatever was thrown, which is not always an `Error`.

--- a/packages/editor/src/components/error-boundary/index.jsx
+++ b/packages/editor/src/components/error-boundary/index.jsx
@@ -17,7 +17,12 @@ function getContent() {
 		// application.
 		return select( editorStore ).getEditedPostContent();
 	} catch {}
-	// Serializing the blocks can throw too, and copying 'undefined' helps nobody.
+	// Only reached when the retrieval itself throws: the selector already returns
+	// '' of its own accord when no post is loaded. Serializing the blocks can
+	// fail, and the blocks are exactly what tends to be broken once a boundary
+	// has caught something. Returning nothing here would put the string
+	// 'undefined' on the clipboard, as `useCopyToClipboard` hands the value to
+	// `writeText` unchanged.
 	return '';
 }
 

--- a/packages/editor/src/components/error-boundary/index.jsx
+++ b/packages/editor/src/components/error-boundary/index.jsx
@@ -17,8 +17,6 @@ function getContent() {
 		// application.
 		return select( editorStore ).getEditedPostContent();
 	} catch {}
-	// Rather than copying the string 'undefined'.
-	return '';
 }
 
 // A boundary catches whatever was thrown, which is not always an `Error`.

--- a/packages/editor/src/components/error-boundary/index.jsx
+++ b/packages/editor/src/components/error-boundary/index.jsx
@@ -17,7 +17,7 @@ function getContent() {
 		// application.
 		return select( editorStore ).getEditedPostContent();
 	} catch {}
-	// The site editor has routes that never mount an editor.
+	// Serializing the blocks can throw too, and copying 'undefined' helps nobody.
 	return '';
 }
 


### PR DESCRIPTION
## What?

See https://core.trac.wordpress.org/ticket/66047

Adds a root-level `ErrorBoundary` to the site editor.

## Why?

The Trac ticket above reports the site editor going completely blank, with no error message, after saving. That symptom is an implicit sign that the site editor does not have enough error boundaries.

## How?

Wraps `<Layout />` in `LayoutWithGlobalStylesProvider` with the same `ErrorBoundary` [the post editor uses](https://github.com/WordPress/gutenberg/blob/c9e00c17d0c27f77fec8ecca54bf49054ab4ef89/packages/edit-post/src/components/layout/index.jsx#L558), placed inside the inner `ThemeProvider` so the fallback UI gets the theme tokens it renders with.

`canCopyContent` is deliberately left off. It may occasionally have something to offer, but this boundary catches crashes in the chrome above the editor, where there is usually nothing to rescue.

Separately, `packages/boot` turns out to have the same gap: it guards each surface but has nothing at the root, and `root/single-page.tsx` is missing even the `CanvasRenderer` boundary that `root/index.tsx` has. That needs its own follow up.

## Testing Instructions

1. Apply this patch to throw from the chrome, outside every existing boundary:

```diff
--- a/packages/edit-site/src/components/save-hub/index.jsx
+++ b/packages/edit-site/src/components/save-hub/index.jsx
 export default function SaveHub() {
+	throw new Error( 'Simulated crash' );
 	const { isDisabled, isSaving } = useSelect( ( select ) => {
```

2. Open the site editor.
3. On `trunk`, the screen is blank apart from the admin bar, with only a React error in the console.
4. With this PR, the "The editor has crashed" notice renders instead, with a "Copy error" action.
5. Revert the patch and confirm the site editor still loads and saves normally.

## Screenshots or screencast

### Before

<img width="1067" height="654" alt="image" src="https://github.com/user-attachments/assets/9b856107-3ec0-4831-b90f-c371b3087299" />

### After

<img width="1071" height="665" alt="image" src="https://github.com/user-attachments/assets/cfda3516-2525-45cf-8159-841c1a495662" />

## Use of AI Tools

Investigated and authored with Claude Code. I reviewed the diagnosis and the change, and take responsibility for both.
