### PR TITLE
List View: Disable block icon colors while the block is selected

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fixes
 
+-   `ListView`: Drop the block icon's variation colors while the row is selected, so the icon keeps contrast against the selection background ([#00000](https://github.com/WordPress/gutenberg/pull/00000)).
 -   Flex layout: Output `flex-direction: row` when a viewport override switches a vertical layout to horizontal, so the base `flex-direction: column` no longer keeps applying on that viewport ([#82364](https://github.com/WordPress/gutenberg/pull/82364)).
 -   `BlockManager`: Color library block icons with `color` while retaining a `fill` fallback for custom icons that do not use `currentColor`. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   Block List Appender: Show the appender button as a drop target when dragging a block over an empty container such as a Column, restoring the reveal that the `visibility`-to-`opacity` migration left behind ([#77852](https://github.com/WordPress/gutenberg/pull/77852)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Bug Fixes
 
--   `ListView`: Drop the block icon's variation colors while the row is selected, so the icon keeps contrast against the selection background ([#00000](https://github.com/WordPress/gutenberg/pull/00000)).
+-   `ListView`: Drop the block icon's variation colors while the row is selected, so the icon keeps contrast against the selection background ([#82498](https://github.com/WordPress/gutenberg/pull/82498)).
 -   Flex layout: Output `flex-direction: row` when a viewport override switches a vertical layout to horizontal, so the base `flex-direction: column` no longer keeps applying on that viewport ([#82364](https://github.com/WordPress/gutenberg/pull/82364)).
 -   `BlockManager`: Color library block icons with `color` while retaining a `fill` fallback for custom icons that do not use `currentColor`. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   Block List Appender: Show the appender button as a drop target when dragging a block over an empty container such as a Column, restoring the reveal that the `visibility`-to-`opacity` migration left behind ([#77852](https://github.com/WordPress/gutenberg/pull/77852)).

--- a/packages/block-editor/src/components/list-view/block-select-button.jsx
+++ b/packages/block-editor/src/components/list-view/block-select-button.jsx
@@ -33,6 +33,7 @@ function ListViewBlockSelectButton(
 		onDragEnd,
 		draggable,
 		isExpanded,
+		isSelected,
 		ariaDescribedBy,
 		visibilityLabel,
 		isDisabled = false,
@@ -129,7 +130,11 @@ function ListViewBlockSelectButton(
 			aria-expanded={ isExpanded }
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
-			<BlockIcon icon={ icon } showColors context="list-view" />
+			<BlockIcon
+				icon={ icon }
+				showColors={ ! isSelected }
+				context="list-view"
+			/>
 			<Stack
 				align="center"
 				className="block-editor-list-view-block-select-button__label-wrapper"

--- a/packages/block-editor/src/components/list-view/block.jsx
+++ b/packages/block-editor/src/components/list-view/block.jsx
@@ -656,6 +656,7 @@ function ListViewBlock( {
 							tabIndex={ getListViewBlockTabIndex( tabIndex ) }
 							onFocus={ onFocus }
 							isExpanded={ canEditBlock ? isExpanded : undefined }
+							isSelected={ isSelected }
 							selectedClientIds={ selectedClientIds }
 							ariaDescribedBy={ descriptionId }
 							visibilityLabel={ blockVisibilityDescription }


### PR DESCRIPTION
Noticed while reviewing #82129.

## What?

Disables the block icon colors in the List View while a block is selected.

## Why?

- A selected row's background becomes the primary color, and a block icon whose variation color is close to it becomes hard to see.
- It is also inconsistent with icons that have no variation color to begin with.

## Testing Instructions

1. Insert blocks that have colored icons, such as YouTube Embed and Vimeo Embed.
2. Open the List View and select those blocks.
3. Confirm the icon is legible against the selection background, and that the colors return once the block is deselected.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="354" height="341" alt="image" src="https://github.com/user-attachments/assets/75cb8003-32f1-4790-8bfa-fa7d80abfc72" />| <img width="349" height="329" alt="image" src="https://github.com/user-attachments/assets/8ed52945-f7aa-4bbf-b486-e7317a79f694" /> |

## Use of AI Tools

Claude Code was used to implement the change (prop threading, changelog entry) based on the approach specified by the author. The result has been reviewed by the author.
