### PR TITLE
Navigation: skip aria-label uniqueness suffix for unnamed blocks

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+-   Navigation: Do not emit `aria-label=" 2"` for unnamed Navigation blocks. Empty names skip uniqueness suffixing so a second unnamed nav stays unlabeled instead of getting a space-prefixed count. ([#82287](https://github.com/WordPress/gutenberg/issues/82287))
 -   Footnotes: Prefix newly created footnote IDs with `fn-` so they always start with a letter. A bare UUID often starts with a digit, and an ID that does is not a valid CSS identifier, so `querySelector( '#' + id )` threw and `#id` style rules never matched. Existing footnotes keep their IDs ([#82398](https://github.com/WordPress/gutenberg/pull/82398)).
 -   Navigation: Restore `flex-grow` on the menu container in the editor, where the visually hidden menu description breaks the `:only-child` selector the front end relies on, so the "Space between" and other justification settings apply in the canvas as they do on the front end ([#78447](https://github.com/WordPress/gutenberg/pull/78447)).
 -   Image: Fix cropped galleries rendering images at their natural height in the editor canvas. The baseline inline `height: auto` is no longer emitted for images inside a cropped gallery, so the gallery's own cropping CSS applies ([#82318](https://github.com/WordPress/gutenberg/pull/82318)).

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1002,6 +1002,14 @@ class WP_Navigation_Block_Renderer {
 	private static function get_unique_navigation_name( $attributes ) {
 		$nav_menu_name = static::get_navigation_name( $attributes );
 
+		/*
+		 * Empty names should not receive a uniqueness suffix. Appending only
+		 * the count would produce aria-label values like " 2".
+		 */
+		if ( '' === $nav_menu_name ) {
+			return '';
+		}
+
 		// This is used to count the number of times a navigation name has been seen,
 		// so that we can ensure every navigation has a unique id.
 		if ( isset( static::$seen_menu_names[ $nav_menu_name ] ) ) {

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -431,4 +431,37 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Hello, World!', $output, 'Shortcode inside the navigation overlay should be expanded.' );
 		$this->assertStringNotContainsString( '[gb_test_overlay_shortcode]', $output, 'Raw shortcode token should not appear in the overlay output.' );
 	}
+
+	/**
+	 * Unnamed navigations must not receive a space-prefixed uniqueness suffix.
+	 *
+	 * @group navigation-renderer
+	 *
+	 * @covers WP_Navigation_Block_Renderer::get_unique_navigation_name
+	 */
+	public function test_unnamed_navigation_does_not_get_space_prefixed_aria_label() {
+		$reflection = new ReflectionClass( 'WP_Navigation_Block_Renderer_Gutenberg' );
+		$property   = $reflection->getProperty( 'seen_menu_names' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, array() );
+
+		$method = $reflection->getMethod( 'get_unique_navigation_name' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$first  = $method->invoke( null, array() );
+		$second = $method->invoke( null, array() );
+
+		$this->assertSame( '', $first );
+		$this->assertSame( '', $second );
+
+		$named_first  = $method->invoke( null, array( 'ariaLabel' => 'Primary' ) );
+		$named_second = $method->invoke( null, array( 'ariaLabel' => 'Primary' ) );
+
+		$this->assertSame( 'Primary', $named_first );
+		$this->assertSame( 'Primary 2', $named_second );
+	}
 }


### PR DESCRIPTION
## What
Fixes #82287

Unnamed Navigation blocks no longer receive a uniqueness suffix. Previously a second unnamed navigation got `aria-label=" 2"` (space + count), which is worse for screen readers than leaving it unlabeled.

## How
- In `get_unique_navigation_name()`, return early when the navigation name is empty
- Named navigations still get uniqueness suffixes (`Primary`, `Primary 2`)
- PHPUnit coverage for empty and duplicate named names

## Test plan
- [ ] Add two Navigation blocks with empty Aria Label (inline menus)
- [ ] View the front end — neither should have `aria-label=" 2"`
- [ ] Add two Navigation blocks both named `Primary` , second should be `Primary 2`
- [ ] Confirm a single named Navigation still gets its aria-label