### PR TITLE
Components: Add compound component composition diagnostics

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.jsdom.test.jsx
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.jsdom.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Composite } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import DownloadableBlockListItem from '../';
 import { plugin } from '../../test/fixtures';
@@ -10,6 +11,14 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 	return mock;
 } );
 
+function renderItem( props ) {
+	return render(
+		<Composite>
+			<DownloadableBlockListItem { ...props } />
+		</Composite>
+	);
+}
+
 describe( 'DownloadableBlockListItem', () => {
 	it( 'should render a block item', () => {
 		useSelect.mockImplementation( () => ( {
@@ -17,9 +26,7 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstallable: true,
 		} ) );
 
-		render(
-			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
-		);
+		renderItem( { onClick: jest.fn(), item: plugin } );
 		const author = screen.queryByText( `by ${ plugin.author }` );
 		const description = screen.queryByText( plugin.description );
 		expect( author ).toBeInTheDocument();
@@ -32,9 +39,7 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstallable: true,
 		} ) );
 
-		render(
-			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
-		);
+		renderItem( { onClick: jest.fn(), item: plugin } );
 		const statusLabel = screen.queryByText( 'Installing…' );
 		expect( statusLabel ).toBeInTheDocument();
 	} );
@@ -45,9 +50,7 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstallable: false,
 		} ) );
 
-		render(
-			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
-		);
+		renderItem( { onClick: jest.fn(), item: plugin } );
 		const button = screen.getByRole( 'option' );
 		// Keeping it false to avoid focus loss and disable it using aria-disabled.
 		expect( button ).toBeEnabled();
@@ -62,9 +65,7 @@ describe( 'DownloadableBlockListItem', () => {
 			isInstallable: true,
 		} ) );
 		const onClick = jest.fn();
