### PR TITLE
ProgressBar: Respect reduced motion preferences

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+-   `ProgressBar`: Use slower, stepped visual updates when reduced motion is preferred. ([#82490](https://github.com/WordPress/gutenberg/pull/82490))
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `BorderBoxControl`: Give the group of border controls an accessible name from the `label` prop, by rendering the wrapper as a `role="group"` associated with the label through `aria-labelledby`. A consumer-supplied `aria-labelledby` or `aria-label` takes precedence over `label` and names the group instead; the wrapper is only given the `group` role when one of the three provides a name. A hidden label (`hideLabelFromVision`) now renders as a `span` rather than a `label` element, matching the visible one ([#82279](https://github.com/WordPress/gutenberg/pull/82279)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug Fixes
 
--   `ProgressBar`: Use slower, stepped visual updates when reduced motion is preferred. ([#82490](https://github.com/WordPress/gutenberg/pull/82490))
+-   `ProgressBar`: Remove determinate transitions and use a slower, stepped indeterminate animation when reduced motion is preferred. ([#82490](https://github.com/WordPress/gutenberg/pull/82490))
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `BorderBoxControl`: Give the group of border controls an accessible name from the `label` prop, by rendering the wrapper as a `role="group"` associated with the label through `aria-labelledby`. A consumer-supplied `aria-labelledby` or `aria-label` takes precedence over `label` and names the group instead; the wrapper is only given the `group` role when one of the three provides a name. A hidden label (`hideLabelFromVision`) now renders as a `span` rather than a `label` element, matching the visible one ([#82279](https://github.com/WordPress/gutenberg/pull/82279)).

--- a/packages/components/src/progress-bar/style.module.scss
+++ b/packages/components/src/progress-bar/style.module.scss
@@ -40,6 +40,16 @@ $indeterminate-indicator-width: 50%;
 		animation: indeterminate-slide 1.5s ease-in-out infinite;
 		transition: none;
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		transition-duration: 0.8s;
+		transition-timing-function: steps(4, end);
+
+		&.is-indeterminate {
+			animation-duration: 3s;
+			animation-timing-function: steps(4, end);
+		}
+	}
 }
 
 @keyframes indeterminate-slide {

--- a/packages/components/src/progress-bar/style.module.scss
+++ b/packages/components/src/progress-bar/style.module.scss
@@ -33,19 +33,17 @@ $indeterminate-indicator-width: 50%;
 	outline-offset: -2px;
 
 	width: var(--indicator-width);
-	transition: width 0.4s ease-in-out;
+
+	@media not (prefers-reduced-motion) {
+		transition: width 0.4s ease-in-out;
+	}
 
 	&.is-indeterminate {
 		--indicator-width: #{$indeterminate-indicator-width};
 		animation: indeterminate-slide 1.5s ease-in-out infinite;
 		transition: none;
-	}
 
-	@media (prefers-reduced-motion: reduce) {
-		transition-duration: 0.8s;
-		transition-timing-function: steps(4, end);
-
-		&.is-indeterminate {
+		@media (prefers-reduced-motion: reduce) {
 			animation-duration: 3s;
 			animation-timing-function: steps(4, end);
 		}


### PR DESCRIPTION
Closes #76926

Alternative to #77051, updated for the current SCSS implementation.

## What?

Make determinate `ProgressBar` updates immediate and use a slower, stepped indeterminate animation when the user prefers reduced motion.

## Why?

Determinate transitions and the continuous indeterminate animation currently run regardless of the user's OS or browser preference.

## How?

The determinate transition only runs when reduced motion is not preferred. Under `prefers-reduced-motion: reduce`, determinate progress snaps to each supplied value, while the repeating indeterminate animation advances in four steps over 3 seconds. The default motion stays unchanged.

## Testing Instructions

1. Open the [ProgressBar Storybook story](https://wordpress.github.io/gutenberg/?path=/docs/components-progressbar--docs).
2. With reduced-motion emulation disabled, confirm that the indeterminate bar moves smoothly.
3. Enable `prefers-reduced-motion: reduce` in the browser developer tools or OS settings.
4. Confirm that **the indeterminate bar moves more slowly in four visible steps** and still communicates ongoing progress.
5. **Set the story's `value` control to several values. Confirm that updates are immediate with reduced motion enabled and smooth with it disabled.**

### Testing Instructions for Keyboard

There is no keyboard interaction in this change. Confirm that the progress bar remains exposed with `role="progressbar"` and its accessible label.

### Screencast

Note:  with`prefers-reduced-motion: reduce`

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/e7eae825-c6e5-4549-81ee-a896a2f81aac" /> | <video src="https://github.com/user-attachments/assets/f11b754a-81f8-43a5-844e-67c85f2afc78" /> |

## Use of AI Tools

I used Codex to investigate the issue, implement the change, and draft this pull request.
