### PR TITLE
Grid: preserve tile content semantics when dragging is disabled

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Preserve tile content semantics when dragging is disabled in `DashboardGrid` and `DashboardLanes`.
+-   Preserve tile content semantics when dragging is disabled in `DashboardGrid` and `DashboardLanes` ([#82511](https://github.com/WordPress/gutenberg/pull/82511)).
 
 ### New Features
 

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Preserve tile content semantics when dragging is disabled in `DashboardGrid` and `DashboardLanes`.
+
 ### New Features
 
 -   Layout items accept `draggable` and `resizable` flags. A non-draggable

--- a/packages/grid/src/dashboard-grid/grid-item.tsx
+++ b/packages/grid/src/dashboard-grid/grid-item.tsx
@@ -166,7 +166,7 @@ export function GridItem( {
 
 			<div
 				ref={ setActivatorNodeRef }
-				{ ...attributes }
+				{ ...( dragDisabled ? {} : attributes ) }
 				{ ...listeners }
 				style={ {
 					height: '100%',

--- a/packages/grid/src/dashboard-grid/test/item-interactions.jsdom.test.tsx
+++ b/packages/grid/src/dashboard-grid/test/item-interactions.jsdom.test.tsx
@@ -52,7 +52,7 @@ describe( 'DashboardGrid item interactions', () => {
 
 	it( 'keeps an item in place when draggable is false', () => {
 		const { activator, resizeHandle } = renderItem( { draggable: false } );
-		expect( activator ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( activator ).toBeNull();
 		expect( resizeHandle ).not.toBeNull();
 	} );
 

--- a/packages/grid/src/dashboard-lanes/lanes-item.tsx
+++ b/packages/grid/src/dashboard-lanes/lanes-item.tsx
@@ -223,7 +223,7 @@ export function LanesItem( {
 
 			<div
 				ref={ setActivatorNodeRef }
-				{ ...attributes }
+				{ ...( dragDisabled ? {} : attributes ) }
 				{ ...listeners }
 				style={ {
 					height: '100%',

--- a/packages/grid/src/dashboard-lanes/test/item-interactions.jsdom.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/item-interactions.jsdom.test.tsx
@@ -52,7 +52,7 @@ describe( 'DashboardLanes item interactions', () => {
 
 	it( 'keeps an item in place when draggable is false', () => {
 		const { activator, resizeHandle } = renderItem( { draggable: false } );
-		expect( activator ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( activator ).toBeNull();
 		expect( resizeHandle ).not.toBeNull();
 	} );
 

--- a/packages/grid/src/shared/test/sortable-semantics.jsdom.test.tsx
+++ b/packages/grid/src/shared/test/sortable-semantics.jsdom.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useId } from '@wordpress/element';
+import { DashboardGrid } from '../../dashboard-grid';
+import { DashboardLanes } from '../../dashboard-lanes';
+
+class MockResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+function Tile( {
+	children,
+}: {
+	children: React.ReactNode;
+	actionableArea?: React.ReactNode;
+} ) {
+	return <section>{ children }</section>;
+}
+
+function MetricControl() {
+	const id = useId();
+	return (
+		<label htmlFor={ id }>
+			Metric
+			<select id={ id }>
+				<option>Views</option>
+				<option>Clicks</option>
+			</select>
+		</label>
+	);
+}
+
+beforeEach( () => {
+	vi.stubGlobal( 'ResizeObserver', MockResizeObserver );
+} );
+
+afterEach( () => {
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+} );
+
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+describe.each( [
+	[ 'DashboardGrid', DashboardGrid ],
+	[ 'DashboardLanes', DashboardLanes ],
+] as const )( '%s sortable semantics', ( _, Dashboard ) => {
+	it.each( [
+		[ 'read mode', false, true ],
+		[ 'a pinned item', true, false ],
+	] as const )(
+		'preserves interactive content semantics in %s',
+		( __, editMode, draggable ) => {
+			const { container } = render(
+				<Dashboard
+					layout={ [ { key: 'a', width: 1, draggable } ] }
+					columns={ 2 }
+					editMode={ editMode }
+				>
+					<Tile
+						key="a"
+						actionableArea={
+							<button type="button">Settings</button>
+						}
+					>
+						<a href="#details">Details</a>
+						<button type="button">Refresh</button>
+						<MetricControl />
+					</Tile>
+				</Dashboard>
+			);
+
+			for ( const control of [
+				screen.getByRole( 'link', { name: 'Details' } ),
+				screen.getByRole( 'button', { name: 'Refresh' } ),
+				screen.getByRole( 'combobox', { name: 'Metric' } ),
+			] ) {
+				expect(
+					control.closest( '[aria-disabled="true"]' )
+				).toBeNull();
+				expect(
+					control.parentElement?.closest( '[role="button"]' )
+				).toBeNull();
+				expect(
+					control.parentElement?.closest( '[tabindex]' )
+				).toBeNull();
+			}
+			expect(
+				container.querySelector( '[aria-roledescription="sortable"]' )
+			).toBeNull();
+			const settings = screen.getByRole( 'button', { name: 'Settings' } );
+			expect( settings ).toBeEnabled();
+			expect(
+				settings.closest( '[inert], [aria-disabled="true"]' )
+			).toBeNull();
+		}
+	);
+
+	it.each( [
+		[ 'a draggable item', true, 'sortable' ],
+		[ 'a pinned item resize handle', false, 'draggable' ],
+	] as const )(
+		'retains keyboard activation and focus for %s',
+		async ( __, draggable, roleDescription ) => {
+			vi.useFakeTimers();
+			const { container } = render(
+				<Dashboard
+					layout={ [ { key: 'a', width: 1, draggable } ] }
+					columns={ 2 }
+					editMode
+				>
+					<div key="a">A</div>
+				</Dashboard>
+			);
+			const activator = container.querySelector< HTMLElement >(
+				`[aria-roledescription="${ roleDescription }"]`
+			)!;
+			expect( activator ).toHaveAttribute( 'role', 'button' );
+			expect( activator ).toHaveAttribute( 'tabindex', '0' );
+			expect( activator ).toHaveAttribute( 'aria-disabled', 'false' );
+			expect( activator ).toHaveAttribute( 'aria-describedby' );
+			activator.focus();
+			fireEvent.keyDown( activator, { code: 'Space' } );
+			act( () => {
+				vi.runOnlyPendingTimers();
+			} );
+			expect( activator ).toHaveAttribute( 'aria-pressed', 'true' );
+			fireEvent.keyDown( activator, { code: 'Escape' } );
+			await act( async () => {
+				vi.runOnlyPendingTimers();
+			} );
+			expect( activator ).not.toHaveAttribute( 'aria-pressed' );
+			expect( activator ).toHaveFocus();
+		}
+	);
+} );
+/* eslint-enable testing-library/no-container, testing-library/no-node-access */

--- a/packages/widget-dashboard/src/test/policy.jsdom.test.tsx
+++ b/packages/widget-dashboard/src/test/policy.jsdom.test.tsx
@@ -277,18 +277,22 @@ describe( 'WidgetDashboard.Policy instance operations', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'keeps the tile fixed when move is denied', async () => {
+	it( 'omits the drag activator while preserving permitted controls when move is denied', async () => {
 		/* eslint-disable testing-library/no-container, testing-library/no-node-access */
 		const { container } = render(
 			<Harness canPerform={ deny( 'move' ) } editMode />
 		);
-		await screen.findByTestId( 'label' );
+		const content = await screen.findByTestId( 'label' );
 
 		const activator = container.querySelector(
 			'[aria-roledescription="sortable"]'
 		);
-		expect( activator ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( activator ).toBeNull();
+		expect( content.closest( '[aria-disabled="true"]' ) ).toBeNull();
 		/* eslint-enable testing-library/no-container, testing-library/no-node-access */
+		expect(
+			screen.getByRole( 'button', { name: 'Widget options' } )
+		).toBeEnabled();
 	} );
 
 	it( 'treats a non-boolean answer as a denial on every surface', async () => {
@@ -301,16 +305,17 @@ describe( 'WidgetDashboard.Policy instance operations', () => {
 		const { container } = render(
 			<Harness canPerform={ canPerform } editMode />
 		);
-		await screen.findByTestId( 'label' );
+		const content = await screen.findByTestId( 'label' );
 
 		const activator = container.querySelector(
 			'[aria-roledescription="sortable"]'
 		);
-		expect( activator ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( activator ).toBeNull();
+		expect( content.closest( '[aria-disabled="true"]' ) ).toBeNull();
 		/* eslint-enable testing-library/no-container, testing-library/no-node-access */
 		expect(
 			screen.getByRole( 'button', { name: 'Widget options' } )
-		).toBeInTheDocument();
+		).toBeEnabled();
 	} );
 
 	it( 'renders the widget read-only and without attribute controls when edit is denied', async () => {


### PR DESCRIPTION
## What?

Closes #82507.

Remove inactive drag-control semantics from tile content in `DashboardGrid` and `DashboardLanes`, including pinned items.

## Why?

Read-mode and pinned tiles currently wrap their content in a focusable `role="button"` with `aria-disabled="true"`. This gives enabled links, buttons and form controls a disabled semantic ancestor and introduces an inactive drag control in the tab order.

## How?

Apply the sortable attributes only when dragging is enabled. Keep the existing listeners, refs, enabled activator and independent resize/action controls.

Update pinned-item and WidgetDashboard policy expectations, and add mounted tests for descendant semantics in both layouts, plus keyboard pickup, cancellation and focus for enabled drag controls and pinned resize handles. Move-denied widgets expose no drag activator while retaining permitted layout controls. Review should focus on the disabled wrapper semantics and preservation of permitted controls. Keyboard reorder completion in #82508 remains separate.

## Testing Instructions

After rebasing onto trunk `980605ca93`, all Grid and WidgetDashboard Vitest tests pass (252 tests), and changed-file lint passes. These focused checks ran on the available Node 24.12 environment with npm's engine gate bypassed because the host is below trunk's current Node 24.18 and npm 11.16 minimums; GitHub CI is validating the supported Node 24 and 26 matrix. Before the rebase, the previous head also passed the full production build and repository type check. The final Grid regression has four expected failures on unmodified wrappers and passes all eight cases with this change. These mounted JSDOM tests are complemented by fresh Chrome checks of both built layouts: native controls in read and pinned modes, enabled pickup/cancel with focus restoration, and pinned keyboard resizing. Full screen-reader qualification has not been performed.

1. Run `npm run test:unit:vitest -- packages/grid packages/widget-dashboard`.
2. Render the package-only fixture in #82507. Confirm that the link, button and select have no ancestor with disabled sortable-button semantics.
3. Set `editMode={ true }` and add `draggable: false` to the layout item. Confirm that its content retains ordinary semantics and its resize handle remains available.
4. Repeat with `DashboardLanes`.

### Testing Instructions for Keyboard

1. With `editMode={ false }`, Tab through the fixture. Focus should reach its native controls without stopping on an inactive drag wrapper. Activate Details with Enter, Refresh with Space, and change Metric with the arrow keys.
2. Repeat with an item whose layout has `draggable: false` in edit mode. Its permitted resize control should remain reachable.
3. Restore a draggable item in edit mode. Focus its drag activator, press Space to pick it up, and Escape to cancel. Confirm that focus remains on the activator.
4. Repeat for both layouts.

## Screenshots or screencast

This changes accessibility semantics without a visual layout change.

## Use of AI Tools

I used OpenAI Codex to investigate, implement and test this change.
