### PR TITLE
UI: Validate compound component context

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Enhancements
 
+-   Compound components: Throw clear development errors when required parent context is missing ([#82510](https://github.com/WordPress/gutenberg/pull/82510)).
 -   Give input fields and checkboxes solid, state-aware themed backgrounds while keeping minimal Select triggers transparent. ([#82391](https://github.com/WordPress/gutenberg/pull/82391))
 -   `AlertDialog`, `Dialog`, `Drawer`, `Popover`, and `Tooltip`: Derive Trigger props from the corresponding Base UI components. ([#81824](https://github.com/WordPress/gutenberg/pull/81824))
 -   `Autocomplete.Status`, `Combobox.Status`: Add a `Status` subcomponent that announces async list status to screen readers. Item popups give Status its own collapsing grid row so a visible result count sits above the list without overlaying items ([#82195](https://github.com/WordPress/gutenberg/pull/82195)).

--- a/packages/ui/src/form/primitives/autocomplete/context.ts
+++ b/packages/ui/src/form/primitives/autocomplete/context.ts
@@ -1,0 +1,6 @@
+import { createContext, useContext } from '@wordpress/element';
+
+export const AutocompleteGridContext = createContext( false );
+
+export const useAutocompleteGridContext = () =>
+	useContext( AutocompleteGridContext );

--- a/packages/ui/src/form/primitives/autocomplete/root.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/root.tsx
@@ -1,6 +1,7 @@
 import { Autocomplete as _Autocomplete } from '@base-ui/react/autocomplete';
 import type { AutocompleteRootProps } from './types';
 import { DirectionProvider } from '../../../utils/direction-provider';
+import { AutocompleteGridContext } from './context';
 
 /**
  * Low-level primitive for an autocomplete input that suggests options as
@@ -13,8 +14,10 @@ import { DirectionProvider } from '../../../utils/direction-provider';
  */
 export function Root( props: AutocompleteRootProps ) {
 	return (
-		<DirectionProvider>
-			<_Autocomplete.Root { ...props } />
-		</DirectionProvider>
+		<AutocompleteGridContext.Provider value={ Boolean( props.grid ) }>
+			<DirectionProvider>
+				<_Autocomplete.Root { ...props } />
+			</DirectionProvider>
+		</AutocompleteGridContext.Provider>
 	);
 }

--- a/packages/ui/src/form/primitives/autocomplete/row.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/row.tsx
@@ -1,6 +1,7 @@
 import { Autocomplete as _Autocomplete } from '@base-ui/react/autocomplete';
 import { forwardRef } from '@wordpress/element';
 import type { AutocompleteRowProps } from './types';
+import { useAutocompleteGridContext } from './context';
 
 /**
  * Groups multiple `Autocomplete.Item` cells into a single row in a grid
@@ -9,6 +10,13 @@ import type { AutocompleteRowProps } from './types';
  */
 export const Row = forwardRef< HTMLDivElement, AutocompleteRowProps >(
 	function Row( { children, ...restProps }, ref ) {
+		const isGrid = useAutocompleteGridContext();
+		if ( process.env.NODE_ENV !== 'production' && ! isGrid ) {
+			throw new Error(
+				'Autocomplete.Row: Missing parent <Autocomplete.Root grid>. Render <Autocomplete.Row> inside <Autocomplete.Root grid>.'
+			);
+		}
+
 		return (
 			<_Autocomplete.Row ref={ ref } { ...restProps }>
 				{ children }

--- a/packages/ui/src/form/primitives/autocomplete/test/index.jsdom.test.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/test/index.jsdom.test.tsx
@@ -470,6 +470,26 @@ describe( 'Autocomplete', () => {
 			},
 		];
 
+		it( 'throws outside Autocomplete.Root', () => {
+			expect( () => render( <Autocomplete.Row /> ) ).toThrow(
+				'Autocomplete.Row: Missing parent <Autocomplete.Root grid>. Render <Autocomplete.Row> inside <Autocomplete.Root grid>.'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
+		it( 'throws when Autocomplete.Root does not enable grid mode', () => {
+			expect( () =>
+				render(
+					<Autocomplete.Root items={ GRID_ITEMS }>
+						<Autocomplete.Row />
+					</Autocomplete.Root>
+				)
+			).toThrow(
+				'Autocomplete.Row: Missing parent <Autocomplete.Root grid>. Render <Autocomplete.Row> inside <Autocomplete.Root grid>.'
+			);
+			expect( console ).toHaveErrored();
+		} );
+
 		it( 'forwards ref', async () => {
 			const rowRef = createRef< HTMLDivElement >();
 

--- a/packages/ui/src/form/primitives/fieldset/context.tsx
+++ b/packages/ui/src/form/primitives/fieldset/context.tsx
@@ -5,9 +5,25 @@ type FieldsetContextType = {
 	unregisterDescriptionId: () => void;
 };
 
-export const FieldsetContext = createContext< FieldsetContextType >( {
+const fallbackContext: FieldsetContextType = {
 	registerDescriptionId: () => {},
 	unregisterDescriptionId: () => {},
-} );
+};
 
-export const useFieldsetContext = () => useContext( FieldsetContext );
+export const FieldsetContext = createContext< FieldsetContextType | null >(
+	null
+);
+
+export const useFieldsetContext = (
+	componentName: 'Fieldset.Description' | 'Fieldset.Details'
+) => {
+	const context = useContext( FieldsetContext );
+
+	if ( process.env.NODE_ENV !== 'production' && ! context ) {
+		throw new Error(
+			`${ componentName }: Missing parent <Fieldset.Root>. Render <${ componentName }> inside <Fieldset.Root>.`
+		);
+	}
+
+	return context ?? fallbackContext;
+};

--- a/packages/ui/src/form/primitives/fieldset/description.tsx
+++ b/packages/ui/src/form/primitives/fieldset/description.tsx
@@ -16,7 +16,7 @@ export const FieldsetDescription = forwardRef<
 	const generatedId = useId();
 	const id = idProp ?? generatedId;
 	const { registerDescriptionId, unregisterDescriptionId } =
-		useFieldsetContext();
+		useFieldsetContext( 'Fieldset.Description' );
 
 	useEffect( () => {
 		registerDescriptionId( id );

--- a/packages/ui/src/form/primitives/fieldset/details.tsx
+++ b/packages/ui/src/form/primitives/fieldset/details.tsx
@@ -24,7 +24,7 @@ export const FieldsetDetails = forwardRef<
 >( function FieldsetDetails( { className, ...restProps }, ref ) {
 	const id = useId();
 	const { registerDescriptionId, unregisterDescriptionId } =
-		useFieldsetContext();
+		useFieldsetContext( 'Fieldset.Details' );
 
 	useEffect( () => {
 		registerDescriptionId( id );

--- a/packages/ui/src/form/primitives/fieldset/test/index.jsdom.test.tsx
+++ b/packages/ui/src/form/primitives/fieldset/test/index.jsdom.test.tsx
@@ -3,6 +3,24 @@ import { createRef } from '@wordpress/element';
 import * as Fieldset from '../';
 
 describe( 'Fieldset', () => {
+	it( 'throws when Fieldset.Description is outside Fieldset.Root', () => {
+		expect( () =>
+			render( <Fieldset.Description>Description</Fieldset.Description> )
+		).toThrow(
+			'Fieldset.Description: Missing parent <Fieldset.Root>. Render <Fieldset.Description> inside <Fieldset.Root>.'
+		);
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'throws when Fieldset.Details is outside Fieldset.Root', () => {
+		expect( () =>
+			render( <Fieldset.Details>Details</Fieldset.Details> )
+		).toThrow(
+			'Fieldset.Details: Missing parent <Fieldset.Root>. Render <Fieldset.Details> inside <Fieldset.Root>.'
+		);
+		expect( console ).toHaveErrored();
+	} );
+
 	it( 'forwards ref', () => {
 		const rootRef = createRef< HTMLFieldSetElement >();
 		const legendRef = createRef< HTMLDivElement >();

--- a/packages/ui/src/menu/context.tsx
+++ b/packages/ui/src/menu/context.tsx
@@ -12,6 +12,7 @@ const MenuContext = createContext< MenuContextValue >( {
 const useMenuContext = () => useContext( MenuContext );
 
 type MenuItemContentContextValue = {
+	descriptionIds: readonly string[];
 	labelId?: string;
 	labelTrailing?: ReactNode;
 };

--- a/packages/ui/src/menu/context.tsx
+++ b/packages/ui/src/menu/context.tsx
@@ -12,7 +12,6 @@ const MenuContext = createContext< MenuContextValue >( {
 const useMenuContext = () => useContext( MenuContext );
 
 type MenuItemContentContextValue = {
-	descriptionIds: readonly string[];
 	labelId?: string;
 	labelTrailing?: ReactNode;
 };

--- a/packages/ui/src/menu/item-description.tsx
+++ b/packages/ui/src/menu/item-description.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from '@wordpress/element';
 import styles from './style.module.css';
 import type { ItemDescriptionProps } from './types';
 import { Text } from '../text';
+import { useMenuItemContentContext } from './context';
 
 /**
  * Renders supplementary text below a menu item label. Use it as a direct child
@@ -10,6 +11,16 @@ import { Text } from '../text';
  */
 const ItemDescription = forwardRef< HTMLSpanElement, ItemDescriptionProps >(
 	function MenuItemDescription( { className, id, ...props }, ref ) {
+		const itemContentContext = useMenuItemContentContext();
+		if (
+			process.env.NODE_ENV !== 'production' &&
+			( ! id || ! itemContentContext?.descriptionIds.includes( id ) )
+		) {
+			throw new Error(
+				'Menu.ItemDescription: Missing direct menu item parent. Render <Menu.ItemDescription> as a direct child of a menu item.'
+			);
+		}
+
 		return (
 			<Text
 				ref={ ref }

--- a/packages/ui/src/menu/item-description.tsx
+++ b/packages/ui/src/menu/item-description.tsx
@@ -3,18 +3,24 @@ import { forwardRef } from '@wordpress/element';
 import styles from './style.module.css';
 import type { ItemDescriptionProps } from './types';
 import { Text } from '../text';
-import { useMenuItemContentContext } from './context';
+
+const ITEM_DESCRIPTION_DIRECT_CHILD = Symbol();
+
+type InternalItemDescriptionProps = ItemDescriptionProps & {
+	validationToken?: typeof ITEM_DESCRIPTION_DIRECT_CHILD;
+};
 
 /**
  * Renders supplementary text below a menu item label. Use it as a direct child
  * alongside `Menu.ItemLabel`.
  */
 const ItemDescription = forwardRef< HTMLSpanElement, ItemDescriptionProps >(
-	function MenuItemDescription( { className, id, ...props }, ref ) {
-		const itemContentContext = useMenuItemContentContext();
+	function MenuItemDescription( props, ref ) {
+		const { className, id, validationToken, ...restProps } =
+			props as InternalItemDescriptionProps;
 		if (
 			process.env.NODE_ENV !== 'production' &&
-			( ! id || ! itemContentContext?.descriptionIds.includes( id ) )
+			validationToken !== ITEM_DESCRIPTION_DIRECT_CHILD
 		) {
 			throw new Error(
 				'Menu.ItemDescription: Missing direct menu item parent. Render <Menu.ItemDescription> as a direct child of a menu item.'
@@ -25,7 +31,7 @@ const ItemDescription = forwardRef< HTMLSpanElement, ItemDescriptionProps >(
 			<Text
 				ref={ ref }
 				variant="body-sm"
-				{ ...props }
+				{ ...restProps }
 				id={ id }
 				className={ clsx( styles[ 'item-description' ], className ) }
 			/>
@@ -33,4 +39,4 @@ const ItemDescription = forwardRef< HTMLSpanElement, ItemDescriptionProps >(
 	}
 );
 
-export { ItemDescription };
+export { ITEM_DESCRIPTION_DIRECT_CHILD, ItemDescription };

--- a/packages/ui/src/menu/item.tsx
+++ b/packages/ui/src/menu/item.tsx
@@ -121,6 +121,7 @@ function useItemContent(
 	return {
 		contentChildren,
 		contentContextValue: {
+			descriptionIds: resolvedDescriptionIds,
 			labelId: resolvedLabelId,
 			labelTrailing,
 		},

--- a/packages/ui/src/menu/item.tsx
+++ b/packages/ui/src/menu/item.tsx
@@ -16,7 +16,10 @@ import {
 } from '../utils/keyboard-shortcut';
 import styles from './style.module.css';
 import { MenuItemContentContext } from './context';
-import { ItemDescription } from './item-description';
+import {
+	ITEM_DESCRIPTION_DIRECT_CHILD,
+	ItemDescription,
+} from './item-description';
 import { ItemLabel } from './item-label';
 import type { ItemDescriptionProps, ItemProps } from './types';
 
@@ -87,7 +90,7 @@ function useItemContent(
 	).join( ' ' );
 	let descriptionIndex = 0;
 	// React widens the tuple while mapping; validation preserves the item-child
-	// contract and cloning changes only generated description IDs.
+	// contract and cloning adds only private validation data and generated IDs.
 	const contentChildren = Children.map( children, ( child ) => {
 		if (
 			! isValidElement< ItemDescriptionProps >( child ) ||
@@ -97,9 +100,11 @@ function useItemContent(
 		}
 
 		const descriptionId = resolvedDescriptionIds[ descriptionIndex++ ];
-		return child.props.id === descriptionId
-			? child
-			: cloneElement( child, { id: descriptionId } );
+		const descriptionProps = {
+			id: descriptionId,
+			validationToken: ITEM_DESCRIPTION_DIRECT_CHILD,
+		};
+		return cloneElement( child, descriptionProps );
 	} ) as ItemProps[ 'children' ];
 	const {
 		descriptionId: shortcutDescriptionId,
@@ -121,7 +126,6 @@ function useItemContent(
 	return {
 		contentChildren,
 		contentContextValue: {
-			descriptionIds: resolvedDescriptionIds,
 			labelId: resolvedLabelId,
 			labelTrailing,
 		},

--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -910,6 +910,38 @@ describe( 'Menu', () => {
 		expect( screen.getByText( 'separate' ).tagName ).toBe( 'STRONG' );
 	} );
 
+	it( 'throws when ItemDescription is outside a menu item', () => {
+		expect( () =>
+			render( <Menu.ItemDescription>Description</Menu.ItemDescription> )
+		).toThrow(
+			'Menu.ItemDescription: Missing direct menu item parent. Render <Menu.ItemDescription> as a direct child of a menu item.'
+		);
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'throws when ItemDescription is nested inside a menu item', () => {
+		expect( () =>
+			render(
+				<Menu.Root defaultOpen>
+					<Menu.Trigger>Actions</Menu.Trigger>
+					<Menu.Popup>
+						<Menu.Item>
+							<Menu.ItemLabel>
+								Duplicate
+								<Menu.ItemDescription>
+									Description
+								</Menu.ItemDescription>
+							</Menu.ItemLabel>
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+			)
+		).toThrow(
+			'Menu.ItemDescription: Missing direct menu item parent. Render <Menu.ItemDescription> as a direct child of a menu item.'
+		);
+		expect( console ).toHaveErrored();
+	} );
+
 	it( 'combines multiple item descriptions in DOM order', async () => {
 		const user = userEvent.setup();
 

--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -942,6 +942,36 @@ describe( 'Menu', () => {
 		expect( console ).toHaveErrored();
 	} );
 
+	it( 'throws when a nested ItemDescription reuses a direct sibling ID', () => {
+		function MenuWithDuplicateDescriptionId() {
+			const descriptionId = useId();
+
+			return (
+				<Menu.Root defaultOpen>
+					<Menu.Trigger>Actions</Menu.Trigger>
+					<Menu.Popup>
+						<Menu.Item>
+							<Menu.ItemLabel>
+								Duplicate
+								<Menu.ItemDescription id={ descriptionId }>
+									Nested description
+								</Menu.ItemDescription>
+							</Menu.ItemLabel>
+							<Menu.ItemDescription id={ descriptionId }>
+								Direct description
+							</Menu.ItemDescription>
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+			);
+		}
+
+		expect( () => render( <MenuWithDuplicateDescriptionId /> ) ).toThrow(
+			'Menu.ItemDescription: Missing direct menu item parent. Render <Menu.ItemDescription> as a direct child of a menu item.'
+		);
+		expect( console ).toHaveErrored();
+	} );
+
 	it( 'combines multiple item descriptions in DOM order', async () => {
 		const user = userEvent.setup();
 


### PR DESCRIPTION
Part of #66530.

## What?

Adds development-time errors for invalid compound-component composition in `@wordpress/ui`:

- `Fieldset.Description` and `Fieldset.Details` outside `Fieldset.Root`.
- `Autocomplete.Row` outside `Autocomplete.Root` or when the root does not enable `grid`.
- `Menu.ItemDescription` unless it is a direct child of a menu item.

## Why?

These compositions can render without the accessible relationship or keyboard-navigation state that the subcomponent requires. The new errors identify the missing parent and show the supported composition.

## How?

Fieldset and Autocomplete roots provide private context that their dependent subcomponents validate. Menu items clone their direct descriptions with resolved IDs and a private validation token, so nested or orphaned descriptions are rejected even if they reuse a direct sibling's ID. The checks are removed from production builds, following the package's existing compound-component validation convention.

## Testing Instructions

1. Run the focused unit tests:
   ```sh
   npm run test:unit -- --runInBand packages/ui/src/form/primitives/fieldset/test/index.jsdom.test.tsx packages/ui/src/form/primitives/autocomplete/test/index.jsdom.test.tsx packages/ui/src/menu/test/index.jsdom.test.tsx
   ```
2. Confirm the invalid examples throw the specific parent guidance asserted by the tests, including a nested menu description that reuses a direct sibling's ID.
3. Confirm the existing valid Fieldset associations, Autocomplete grid rows, and Menu item descriptions still pass.

### Testing Instructions for Keyboard

No valid interaction changes. Confirm the existing Autocomplete and Menu keyboard-interaction tests pass in the focused test run.

## Screenshots or screencast

Not applicable; this change adds developer-facing errors and does not alter valid rendering.

## Use of AI Tools

Codex was used to inspect the issue and consumers, implement the changes and tests, and draft this description. The author reviewed the resulting diff and verification output.