-		render(
-			<DownloadableBlockListItem onClick={ onClick } item={ plugin } />
-		);
+		renderItem( { onClick, item: plugin } );
 
 		await user.click( screen.getByRole( 'option' ) );
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+-   Compound components: Throw clear errors when required state or semantic structure is missing ([#82509](https://github.com/WordPress/gutenberg/pull/82509)).
 -   `ToggleGroupControl`: Honor the root `disabled` prop so the whole control is unselectable ([#82259](https://github.com/WordPress/gutenberg/pull/82259)).
 -   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring and border ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Compound components: Throw clear errors when required state or semantic structure is missing ([#82509](https://github.com/WordPress/gutenberg/pull/82509)).
+-   Compound components: Report missing state or accessible semantic structure with clear developer guidance ([#82509](https://github.com/WordPress/gutenberg/pull/82509)).
 -   `ToggleGroupControl`: Honor the root `disabled` prop so the whole control is unselectable ([#82259](https://github.com/WordPress/gutenberg/pull/82259)).
 -   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring and border ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   `Popover`: Widen `offset` to also accept an object with separate main and cross axis offsets. The same applies to `BorderBoxControl`'s `popoverOffset` prop ([#82060](https://github.com/WordPress/gutenberg/pull/82060)).

--- a/packages/components/src/composite/context.tsx
+++ b/packages/components/src/composite/context.tsx
@@ -5,3 +5,9 @@ export const CompositeContext = createContext< CompositeContextProps >( {} );
 CompositeContext.displayName = 'CompositeContext';
 
 export const useCompositeContext = () => useContext( CompositeContext );
+
+export const CompositeGroupContext = createContext( false );
+CompositeGroupContext.displayName = 'CompositeGroupContext';
+
+export const useCompositeGroupContext = () =>
+	useContext( CompositeGroupContext );

--- a/packages/components/src/composite/group-label.tsx
+++ b/packages/components/src/composite/group-label.tsx
@@ -1,7 +1,7 @@
 import * as Ariakit from '@ariakit/react';
 import { forwardRef } from '@wordpress/element';
 import type { WordPressComponentProps } from '../context';
-import { useCompositeContext } from './context';
+import { useCompositeContext, useCompositeGroupContext } from './context';
 import type { CompositeGroupLabelProps } from './types';
 
 export const CompositeGroupLabel = forwardRef<
@@ -9,6 +9,13 @@ export const CompositeGroupLabel = forwardRef<
 	WordPressComponentProps< CompositeGroupLabelProps, 'div', false >
 >( function CompositeGroupLabel( props, ref ) {
 	const context = useCompositeContext();
+	const isWithinGroup = useCompositeGroupContext();
+
+	if ( ! isWithinGroup ) {
+		throw new Error(
+			'Composite.GroupLabel can only be rendered inside Composite.Group.'
+		);
+	}
 
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is

--- a/packages/components/src/composite/group.tsx
+++ b/packages/components/src/composite/group.tsx
@@ -1,7 +1,7 @@
 import * as Ariakit from '@ariakit/react';
 import { forwardRef } from '@wordpress/element';
 import type { WordPressComponentProps } from '../context';
-import { useCompositeContext } from './context';
+import { CompositeGroupContext, useCompositeContext } from './context';
 import type { CompositeGroupProps } from './types';
 
 export const CompositeGroup = forwardRef<
@@ -9,11 +9,18 @@ export const CompositeGroup = forwardRef<
 	WordPressComponentProps< CompositeGroupProps, 'div', false >
 >( function CompositeGroup( props, ref ) {
 	const context = useCompositeContext();
+	const { children, ...restProps } = props;
 
 	// @ts-expect-error The store prop is undocumented and only used by the
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
-	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;
+	return (
+		<Ariakit.CompositeGroup store={ store } { ...restProps } ref={ ref }>
+			<CompositeGroupContext.Provider value>
+				{ children }
+			</CompositeGroupContext.Provider>
+		</Ariakit.CompositeGroup>
+	);
 } );

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -14,6 +14,11 @@ export const CompositeItem = forwardRef<
 	// legacy compat layer. The `store` prop is documented, but its type is
 	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
+	if ( ! store ) {
+		throw new Error(
+			'Composite.Item can only be rendered with composite state from Composite or an explicit store prop.'
+		);
+	}
 
 	return <Ariakit.CompositeItem store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -17,7 +17,7 @@ export const CompositeItem = forwardRef<
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 	if ( ! store ) {
 		warning(
-			'Composite.Item: Missing composite state. Render inside Composite or provide a store prop to enable composite keyboard behavior.'
+			'Composite.Item: Missing composite state. Render inside Composite to enable composite keyboard behavior.'
 		);
 	}
 

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -1,5 +1,6 @@
 import * as Ariakit from '@ariakit/react';
 import { forwardRef } from '@wordpress/element';
+import warning from '@wordpress/warning';
 import type { WordPressComponentProps } from '../context';
 import { useCompositeContext } from './context';
 import type { CompositeItemProps } from './types';
@@ -15,8 +16,8 @@ export const CompositeItem = forwardRef<
 	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 	if ( ! store ) {
-		throw new Error(
-			'Composite.Item can only be rendered with composite state from Composite or an explicit store prop.'
+		warning(
+			'Composite.Item: Missing composite state. Render inside Composite or provide a store prop to enable composite keyboard behavior.'
 		);
 	}
 

--- a/packages/components/src/composite/test/index.jsdom.test.tsx
+++ b/packages/components/src/composite/test/index.jsdom.test.tsx
@@ -1,5 +1,6 @@
 import { queryByAttribute, render, screen } from '@testing-library/react';
 import { click, press, waitFor } from '@ariakit/test';
+import * as Ariakit from '@ariakit/react';
 import type { ComponentProps } from 'react';
 import { useState } from '@wordpress/element';
 import { Composite } from '..';
@@ -698,6 +699,51 @@ describe( 'Composite', () => {
 				// C2 is disabled
 				expect( itemB2 ).toHaveFocus();
 			} );
+		} );
+	} );
+
+	describe( 'required context', () => {
+		it( 'throws when Composite.Item has no composite state', () => {
+			expect( () =>
+				render( <Composite.Item>Item</Composite.Item> )
+			).toThrow(
+				'Composite.Item can only be rendered with composite state from Composite or an explicit store prop.'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'supports an explicit store prop for Composite.Item', () => {
+			function ItemWithStore() {
+				const store = Ariakit.useCompositeStore();
+
+				return (
+					<Composite.Item
+						// @ts-expect-error The store prop is intentionally omitted from the public types.
+						store={ store }
+					>
+						Item
+					</Composite.Item>
+				);
+			}
+
+			render( <ItemWithStore /> );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Item' } )
+			).toBeVisible();
+		} );
+
+		it( 'throws when Composite.GroupLabel is outside Composite.Group', () => {
+			expect( () =>
+				render(
+					<Composite>
+						<Composite.GroupLabel>Label</Composite.GroupLabel>
+					</Composite>
+				)
+			).toThrow(
+				'Composite.GroupLabel can only be rendered inside Composite.Group.'
+			);
+			expect( console ).toHaveErrored();
 		} );
 	} );
 } );

--- a/packages/components/src/composite/test/index.jsdom.test.tsx
+++ b/packages/components/src/composite/test/index.jsdom.test.tsx
@@ -710,7 +710,7 @@ describe( 'Composite', () => {
 				screen.getByRole( 'button', { name: 'Item' } )
 			).toBeVisible();
 			expect( console ).toHaveWarnedWith(
-				'Composite.Item: Missing composite state. Render inside Composite or provide a store prop to enable composite keyboard behavior.'
+				'Composite.Item: Missing composite state. Render inside Composite to enable composite keyboard behavior.'
 			);
 		} );
 

--- a/packages/components/src/composite/test/index.jsdom.test.tsx
+++ b/packages/components/src/composite/test/index.jsdom.test.tsx
@@ -703,13 +703,15 @@ describe( 'Composite', () => {
 	} );
 
 	describe( 'required context', () => {
-		it( 'throws when Composite.Item has no composite state', () => {
-			expect( () =>
-				render( <Composite.Item>Item</Composite.Item> )
-			).toThrow(
-				'Composite.Item can only be rendered with composite state from Composite or an explicit store prop.'
+		it( 'warns when Composite.Item has no composite state', () => {
+			render( <Composite.Item>Item</Composite.Item> );
+
+			expect(
+				screen.getByRole( 'button', { name: 'Item' } )
+			).toBeVisible();
+			expect( console ).toHaveWarnedWith(
+				'Composite.Item: Missing composite state. Render inside Composite or provide a store prop to enable composite keyboard behavior.'
 			);
-			expect( console ).toHaveErrored();
 		} );
 
 		it( 'supports an explicit store prop for Composite.Item', () => {

--- a/packages/components/src/item-group/context.ts
+++ b/packages/components/src/item-group/context.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from '@wordpress/element';
 import type { ItemGroupContext as Context } from './types';
 
 export const ItemGroupContext = createContext( {
+	isList: false,
 	size: 'medium',
 } as Context );
 ItemGroupContext.displayName = 'ItemGroupContext';

--- a/packages/components/src/item-group/item-group/component.tsx
+++ b/packages/components/src/item-group/item-group/component.tsx
@@ -1,4 +1,6 @@
 import type { ForwardedRef } from 'react';
+import { useRef } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { useItemGroup } from './hook';
@@ -16,6 +18,8 @@ function UnconnectedItemGroup(
 		size: sizeProp,
 		...otherProps
 	} = useItemGroup( props );
+	const itemGroupRef = useRef< HTMLElement >( null );
+	const refs = useMergeRefs( [ itemGroupRef, forwardedRef ] );
 
 	const { size: contextSize } = useItemGroupContext();
 
@@ -23,13 +27,15 @@ function UnconnectedItemGroup(
 	const size = sizeProp || contextSize;
 
 	const contextValue = {
+		itemGroupRef,
+		isList: otherProps.role === 'list',
 		spacedAround,
 		size,
 	};
 
 	return (
 		<ItemGroupContext.Provider value={ contextValue }>
-			<View { ...otherProps } ref={ forwardedRef } />
+			<View { ...otherProps } ref={ refs } />
 		</ItemGroupContext.Provider>
 	);
 }

--- a/packages/components/src/item-group/item-group/component.tsx
+++ b/packages/components/src/item-group/item-group/component.tsx
@@ -1,6 +1,4 @@
 import type { ForwardedRef } from 'react';
-import { useRef } from '@wordpress/element';
-import { useMergeRefs } from '@wordpress/compose';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { useItemGroup } from './hook';
@@ -18,8 +16,6 @@ function UnconnectedItemGroup(
 		size: sizeProp,
 		...otherProps
 	} = useItemGroup( props );
-	const itemGroupRef = useRef< HTMLElement >( null );
-	const refs = useMergeRefs( [ itemGroupRef, forwardedRef ] );
 
 	const { size: contextSize } = useItemGroupContext();
 
@@ -27,7 +23,6 @@ function UnconnectedItemGroup(
 	const size = sizeProp || contextSize;
 
 	const contextValue = {
-		itemGroupRef,
 		isList: otherProps.role === 'list',
 		spacedAround,
 		size,
@@ -35,7 +30,7 @@ function UnconnectedItemGroup(
 
 	return (
 		<ItemGroupContext.Provider value={ contextValue }>
-			<View { ...otherProps } ref={ refs } />
+			<View { ...otherProps } ref={ forwardedRef } />
 		</ItemGroupContext.Provider>
 	);
 }

--- a/packages/components/src/item-group/item-group/component.tsx
+++ b/packages/components/src/item-group/item-group/component.tsx
@@ -23,7 +23,7 @@ function UnconnectedItemGroup(
 	const size = sizeProp || contextSize;
 
 	const contextValue = {
-		isList: otherProps.role === 'list',
+		isList: otherProps.role === 'list' || otherProps.role === 'directory',
 		spacedAround,
 		size,
 	};

--- a/packages/components/src/item-group/item/component.tsx
+++ b/packages/components/src/item-group/item/component.tsx
@@ -1,18 +1,34 @@
 import type { ForwardedRef } from 'react';
+import { useEffect, useRef } from '@wordpress/element';
 import type { ItemProps } from '../types';
 import { useItem } from './hook';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import { View } from '../../view';
+import { useItemGroupContext } from '../context';
 
 function UnconnectedItem(
 	props: WordPressComponentProps< ItemProps, 'div' >,
 	forwardedRef: ForwardedRef< any >
 ) {
 	const { role, wrapperClassName, ...otherProps } = useItem( props );
+	const itemRef = useRef< HTMLDivElement >( null );
+	const { itemGroupRef, isList } = useItemGroupContext();
+
+	useEffect( () => {
+		if (
+			isList &&
+			role === 'listitem' &&
+			itemRef.current?.parentElement !== itemGroupRef?.current
+		) {
+			throw new Error(
+				'Item must be rendered as a direct child of ItemGroup when both components use list semantics.'
+			);
+		}
+	} );
 
 	return (
-		<div role={ role } className={ wrapperClassName }>
+		<div ref={ itemRef } role={ role } className={ wrapperClassName }>
 			<View { ...otherProps } ref={ forwardedRef } />
 		</div>
 	);

--- a/packages/components/src/item-group/item/component.tsx
+++ b/packages/components/src/item-group/item/component.tsx
@@ -13,19 +13,21 @@ function UnconnectedItem(
 ) {
 	const { role, wrapperClassName, ...otherProps } = useItem( props );
 	const itemRef = useRef< HTMLDivElement >( null );
-	const { itemGroupRef, isList } = useItemGroupContext();
+	const { isList } = useItemGroupContext();
 
 	useEffect( () => {
 		if (
 			isList &&
 			role === 'listitem' &&
-			itemRef.current?.parentElement !== itemGroupRef?.current
+			! itemRef.current?.closest(
+				'ol, ul, menu, [role="list"], [role="directory"]'
+			)
 		) {
 			throw new Error(
-				'Item must be rendered as a direct child of ItemGroup when both components use list semantics.'
+				'Item with list semantics must be rendered inside an element with role="list".'
 			);
 		}
-	} );
+	}, [ isList, role ] );
 
 	return (
 		<div ref={ itemRef } role={ role } className={ wrapperClassName }>

--- a/packages/components/src/item-group/item/hook.ts
+++ b/packages/components/src/item-group/item/hook.ts
@@ -12,16 +12,15 @@ const sizeClassName = {
 };
 
 export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
+	const { isList, spacedAround, size: contextSize } = useItemGroupContext();
 	const {
 		as: asProp,
 		className,
 		onClick,
-		role = 'listitem',
+		role = isList ? 'listitem' : undefined,
 		size: sizeProp,
 		...otherProps
 	} = useContextSystem( props, 'Item' );
-
-	const { spacedAround, size: contextSize } = useItemGroupContext();
 
 	const size = sizeProp || contextSize;
 

--- a/packages/components/src/item-group/test/__snapshots__/index.jsdom.test.tsx.snap
+++ b/packages/components/src/item-group/test/__snapshots__/index.jsdom.test.tsx.snap
@@ -38,10 +38,10 @@ Snapshot Diff:
 - First value
 + Second value
 
-@@ -2,11 +2,11 @@
+@@ -1,11 +1,11 @@
+  <div>
     <div
       class="style-item-wrapper"
-      role="listitem"
     >
       <div
 -       class="style-item style-is-size-medium components-item"

--- a/packages/components/src/item-group/test/index.jsdom.test.tsx
+++ b/packages/components/src/item-group/test/index.jsdom.test.tsx
@@ -4,6 +4,43 @@ import { Item, ItemGroup } from '..';
 
 describe( 'ItemGroup', () => {
 	describe( 'ItemGroup component', () => {
+		it( 'throws when an Item with list semantics is not a direct child', () => {
+			expect( () =>
+				render(
+					<ItemGroup>
+						<div>
+							<Item>Nested item</Item>
+						</div>
+					</ItemGroup>
+				)
+			).toThrow(
+				'Item must be rendered as a direct child of ItemGroup when both components use list semantics.'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'accepts custom children', () => {
+			render(
+				<ItemGroup>
+					<div>Custom item</div>
+				</ItemGroup>
+			);
+
+			expect( screen.getByText( 'Custom item' ) ).toBeVisible();
+		} );
+
+		it( 'preserves custom roles', () => {
+			render(
+				<ItemGroup role="group">
+					<div>
+						<Item role="presentation">Custom item</Item>
+					</div>
+				</ItemGroup>
+			);
+
+			expect( screen.getByRole( 'group' ) ).toBeVisible();
+		} );
+
 		it( 'should render correctly', () => {
 			const { container } = render(
 				<ItemGroup>

--- a/packages/components/src/item-group/test/index.jsdom.test.tsx
+++ b/packages/components/src/item-group/test/index.jsdom.test.tsx
@@ -1,22 +1,45 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createPortal } from '@wordpress/element';
 import { Item, ItemGroup } from '..';
 
 describe( 'ItemGroup', () => {
 	describe( 'ItemGroup component', () => {
-		it( 'throws when an Item with list semantics is not a direct child', () => {
-			expect( () =>
-				render(
-					<ItemGroup>
-						<div>
-							<Item>Nested item</Item>
-						</div>
-					</ItemGroup>
-				)
-			).toThrow(
-				'Item must be rendered as a direct child of ItemGroup when both components use list semantics.'
+		it( 'accepts an Item nested within a semantic list', () => {
+			render(
+				<ItemGroup>
+					<div>
+						<Item>Nested item</Item>
+					</div>
+				</ItemGroup>
 			);
-			expect( console ).toHaveErrored();
+
+			expect( screen.getByRole( 'listitem' ) ).toHaveTextContent(
+				'Nested item'
+			);
+		} );
+
+		it( 'throws when an Item with list semantics is outside a semantic list', () => {
+			const portalContainer = document.createElement( 'div' );
+			document.body.append( portalContainer );
+
+			try {
+				expect( () =>
+					render(
+						<ItemGroup>
+							{ createPortal(
+								<Item>Portaled item</Item>,
+								portalContainer
+							) }
+						</ItemGroup>
+					)
+				).toThrow(
+					'Item with list semantics must be rendered inside an element with role="list".'
+				);
+				expect( console ).toHaveErrored();
+			} finally {
+				portalContainer.remove();
+			}
 		} );
 
 		it( 'accepts custom children', () => {
@@ -103,6 +126,30 @@ describe( 'ItemGroup', () => {
 	} );
 
 	describe( 'Item', () => {
+		it( 'uses list semantics only within a list-semantic ItemGroup', () => {
+			const { rerender } = render( <Item>Standalone item</Item> );
+
+			expect( screen.queryByRole( 'listitem' ) ).not.toBeInTheDocument();
+
+			rerender(
+				<ItemGroup role="group">
+					<Item>Non-list item</Item>
+				</ItemGroup>
+			);
+
+			expect( screen.queryByRole( 'listitem' ) ).not.toBeInTheDocument();
+
+			rerender(
+				<ItemGroup>
+					<Item>Grouped item</Item>
+				</ItemGroup>
+			);
+
+			expect( screen.getByRole( 'listitem' ) ).toHaveTextContent(
+				'Grouped item'
+			);
+		} );
+
 		it( 'should render as a `button` if the `onClick` handler is specified', async () => {
 			const user = userEvent.setup();
 			const spy = jest.fn();

--- a/packages/components/src/item-group/test/index.jsdom.test.tsx
+++ b/packages/components/src/item-group/test/index.jsdom.test.tsx
@@ -150,6 +150,18 @@ describe( 'ItemGroup', () => {
 			);
 		} );
 
+		it( 'uses list semantics within an ItemGroup with the directory role', () => {
+			render(
+				<ItemGroup role="directory">
+					<Item>Directory item</Item>
+				</ItemGroup>
+			);
+
+			expect( screen.getByRole( 'listitem' ) ).toHaveTextContent(
+				'Directory item'
+			);
+		} );
+
 		it( 'should render as a `button` if the `onClick` handler is specified', async () => {
 			const user = userEvent.setup();
 			const spy = jest.fn();

--- a/packages/components/src/item-group/types.ts
+++ b/packages/components/src/item-group/types.ts
@@ -46,6 +46,14 @@ export interface ItemProps {
 
 export type ItemGroupContext = {
 	/**
+	 * The element that owns items with list semantics.
+	 */
+	itemGroupRef?: React.RefObject< HTMLElement | null >;
+	/**
+	 * Whether items should use list semantics.
+	 */
+	isList: boolean;
+	/**
 	 * When true, each `Item` will be styled as an individual item (e.g. with rounded
 	 * borders), instead of being part of the same UI block with the rest of the items.
 	 *

--- a/packages/components/src/item-group/types.ts
+++ b/packages/components/src/item-group/types.ts
@@ -46,10 +46,6 @@ export interface ItemProps {
 
 export type ItemGroupContext = {
 	/**
-	 * The element that owns items with list semantics.
-	 */
-	itemGroupRef?: React.RefObject< HTMLElement | null >;
-	/**
 	 * Whether items should use list semantics.
 	 */
 	isList: boolean;

--- a/packages/components/src/toggle-group-control/context.ts
+++ b/packages/components/src/toggle-group-control/context.ts
@@ -1,11 +1,20 @@
 import { createContext, useContext } from '@wordpress/element';
 import type { ToggleGroupControlContextProps } from './types';
 
-const ToggleGroupControlContext = createContext(
-	{} as ToggleGroupControlContextProps
-);
+const ToggleGroupControlContext = createContext<
+	ToggleGroupControlContextProps | undefined
+>( undefined );
 ToggleGroupControlContext.displayName = 'ToggleGroupControlContext';
 
-export const useToggleGroupControlContext = () =>
-	useContext( ToggleGroupControlContext );
+export const useToggleGroupControlContext = (
+	componentName = 'ToggleGroupControlOptionBase'
+) => {
+	const context = useContext( ToggleGroupControlContext );
+	if ( ! context ) {
+		throw new Error(
+			`${ componentName } can only be rendered inside ToggleGroupControl.`
+		);
+	}
+	return context;
+};
 export default ToggleGroupControlContext;

--- a/packages/components/src/toggle-group-control/test/index.jsdom.test.tsx
+++ b/packages/components/src/toggle-group-control/test/index.jsdom.test.tsx
@@ -99,6 +99,32 @@ const optionsWithDisabledOption = (
 	</>
 );
 
+describe( 'required context', () => {
+	it( 'throws when ToggleGroupControlOption is outside ToggleGroupControl', () => {
+		expect( () =>
+			render( <ToggleGroupControlOption value="value" label="Label" /> )
+		).toThrow(
+			'ToggleGroupControlOption can only be rendered inside ToggleGroupControl.'
+		);
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'throws when ToggleGroupControlOptionIcon is outside ToggleGroupControl', () => {
+		expect( () =>
+			render(
+				<ToggleGroupControlOptionIcon
+					value="value"
+					label="Label"
+					icon={ formatUppercase }
+				/>
+			)
+		).toThrow(
+			'ToggleGroupControlOptionIcon can only be rendered inside ToggleGroupControl.'
+		);
+		expect( console ).toHaveErrored();
+	} );
+} );
+
 describe.each( [
 	[ 'uncontrolled', ToggleGroupControl ],
 	[ 'controlled', ControlledToggleGroupControl ],

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from '@wordpress/element';
 import type { WordPressComponentProps } from '../../context';
 import type { ToggleGroupControlOptionIconProps } from '../types';
 import { ToggleGroupControlOptionBase } from '../toggle-group-control-option-base';
+import { useToggleGroupControlContext } from '../context';
 import Icon from '../../icon';
 
 function UnforwardedToggleGroupControlOptionIcon(
@@ -13,6 +14,7 @@ function UnforwardedToggleGroupControlOptionIcon(
 	>,
 	ref: ForwardedRef< any >
 ) {
+	useToggleGroupControlContext( 'ToggleGroupControlOptionIcon' );
 	const { icon, label, ...restProps } = props;
 	return (
 		<ToggleGroupControlOptionBase

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from '@wordpress/element';
 import type { WordPressComponentProps } from '../../context';
 import type { ToggleGroupControlOptionProps } from '../types';
 import { ToggleGroupControlOptionBase } from '../toggle-group-control-option-base';
+import { useToggleGroupControlContext } from '../context';
 
 function UnforwardedToggleGroupControlOption(
 	props: WordPressComponentProps<
@@ -12,6 +13,7 @@ function UnforwardedToggleGroupControlOption(
 	>,
 	ref: ForwardedRef< any >
 ) {
+	useToggleGroupControlContext( 'ToggleGroupControlOption' );
 	const { label, ...restProps } = props;
 	const optionLabel = restProps[ 'aria-label' ] || label;
 	return (

--- a/packages/components/src/tree-grid/cell.tsx
+++ b/packages/components/src/tree-grid/cell.tsx
@@ -1,7 +1,8 @@
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useRef } from '@wordpress/element';
 import TreeGridItem from './item';
 import type { WordPressComponentProps } from '../context';
 import type { TreeGridCellProps } from './types';
+import { useValidateTreeGridStructure } from './use-validate-tree-grid-structure';
 
 function UnforwardedTreeGridCell(
 	{
@@ -11,8 +12,11 @@ function UnforwardedTreeGridCell(
 	}: WordPressComponentProps< TreeGridCellProps, 'td', false >,
 	ref: React.ForwardedRef< any >
 ) {
+	const cellRef = useRef< HTMLTableCellElement >( null );
+	useValidateTreeGridStructure( 'TreeGridCell', cellRef );
+
 	return (
-		<td { ...props } role="gridcell">
+		<td ref={ cellRef } { ...props } role="gridcell">
 			{ withoutGridItem ? (
 				<>
 					{ typeof children === 'function'

--- a/packages/components/src/tree-grid/roving-tab-index-item.tsx
+++ b/packages/components/src/tree-grid/roving-tab-index-item.tsx
@@ -9,9 +9,13 @@ export const RovingTabIndexItem = forwardRef(
 	) {
 		const localRef = useRef< any >( null );
 		const ref = forwardedRef || localRef;
-		// @ts-expect-error - We actually want to throw an error if this is undefined.
-		const { lastFocusedElement, setLastFocusedElement } =
-			useRovingTabIndexContext();
+		const context = useRovingTabIndexContext();
+		if ( ! context ) {
+			throw new Error(
+				'TreeGridItem can only be rendered inside a TreeGrid component.'
+			);
+		}
+		const { lastFocusedElement, setLastFocusedElement } = context;
 		let tabIndex;
 
 		if ( lastFocusedElement ) {

--- a/packages/components/src/tree-grid/row.tsx
+++ b/packages/components/src/tree-grid/row.tsx
@@ -1,6 +1,8 @@
-import { forwardRef } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
+import { forwardRef, useRef } from '@wordpress/element';
 import type { WordPressComponentProps } from '../context';
 import type { TreeGridRowProps } from './types';
+import { useValidateTreeGridStructure } from './use-validate-tree-grid-structure';
 
 function UnforwardedTreeGridRow(
 	{
@@ -13,10 +15,14 @@ function UnforwardedTreeGridRow(
 	}: WordPressComponentProps< TreeGridRowProps, 'tr', false >,
 	ref: React.ForwardedRef< HTMLTableRowElement >
 ) {
+	const rowRef = useRef< HTMLTableRowElement >( null );
+	const refs = useMergeRefs( [ rowRef, ref ] );
+	useValidateTreeGridStructure( 'TreeGridRow', rowRef );
+
 	return (
 		<tr
 			{ ...props }
-			ref={ ref }
+			ref={ refs }
 			role="row"
 			aria-level={ level }
 			aria-posinset={ positionInSet }

--- a/packages/components/src/tree-grid/test/__snapshots__/row.jsdom.test.tsx.snap
+++ b/packages/components/src/tree-grid/test/__snapshots__/row.jsdom.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`TreeGridRow forwards other props to the rendered tr element 1`] = `
 <div>
-  <table>
+  <table
+    role="treegrid"
+  >
     <tbody>
       <tr
         aria-level="1"
@@ -22,7 +24,9 @@ exports[`TreeGridRow forwards other props to the rendered tr element 1`] = `
 
 exports[`TreeGridRow renders a tr with support for level, positionInSet and setSize props 1`] = `
 <div>
-  <table>
+  <table
+    role="treegrid"
+  >
     <tbody>
       <tr
         aria-level="1"

--- a/packages/components/src/tree-grid/test/cell.jsdom.test.tsx
+++ b/packages/components/src/tree-grid/test/cell.jsdom.test.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react';
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+import { render, screen } from '@testing-library/react';
 import { forwardRef } from '@wordpress/element';
 import TreeGrid from '..';
 import TreeGridCell from '../cell';
@@ -11,19 +12,35 @@ const TestButton = forwardRef(
 );
 
 describe( 'TreeGridCell', () => {
-	it( 'requires TreeGrid to be declared as a parent component somewhere in the component hierarchy', () => {
+	it( 'throws outside a treegrid', () => {
 		expect( () =>
 			render(
-				<TreeGridCell>
-					{ ( props ) => (
-						<TestButton className="my-button" { ...props }>
-							Click Me!
-						</TestButton>
-					) }
-				</TreeGridCell>
+				<table>
+					<tbody>
+						<tr>
+							<TreeGridCell withoutGridItem>Test</TreeGridCell>
+						</tr>
+					</tbody>
+				</table>
 			)
-		).toThrow();
+		).toThrow(
+			'TreeGridCell must be rendered as a cell in a row that belongs to an element with role="treegrid".'
+		);
 		expect( console ).toHaveErrored();
+	} );
+
+	it( 'supports a custom semantic treegrid structure without a TreeGrid parent', () => {
+		render(
+			<table role="treegrid">
+				<tbody>
+					<tr>
+						<TreeGridCell withoutGridItem>Test</TreeGridCell>
+					</tr>
+				</tbody>
+			</table>
+		);
+
+		expect( screen.getByRole( 'gridcell' ) ).toHaveTextContent( 'Test' );
 	} );
 
 	it( 'uses a child render function to render children', () => {
@@ -44,3 +61,4 @@ describe( 'TreeGridCell', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 } );
+/* eslint-enable jsx-a11y/no-noninteractive-element-to-interactive-role */

--- a/packages/components/src/tree-grid/test/cell.jsdom.test.tsx
+++ b/packages/components/src/tree-grid/test/cell.jsdom.test.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 import { render, screen } from '@testing-library/react';
-import { forwardRef } from '@wordpress/element';
+import { createPortal, forwardRef, useId } from '@wordpress/element';
 import TreeGrid from '..';
 import TreeGridCell from '../cell';
+import TreeGridRow from '../row';
 
 const TestButton = forwardRef(
 	(
@@ -41,6 +42,48 @@ describe( 'TreeGridCell', () => {
 		);
 
 		expect( screen.getByRole( 'gridcell' ) ).toHaveTextContent( 'Test' );
+	} );
+
+	it( 'accepts a cell explicitly owned by a valid treegrid row', () => {
+		const portalTable = document.createElement( 'table' );
+		const portalBody = document.createElement( 'tbody' );
+		const portalRow = document.createElement( 'tr' );
+		portalRow.setAttribute( 'role', 'presentation' );
+		portalBody.append( portalRow );
+		portalTable.append( portalBody );
+		document.body.append( portalTable );
+
+		function AriaOwnedCell() {
+			const cellId = useId();
+
+			return (
+				<TreeGrid>
+					<TreeGridRow
+						level={ 1 }
+						positionInSet={ 1 }
+						setSize={ 1 }
+						aria-owns={ cellId }
+					>
+						{ createPortal(
+							<TreeGridCell id={ cellId } withoutGridItem>
+								Test
+							</TreeGridCell>,
+							portalRow
+						) }
+					</TreeGridRow>
+				</TreeGrid>
+			);
+		}
+
+		try {
+			render( <AriaOwnedCell /> );
+
+			expect( screen.getByRole( 'gridcell' ) ).toHaveTextContent(
+				'Test'
+			);
+		} finally {
+			portalTable.remove();
+		}
 	} );
 
 	it( 'uses a child render function to render children', () => {

--- a/packages/components/src/tree-grid/test/cell.jsdom.test.tsx
+++ b/packages/components/src/tree-grid/test/cell.jsdom.test.tsx
@@ -86,6 +86,47 @@ describe( 'TreeGridCell', () => {
 		}
 	} );
 
+	it( 'accepts a cell inside a wrapper explicitly owned by a valid treegrid row', () => {
+		const portalTable = document.createElement( 'table' );
+		const portalBody = document.createElement( 'tbody' );
+		portalTable.append( portalBody );
+		document.body.append( portalTable );
+
+		function AriaOwnedCellWrapper() {
+			const wrapperId = useId();
+
+			return (
+				<TreeGrid>
+					<TreeGridRow
+						level={ 1 }
+						positionInSet={ 1 }
+						setSize={ 1 }
+						aria-owns={ wrapperId }
+					>
+						{ createPortal(
+							<tr id={ wrapperId } role="presentation">
+								<TreeGridCell withoutGridItem>
+									Test
+								</TreeGridCell>
+							</tr>,
+							portalBody
+						) }
+					</TreeGridRow>
+				</TreeGrid>
+			);
+		}
+
+		try {
+			render( <AriaOwnedCellWrapper /> );
+
+			expect( screen.getByRole( 'gridcell' ) ).toHaveTextContent(
+				'Test'
+			);
+		} finally {
+			portalTable.remove();
+		}
+	} );
+
 	it( 'uses a child render function to render children', () => {
 		const { container } = render(
 			<TreeGrid>

--- a/packages/components/src/tree-grid/test/roving-tab-index-item.jsdom.test.tsx
+++ b/packages/components/src/tree-grid/test/roving-tab-index-item.jsdom.test.tsx
@@ -14,7 +14,9 @@ describe( 'RovingTabIndexItem', () => {
 	it( 'requires RovingTabIndex to be declared as a parent component somewhere in the component hierarchy', () => {
 		expect( () =>
 			render( <RovingTabIndexItem as={ TestButton } /> )
-		).toThrow();
+		).toThrow(
+			'TreeGridItem can only be rendered inside a TreeGrid component.'
+		);
 		expect( console ).toHaveErrored();
 	} );
 

--- a/packages/components/src/tree-grid/test/row.jsdom.test.tsx
+++ b/packages/components/src/tree-grid/test/row.jsdom.test.tsx
@@ -1,10 +1,32 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 import { render } from '@testing-library/react';
 import TreeGridRow from '../row';
 
 describe( 'TreeGridRow', () => {
+	it( 'throws outside a treegrid', () => {
+		expect( () =>
+			render(
+				<table>
+					<tbody>
+						<TreeGridRow
+							level={ 1 }
+							positionInSet={ 1 }
+							setSize={ 1 }
+						>
+							<td>Test</td>
+						</TreeGridRow>
+					</tbody>
+				</table>
+			)
+		).toThrow(
+			'TreeGridRow must be rendered inside an element with role="treegrid".'
+		);
+		expect( console ).toHaveErrored();
+	} );
+
 	it( 'renders a tr with support for level, positionInSet and setSize props', () => {
 		const { container } = render(
-			<table>
+			<table role="treegrid">
 				<tbody>
 					<TreeGridRow level={ 1 } positionInSet={ 1 } setSize={ 1 }>
 						<td>Test</td>
@@ -18,7 +40,7 @@ describe( 'TreeGridRow', () => {
 
 	it( 'forwards other props to the rendered tr element', () => {
 		const { container } = render(
-			<table>
+			<table role="treegrid">
 				<tbody>
 					<TreeGridRow
 						className="my-row"
@@ -35,3 +57,4 @@ describe( 'TreeGridRow', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 } );
+/* eslint-enable jsx-a11y/no-noninteractive-element-to-interactive-role */

--- a/packages/components/src/tree-grid/test/row.jsdom.test.tsx
+++ b/packages/components/src/tree-grid/test/row.jsdom.test.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { createPortal, useId } from '@wordpress/element';
 import TreeGridRow from '../row';
+import TreeGrid from '..';
 
 describe( 'TreeGridRow', () => {
 	it( 'throws outside a treegrid', () => {
@@ -22,6 +24,41 @@ describe( 'TreeGridRow', () => {
 			'TreeGridRow must be rendered inside an element with role="treegrid".'
 		);
 		expect( console ).toHaveErrored();
+	} );
+
+	it( 'accepts a row explicitly owned by the treegrid', () => {
+		const portalTable = document.createElement( 'table' );
+		const portalBody = document.createElement( 'tbody' );
+		portalTable.append( portalBody );
+		document.body.append( portalTable );
+
+		function AriaOwnedRow() {
+			const rowId = useId();
+
+			return (
+				<TreeGrid aria-owns={ rowId }>
+					{ createPortal(
+						<TreeGridRow
+							id={ rowId }
+							level={ 1 }
+							positionInSet={ 1 }
+							setSize={ 1 }
+						>
+							<td>Test</td>
+						</TreeGridRow>,
+						portalBody
+					) }
+				</TreeGrid>
+			);
+		}
+
+		try {
+			render( <AriaOwnedRow /> );
+
+			expect( screen.getByRole( 'row' ) ).toHaveTextContent( 'Test' );
+		} finally {
+			portalTable.remove();
+		}
 	} );
 
 	it( 'renders a tr with support for level, positionInSet and setSize props', () => {

--- a/packages/components/src/tree-grid/test/row.jsdom.test.tsx
+++ b/packages/components/src/tree-grid/test/row.jsdom.test.tsx
@@ -61,6 +61,40 @@ describe( 'TreeGridRow', () => {
 		}
 	} );
 
+	it( 'accepts a row inside a rowgroup explicitly owned by the treegrid', () => {
+		const portalTable = document.createElement( 'table' );
+		document.body.append( portalTable );
+
+		function AriaOwnedRowGroup() {
+			const rowGroupId = useId();
+
+			return (
+				<TreeGrid aria-owns={ rowGroupId }>
+					{ createPortal(
+						<tbody id={ rowGroupId }>
+							<TreeGridRow
+								level={ 1 }
+								positionInSet={ 1 }
+								setSize={ 1 }
+							>
+								<td>Test</td>
+							</TreeGridRow>
+						</tbody>,
+						portalTable
+					) }
+				</TreeGrid>
+			);
+		}
+
+		try {
+			render( <AriaOwnedRowGroup /> );
+
+			expect( screen.getByRole( 'row' ) ).toHaveTextContent( 'Test' );
+		} finally {
+			portalTable.remove();
+		}
+	} );
+
 	it( 'renders a tr with support for level, positionInSet and setSize props', () => {
 		const { container } = render(
 			<table role="treegrid">

--- a/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
+++ b/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
@@ -1,0 +1,29 @@
+import { useEffect } from '@wordpress/element';
+
+export function useValidateTreeGridStructure(
+	componentName: 'TreeGridRow' | 'TreeGridCell',
+	elementRef: React.RefObject< HTMLElement >
+) {
+	useEffect( () => {
+		const element = elementRef.current;
+		if ( ! element ) {
+			return;
+		}
+
+		let row: HTMLElement | null = element;
+		if ( componentName === 'TreeGridCell' ) {
+			row = element.parentElement?.matches( 'tr, [role="row"]' )
+				? element.parentElement
+				: null;
+		}
+		const treeGrid = row?.closest( '[role="treegrid"]' );
+
+		if ( ! row || ! treeGrid ) {
+			throw new Error(
+				componentName === 'TreeGridRow'
+					? 'TreeGridRow must be rendered inside an element with role="treegrid".'
+					: 'TreeGridCell must be rendered as a cell in a row that belongs to an element with role="treegrid".'
+			);
+		}
+	} );
+}

--- a/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
+++ b/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
@@ -56,7 +56,7 @@ function isOwnedByRowInTreeGrid(
 	}
 	visited.add( element );
 
-	return getAriaOwners( element ).some( ( owner ) => {
+	const hasValidOwner = getAriaOwners( element ).some( ( owner ) => {
 		const row = owner.matches( ROW_SELECTOR )
 			? owner
 			: owner.closest< HTMLElement >( ROW_SELECTOR );
@@ -65,6 +65,13 @@ function isOwnedByRowInTreeGrid(
 			? isContainedInOrOwnedBy( row, TREE_GRID_SELECTOR )
 			: isOwnedByRowInTreeGrid( owner, visited );
 	} );
+	if ( hasValidOwner ) {
+		return true;
+	}
+
+	return element.parentElement
+		? isOwnedByRowInTreeGrid( element.parentElement, visited )
+		: false;
 }
 
 export function useValidateTreeGridStructure(

--- a/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
+++ b/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
@@ -8,14 +8,14 @@ function getAriaOwners( element: HTMLElement ) {
 		return [];
 	}
 
+	const escapedId = element.id
+		.replaceAll( '\\', '\\\\' )
+		.replaceAll( '"', '\\"' );
+
 	return Array.from(
-		element.ownerDocument.querySelectorAll< HTMLElement >( '[aria-owns]' )
-	).filter(
-		( owner ) =>
-			owner
-				.getAttribute( 'aria-owns' )
-				?.split( /\s+/ )
-				.includes( element.id )
+		element.ownerDocument.querySelectorAll< HTMLElement >(
+			`[aria-owns~="${ escapedId }"]`
+		)
 	);
 }
 
@@ -86,5 +86,5 @@ export function useValidateTreeGridStructure(
 					: 'TreeGridCell must be rendered as a cell in a row that belongs to an element with role="treegrid".'
 			);
 		}
-	} );
+	}, [ componentName, elementRef ] );
 }

--- a/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
+++ b/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
@@ -33,11 +33,18 @@ function isContainedInOrOwnedBy(
 		return true;
 	}
 
-	return getAriaOwners( element ).some(
+	const hasValidOwner = getAriaOwners( element ).some(
 		( owner ) =>
 			owner.matches( selector ) ||
 			isContainedInOrOwnedBy( owner, selector, visited )
 	);
+	if ( hasValidOwner ) {
+		return true;
+	}
+
+	return element.parentElement
+		? isContainedInOrOwnedBy( element.parentElement, selector, visited )
+		: false;
 }
 
 function isOwnedByRowInTreeGrid(

--- a/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
+++ b/packages/components/src/tree-grid/use-validate-tree-grid-structure.ts
@@ -1,5 +1,65 @@
 import { useEffect } from '@wordpress/element';
 
+const ROW_SELECTOR = 'tr:not([role]), [role="row"]';
+const TREE_GRID_SELECTOR = '[role="treegrid"]';
+
+function getAriaOwners( element: HTMLElement ) {
+	if ( ! element.id ) {
+		return [];
+	}
+
+	return Array.from(
+		element.ownerDocument.querySelectorAll< HTMLElement >( '[aria-owns]' )
+	).filter(
+		( owner ) =>
+			owner
+				.getAttribute( 'aria-owns' )
+				?.split( /\s+/ )
+				.includes( element.id )
+	);
+}
+
+function isContainedInOrOwnedBy(
+	element: HTMLElement,
+	selector: string,
+	visited = new Set< HTMLElement >()
+): boolean {
+	if ( visited.has( element ) ) {
+		return false;
+	}
+	visited.add( element );
+
+	if ( element.parentElement?.closest( selector ) ) {
+		return true;
+	}
+
+	return getAriaOwners( element ).some(
+		( owner ) =>
+			owner.matches( selector ) ||
+			isContainedInOrOwnedBy( owner, selector, visited )
+	);
+}
+
+function isOwnedByRowInTreeGrid(
+	element: HTMLElement,
+	visited = new Set< HTMLElement >()
+): boolean {
+	if ( visited.has( element ) ) {
+		return false;
+	}
+	visited.add( element );
+
+	return getAriaOwners( element ).some( ( owner ) => {
+		const row = owner.matches( ROW_SELECTOR )
+			? owner
+			: owner.closest< HTMLElement >( ROW_SELECTOR );
+
+		return row
+			? isContainedInOrOwnedBy( row, TREE_GRID_SELECTOR )
+			: isOwnedByRowInTreeGrid( owner, visited );
+	} );
+}
+
 export function useValidateTreeGridStructure(
 	componentName: 'TreeGridRow' | 'TreeGridCell',
 	elementRef: React.RefObject< HTMLElement >
@@ -10,15 +70,16 @@ export function useValidateTreeGridStructure(
 			return;
 		}
 
-		let row: HTMLElement | null = element;
-		if ( componentName === 'TreeGridCell' ) {
-			row = element.parentElement?.matches( 'tr, [role="row"]' )
-				? element.parentElement
-				: null;
-		}
-		const treeGrid = row?.closest( '[role="treegrid"]' );
+		const row =
+			element.parentElement?.closest< HTMLElement >( ROW_SELECTOR );
+		const hasValidStructure =
+			componentName === 'TreeGridRow'
+				? isContainedInOrOwnedBy( element, TREE_GRID_SELECTOR )
+				: ( row &&
+						isContainedInOrOwnedBy( row, TREE_GRID_SELECTOR ) ) ||
+				  isOwnedByRowInTreeGrid( element );
 
-		if ( ! row || ! treeGrid ) {
+		if ( ! hasValidStructure ) {
 			throw new Error(
 				componentName === 'TreeGridRow'
 					? 'TreeGridRow must be rendered inside an element with role="treegrid".'


### PR DESCRIPTION
Part of #66530.

## What?

Adds severity-based diagnostics for invalid compound-component composition in `@wordpress/components`:

- Warns when `Composite.Item` has no composite state, while preserving Ariakit's standalone button fallback.
- Throws when `Composite.GroupLabel`, toggle-group options, or tree-grid parts lack the accessible relationship, semantic structure, or keyboard state they require.
- Applies `listitem` semantics to `Item` only when it is inside a list-semantic `ItemGroup`, and validates its rendered list ancestry.

## Why?

Invalid composition can silently remove accessible labels, required ARIA state, semantic structure, or keyboard behavior. The diagnostic severity now matches the impact: recoverable `Composite.Item` usage gets a development warning, while missing accessible relationships, required semantics, or keyboard state throw clear errors.

## How?

Context checks cover stateful compound components. `ItemGroup` derives the default item role from its own semantics and checks the rendered DOM for a semantic list ancestor, so wrappers, standalone items, custom roles, and custom containers remain supported. Tree-grid rows and cells validate their rendered semantic structure.

The isolated `DownloadableBlockListItem` consumer test now supplies the `Composite` context that its production list already provides.

## Testing Instructions

Run:

```sh
npm run test:unit -- --runInBand packages/components/src/composite/test/index.jsdom.test.tsx packages/components/src/item-group/test/index.jsdom.test.tsx packages/components/src/toggle-group-control/test/index.jsdom.test.tsx packages/components/src/tree-grid/test/row.jsdom.test.tsx packages/components/src/tree-grid/test/cell.jsdom.test.tsx packages/components/src/tree-grid/test/roving-tab-index-item.jsdom.test.tsx packages/block-directory/src/components/downloadable-block-list-item/test/index.jsdom.test.jsx
```

Confirm that standalone `Composite.Item` renders a button and warns, wrapped list items render normally, an item portaled outside a semantic list throws, and the remaining invalid compositions throw their specific errors.

### Testing Instructions for Keyboard

No valid interaction changes. Confirm the existing Composite, ToggleGroupControl, and TreeGrid keyboard-navigation tests pass in the focused test run.

## Screenshots or screencast

Not applicable. This change adds developer diagnostics and corrects conditional list semantics without changing valid visual output.

## Use of AI Tools

Codex was used to inspect the issue and consumers, implement the changes and tests, and draft this description. The author reviewed the resulting diff and verification output.
