### PR TITLE
Docs: Remove invalid `@return` tag from the `block_core_social_link_get_services` hook docblock

### DIFF
--- a/backport-changelog/7.2/13409.md
+++ b/backport-changelog/7.2/13409.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13409
+
+* https://github.com/WordPress/gutenberg/pull/82488

--- a/backport-changelog/7.2/13409.md
+++ b/backport-changelog/7.2/13409.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/13409
-
-* https://github.com/WordPress/gutenberg/pull/82488

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -349,7 +349,6 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 	 * @since 6.9.0
 	 *
 	 * @param array $services_data The list of services. Each item is an array containing a 'name' and 'icon' key.
-	 * @return array The list of social services.
 	 */
 	$services_data = apply_filters( 'block_core_social_link_get_services', $services_data );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Hook docblocks in core document only the value passed through the hook, via `@param`.  `@return` is not part of the inline hook documentation standard — `apply_filters()` is not  the function being documented, and the filtered value is already described by the first  `@param` tag.
  
The `block_core_social_link_get_services` filter, introduced in 6.9.0, is currently the only  hook docblock in `src/` carrying a `@return` tag. This removes it.
  
Verified by scanning every docblock immediately preceding an `apply_filters()`,  `apply_filters_ref_array()`, `apply_filters_deprecated()`, `do_action()`,  `do_action_ref_array()`, or `do_action_deprecated()` call across `src/`, `tools/`,  and `tests/` — this was the sole match. Remaining `@return` tags near hook calls all belong  to regular function docblocks whose bodies happen to invoke a hook.
  
Documentation-only change; no functional impact.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
