### PR TITLE
Grid: commit keyboard reordering to the final drop target

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Commit keyboard reordering to the final drop target in `DashboardGrid` and `DashboardLanes`, preserving pinned items and cancellation. Keyboard layout previews now commit on drop ([#82508](https://github.com/WordPress/gutenberg/issues/82508)).
+
 ### New Features
 
 -   Layout items accept `draggable` and `resizable` flags. A non-draggable

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Commit keyboard reordering to the final drop target in `DashboardGrid` and `DashboardLanes`, preserving pinned items and cancellation. Keyboard layout previews now commit on drop ([#82508](https://github.com/WordPress/gutenberg/issues/82508)).
+-   Commit keyboard reordering to the final drop target in `DashboardGrid` and `DashboardLanes`, preserving pinned items and cancellation. Keyboard layout previews now commit on drop ([#82512](https://github.com/WordPress/gutenberg/pull/82512)).
 
 ### New Features
 

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -144,22 +144,22 @@ interface DashboardGridLayoutItem {
 
 ### Props
 
-| Prop                 | Type                                       | Default  | Description                                                                                                                                             |
-| -------------------- | ------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `layout`             | `DashboardGridLayoutItem[]`                | —        | Required. Positions and sizes keyed by child `key`.                                                                                                     |
-| `children`           | `ReactNode`                                | —        | Required. Each child needs a `key` matching a layout entry.                                                                                             |
-| `columns`            | `number`                                   | `6`      | Total columns (fixed mode).                                                                                                                             |
-| `minColumnWidth`     | `number`                                   | —        | If set, enables responsive mode: columns derived from container width. Mutually exclusive with `columns`.                                               |
-| `rowHeight`          | `number \| 'auto'`                         | `'auto'` | Row height in pixels, or `'auto'` to let content size rows.                                                                                             |
-| `itemLimits`         | `Record< string, GridItemLimits >`         | —        | Per-item minimum and maximum tile sizes in pixels, keyed by layout item key. See [Size limits](#size-limits).                                           |
-| `editMode`           | `boolean`                                  | `false`  | Enables drag-to-reorder and resize handles.                                                                                                             |
-| `onChangeLayout`     | `( layout ) => void`                       | —        | Fired when the user commits a drag or resize.                                                                                                           |
-| `onPreviewLayout`    | `( layout ) => void`                       | —        | Fired continuously during a drag or resize with the in-progress layout. Use for live feedback; `onChangeLayout` still emits the committed result.       |
-| `renderResizeHandle` | `ComponentType< ResizeHandleRenderProps >` | —        | Override the default corner-triangle resize handle. See [Custom resize handle](#custom-resize-handle).                                                  |
-| `renderDragPreview`  | `ComponentType< DragPreviewRenderProps >`  | —        | Wrap the dragged-clone visual mounted inside `<DragOverlay>`. See [Custom drag preview](#custom-drag-preview).                                          |
-| `renderGridOverlay`  | `ComponentType< GridOverlayRenderProps >`  | —        | Override the default edit-mode overlay that visualizes the column and row tracks. Receives the resolved `columns`, `rows`, `rowHeight`, and `isActive`. |
-| `className`          | `string`                                   | —        | Extra class on the grid root.                                                                                                                           |
-| `style`              | `CSSProperties`                            | —        | Inline styles on the grid root; the grid's own layout styles win over them.                                                                             |
+| Prop                 | Type                                       | Default  | Description                                                                                                                                               |
+| -------------------- | ------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `layout`             | `DashboardGridLayoutItem[]`                | —        | Required. Positions and sizes keyed by child `key`.                                                                                                       |
+| `children`           | `ReactNode`                                | —        | Required. Each child needs a `key` matching a layout entry.                                                                                               |
+| `columns`            | `number`                                   | `6`      | Total columns (fixed mode).                                                                                                                               |
+| `minColumnWidth`     | `number`                                   | —        | If set, enables responsive mode: columns derived from container width. Mutually exclusive with `columns`.                                                 |
+| `rowHeight`          | `number \| 'auto'`                         | `'auto'` | Row height in pixels, or `'auto'` to let content size rows.                                                                                               |
+| `itemLimits`         | `Record< string, GridItemLimits >`         | —        | Per-item minimum and maximum tile sizes in pixels, keyed by layout item key. See [Size limits](#size-limits).                                             |
+| `editMode`           | `boolean`                                  | `false`  | Enables drag-to-reorder and resize handles.                                                                                                               |
+| `onChangeLayout`     | `( layout ) => void`                       | —        | Fired when the user commits a drag or resize.                                                                                                             |
+| `onPreviewLayout`    | `( layout ) => void`                       | —        | Fired continuously during a pointer drag or resize with the in-progress layout. Use for live feedback; `onChangeLayout` still emits the committed result. |
+| `renderResizeHandle` | `ComponentType< ResizeHandleRenderProps >` | —        | Override the default corner-triangle resize handle. See [Custom resize handle](#custom-resize-handle).                                                    |
+| `renderDragPreview`  | `ComponentType< DragPreviewRenderProps >`  | —        | Wrap the dragged-clone visual mounted inside `<DragOverlay>`. See [Custom drag preview](#custom-drag-preview).                                            |
+| `renderGridOverlay`  | `ComponentType< GridOverlayRenderProps >`  | —        | Override the default edit-mode overlay that visualizes the column and row tracks. Receives the resolved `columns`, `rows`, `rowHeight`, and `isActive`.   |
+| `className`          | `string`                                   | —        | Extra class on the grid root.                                                                                                                             |
+| `style`              | `CSSProperties`                            | —        | Inline styles on the grid root; the grid's own layout styles win over them.                                                                               |
 
 `DashboardGrid` forwards refs to its root `<div>`, and standard
 `<div>` attributes (`id`, `aria-*`, `data-*`, event handlers,
@@ -217,7 +217,7 @@ When `editMode` is true:
     on every tile is set `inert` so hovers on other tiles can't steal
     the gesture.
 -   `onChangeLayout` fires after drop or resize with the new layout.
--   `onPreviewLayout` fires continuously during the interaction for
+-   `onPreviewLayout` fires continuously during pointer drag or resize for
     live feedback; the committed layout is still emitted via
     `onChangeLayout`.
 -   Sibling tiles animate into their new positions when the layout
@@ -318,7 +318,7 @@ items flow around them; out-of-range values (negative, or beyond
 | `itemLimits`         | `Record< string, GridItemWidthLimits >`    | —       | Per-item minimum and maximum tile widths in pixels, keyed by layout item key. See [Size limits](#size-limits).                                                                                          |
 | `editMode`           | `boolean`                                  | `false` | Enables drag-to-reorder and horizontal resize.                                                                                                                                                          |
 | `onChangeLayout`     | `( layout ) => void`                       | —       | Fired when the user commits a drag or resize.                                                                                                                                                           |
-| `onPreviewLayout`    | `( layout ) => void`                       | —       | Fired continuously during a drag or resize.                                                                                                                                                             |
+| `onPreviewLayout`    | `( layout ) => void`                       | —       | Fired continuously during a pointer drag or resize.                                                                                                                                                     |
 | `renderResizeHandle` | `ComponentType< ResizeHandleRenderProps >` | —       | Override the default side-grip resize handle. See [Custom resize handle](#custom-resize-handle).                                                                                                        |
 | `renderDragPreview`  | `ComponentType< DragPreviewRenderProps >`  | —       | Wrap the dragged-clone visual mounted inside `<DragOverlay>`. See [Custom drag preview](#custom-drag-preview).                                                                                          |
 | `renderGridOverlay`  | `ComponentType< GridOverlayRenderProps >`  | —       | Override the default edit-mode overlay that visualizes the lane tracks. Receives the resolved `columns` and `isActive`; lanes pass no row metrics because heights are content-driven.                   |
@@ -422,6 +422,10 @@ heights are content-driven.
 
 Drag-to-reorder is operable from the keyboard via `@dnd-kit`'s
 keyboard sensor:
+
+Keyboard movement updates the drag overlay and target announcement. Dropping
+commits the final target through `onChangeLayout`; Escape discards the move.
+Keyboard reordering does not emit intermediate `onPreviewLayout` updates.
 
 -   `Tab` to focus a tile.
 -   `Space` to pick it up.

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -10,7 +10,11 @@ import {
 	SortableContext,
 	sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable';
-import type { DragMoveEvent, DragStartEvent } from '@dnd-kit/core';
+import type {
+	DragEndEvent,
+	DragMoveEvent,
+	DragStartEvent,
+} from '@dnd-kit/core';
 import clsx from 'clsx';
 import { useResizeObserver, useEvent, useMergeRefs } from '@wordpress/compose';
 import {
@@ -417,6 +421,12 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		// just when `over.id` changes — otherwise a "swap back" with
 		// the cursor still on the same tile would never fire.
 		const handleDragMove = useEvent( ( event: DragMoveEvent ) => {
+			// Keyboard coordinates identify a target, not a pointer insertion
+			// edge. Commit the final target on drop after collision updates.
+			if ( event.activatorEvent.type === 'keydown' ) {
+				return;
+			}
+
 			const { active, over } = event;
 			if ( ! over || active.id === over.id ) {
 				return;
@@ -505,6 +515,43 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 
 			onChangeLayout( latest );
 			setTemporaryLayout( undefined );
+		} );
+
+		const handleDragEnd = useEvent( ( event: DragEndEvent ) => {
+			if ( event.activatorEvent.type === 'keydown' && editMode ) {
+				const { active, over } = event;
+				const currentIndex = items.indexOf( String( active.id ) );
+				const overIndex = over
+					? items.indexOf( String( over.id ) )
+					: -1;
+				if (
+					currentIndex !== -1 &&
+					overIndex !== -1 &&
+					currentIndex !== overIndex &&
+					layoutMap.get( String( active.id ) )?.draggable !== false
+				) {
+					const updatedItems = arrayMoveWithPinned(
+						items,
+						currentIndex,
+						overIndex,
+						( key ) => layoutMap.get( key )?.draggable === false
+					);
+					if (
+						updatedItems.some(
+							( key, index ) => key !== items[ index ]
+						)
+					) {
+						latestLayoutRef.current = layout.map( ( item ) => ( {
+							...item,
+							order: updatedItems.indexOf( item.key ),
+						} ) );
+						captureLayoutSnapshotRef.current();
+					}
+				}
+			}
+			persistTemporaryLayout();
+			lastReorderCursorRef.current = null;
+			setActiveId( null );
 		} );
 
 		const handleResize = useEvent( ( id: string, delta: ResizeDelta ) => {
@@ -697,11 +744,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 				onDragStart={ handleDragStart }
 				onDragCancel={ handleDragCancel }
 				onDragMove={ handleDragMove }
-				onDragEnd={ () => {
-					persistTemporaryLayout();
-					lastReorderCursorRef.current = null;
-					setActiveId( null );
-				} }
+				onDragEnd={ handleDragEnd }
 			>
 				{ /* No-op strategy: reorder comes from `temporaryLayout`
 				 + CSS Grid, not dnd-kit transforms. */ }

--- a/packages/grid/src/dashboard-grid/test/keyboard-activation.jsdom.test.tsx
+++ b/packages/grid/src/dashboard-grid/test/keyboard-activation.jsdom.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DashboardGrid } from '..';
 
 class MockResizeObserver {
@@ -64,3 +64,149 @@ describe( 'DashboardGrid keyboard activation', () => {
 		/* eslint-enable testing-library/no-container, testing-library/no-node-access */
 	} );
 } );
+
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+describe( 'DashboardGrid keyboard reordering', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+		// jsdom has no layout. Measure the surface separately from the
+		// equal-sized tiles and drag overlay, keeping real dnd-kit sensors.
+		vi.spyOn(
+			HTMLElement.prototype,
+			'getBoundingClientRect'
+		).mockImplementation( function ( this: HTMLElement ) {
+			const key = this.closest( '[data-wp-grid-item-key]' )?.getAttribute(
+				'data-wp-grid-item-key'
+			);
+			// dnd-kit measures the overlay's child, which inherits the fixed
+			// wrapper's starting position rather than an item's DOM ancestry.
+			const overlay = this.closest< HTMLElement >(
+				'[style*="position: fixed"]'
+			);
+			let left = key ? [ 'a', 'b', 'c' ].indexOf( key ) * 124 : 0;
+			if ( overlay ) {
+				left = parseFloat( overlay.style.left );
+			}
+			const width =
+				this.getAttribute( 'data-testid' ) === 'surface' ? 348 : 100;
+			return {
+				x: left,
+				y: 0,
+				left,
+				top: 0,
+				width,
+				height: 100,
+				right: left + width,
+				bottom: 100,
+				toJSON() {},
+			} as DOMRect;
+		} );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	} );
+
+	it.each( [
+		{
+			name: 'moves one position right',
+			key: 'a',
+			moves: [ 'ArrowRight' ],
+			order: [ 1, 0, 2 ],
+		},
+		{
+			name: 'moves one position left',
+			key: 'c',
+			moves: [ 'ArrowLeft' ],
+			order: [ 0, 2, 1 ],
+		},
+		{
+			name: 'commits the final target after multiple steps',
+			key: 'a',
+			moves: [ 'ArrowRight', 'ArrowRight' ],
+			order: [ 2, 0, 1 ],
+		},
+		{
+			name: 'keeps pinned items in place',
+			key: 'a',
+			// Pinned B remains a drop target, so cross it to reach C.
+			moves: [ 'ArrowRight', 'ArrowRight' ],
+			pinned: true,
+			order: [ 2, 1, 0 ],
+		},
+		{
+			name: 'discards a cancelled move',
+			key: 'a',
+			moves: [ 'ArrowRight' ],
+			cancel: true,
+		},
+		{
+			name: 'does not commit a move back to its starting position',
+			key: 'a',
+			moves: [ 'ArrowRight', 'ArrowLeft' ],
+		},
+		{
+			name: 'does not commit when dropped without moving',
+			key: 'a',
+			moves: [],
+		},
+		{
+			name: 'does not move beyond the first item',
+			key: 'a',
+			moves: [ 'ArrowLeft' ],
+		},
+	] )( '$name', async ( { key, moves, order, pinned, cancel } ) => {
+		const onChangeLayout = vi.fn();
+		const onPreviewLayout = vi.fn();
+		const layout = [
+			{ key: 'a', width: 1 },
+			{ key: 'b', width: 1, ...( pinned ? { draggable: false } : {} ) },
+			{ key: 'c', width: 1 },
+		];
+		const { container } = render(
+			<DashboardGrid
+				layout={ layout }
+				columns={ 3 }
+				data-testid="surface"
+				editMode
+				onChangeLayout={ onChangeLayout }
+				onPreviewLayout={ onPreviewLayout }
+			>
+				<div key="a">A</div>
+				<div key="b">B</div>
+				<div key="c">C</div>
+			</DashboardGrid>
+		);
+		const activator = container.querySelector(
+			`[data-wp-grid-item-key="${ key }"] [aria-roledescription="sortable"]`
+		);
+		expect( activator ).not.toBeNull();
+		fireEvent.keyDown( activator!, { code: 'Space' } );
+		// dnd-kit attaches its keyboard listener on the next timer tick.
+		act( () => {
+			vi.runOnlyPendingTimers();
+		} );
+		for ( const code of moves ) {
+			fireEvent.keyDown( activator!, { code } );
+		}
+		fireEvent.keyDown( activator!, { code: cancel ? 'Escape' : 'Space' } );
+		await act( async () => {
+			vi.runOnlyPendingTimers();
+		} );
+
+		const expectedCalls = order
+			? [
+					[
+						layout.map( ( item, index ) => ( {
+							...item,
+							order: order[ index ],
+						} ) ),
+					],
+			  ]
+			: [];
+		expect( onChangeLayout.mock.calls ).toEqual( expectedCalls );
+		expect( onPreviewLayout ).not.toHaveBeenCalled();
+	} );
+} );
+/* eslint-enable testing-library/no-container, testing-library/no-node-access */

--- a/packages/grid/src/dashboard-grid/types.ts
+++ b/packages/grid/src/dashboard-grid/types.ts
@@ -250,10 +250,11 @@ export interface DashboardGridProps
 	onChangeLayout?: ( newLayout: DashboardGridLayoutItem[] ) => void;
 
 	/**
-	 * Callback fired continuously during a drag or resize interaction
+	 * Callback fired continuously during a pointer drag or resize interaction
 	 * with the in-progress layout. Useful for live feedback in the
 	 * surface (e.g., displaying the current width/position). The final
-	 * committed layout is still emitted via `onChangeLayout`.
+	 * committed layout is still emitted via `onChangeLayout`. Keyboard
+	 * reordering commits on drop without intermediate preview updates.
 	 */
 	onPreviewLayout?: ( previewLayout: DashboardGridLayoutItem[] ) => void;
 

--- a/packages/grid/src/dashboard-lanes/index.tsx
+++ b/packages/grid/src/dashboard-lanes/index.tsx
@@ -10,7 +10,11 @@ import {
 	SortableContext,
 	sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable';
-import type { DragMoveEvent, DragStartEvent } from '@dnd-kit/core';
+import type {
+	DragEndEvent,
+	DragMoveEvent,
+	DragStartEvent,
+} from '@dnd-kit/core';
 import clsx from 'clsx';
 import { useResizeObserver, useEvent, useMergeRefs } from '@wordpress/compose';
 import {
@@ -367,6 +371,12 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 		} );
 
 		const handleDragMove = useEvent( ( event: DragMoveEvent ) => {
+			// Keyboard coordinates identify a target, not a pointer insertion
+			// edge. Commit the final target on drop after collision updates.
+			if ( event.activatorEvent.type === 'keydown' ) {
+				return;
+			}
+
 			const { active, over } = event;
 			if ( ! over || active.id === over.id ) {
 				return;
@@ -451,6 +461,43 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 
 			onChangeLayout( latest );
 			setTemporaryLayout( undefined );
+		} );
+
+		const handleDragEnd = useEvent( ( event: DragEndEvent ) => {
+			if ( event.activatorEvent.type === 'keydown' && editMode ) {
+				const { active, over } = event;
+				const currentIndex = items.indexOf( String( active.id ) );
+				const overIndex = over
+					? items.indexOf( String( over.id ) )
+					: -1;
+				if (
+					currentIndex !== -1 &&
+					overIndex !== -1 &&
+					currentIndex !== overIndex &&
+					layoutMap.get( String( active.id ) )?.draggable !== false
+				) {
+					const updatedItems = arrayMoveWithPinned(
+						items,
+						currentIndex,
+						overIndex,
+						( key ) => layoutMap.get( key )?.draggable === false
+					);
+					if (
+						updatedItems.some(
+							( key, index ) => key !== items[ index ]
+						)
+					) {
+						latestLayoutRef.current = layout.map( ( item ) => ( {
+							...item,
+							order: updatedItems.indexOf( item.key ),
+						} ) );
+						captureLayoutSnapshotRef.current();
+					}
+				}
+			}
+			persistTemporaryLayout();
+			lastReorderCursorRef.current = null;
+			setActiveId( null );
 		} );
 
 		const handleResize = useEvent( ( id: string, delta: ResizeDelta ) => {
@@ -577,11 +624,7 @@ export const DashboardLanes = forwardRef< HTMLDivElement, DashboardLanesProps >(
 				onDragStart={ handleDragStart }
 				onDragCancel={ handleDragCancel }
 				onDragMove={ handleDragMove }
-				onDragEnd={ () => {
-					persistTemporaryLayout();
-					lastReorderCursorRef.current = null;
-					setActiveId( null );
-				} }
+				onDragEnd={ handleDragEnd }
 			>
 				<SortableContext items={ items } strategy={ NO_SORT_STRATEGY }>
 					<div

--- a/packages/grid/src/dashboard-lanes/test/keyboard-activation.jsdom.test.tsx
+++ b/packages/grid/src/dashboard-lanes/test/keyboard-activation.jsdom.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DashboardLanes } from '..';
 
 class MockResizeObserver {
@@ -59,3 +59,149 @@ describe( 'DashboardLanes keyboard activation', () => {
 		/* eslint-enable testing-library/no-container, testing-library/no-node-access */
 	} );
 } );
+
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+describe( 'DashboardLanes keyboard reordering', () => {
+	beforeEach( () => {
+		vi.useFakeTimers();
+		// jsdom has no layout. Measure the surface separately from the
+		// equal-sized tiles and drag overlay, keeping real dnd-kit sensors.
+		vi.spyOn(
+			HTMLElement.prototype,
+			'getBoundingClientRect'
+		).mockImplementation( function ( this: HTMLElement ) {
+			const key = this.closest( '[data-wp-grid-item-key]' )?.getAttribute(
+				'data-wp-grid-item-key'
+			);
+			// dnd-kit measures the overlay's child, which inherits the fixed
+			// wrapper's starting position rather than an item's DOM ancestry.
+			const overlay = this.closest< HTMLElement >(
+				'[style*="position: fixed"]'
+			);
+			let left = key ? [ 'a', 'b', 'c' ].indexOf( key ) * 124 : 0;
+			if ( overlay ) {
+				left = parseFloat( overlay.style.left );
+			}
+			const width =
+				this.getAttribute( 'data-testid' ) === 'surface' ? 348 : 100;
+			return {
+				x: left,
+				y: 0,
+				left,
+				top: 0,
+				width,
+				height: 100,
+				right: left + width,
+				bottom: 100,
+				toJSON() {},
+			} as DOMRect;
+		} );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	} );
+
+	it.each( [
+		{
+			name: 'moves one position right',
+			key: 'a',
+			moves: [ 'ArrowRight' ],
+			order: [ 1, 0, 2 ],
+		},
+		{
+			name: 'moves one position left',
+			key: 'c',
+			moves: [ 'ArrowLeft' ],
+			order: [ 0, 2, 1 ],
+		},
+		{
+			name: 'commits the final target after multiple steps',
+			key: 'a',
+			moves: [ 'ArrowRight', 'ArrowRight' ],
+			order: [ 2, 0, 1 ],
+		},
+		{
+			name: 'keeps pinned items in place',
+			key: 'a',
+			// Pinned B remains a drop target, so cross it to reach C.
+			moves: [ 'ArrowRight', 'ArrowRight' ],
+			pinned: true,
+			order: [ 2, 1, 0 ],
+		},
+		{
+			name: 'discards a cancelled move',
+			key: 'a',
+			moves: [ 'ArrowRight' ],
+			cancel: true,
+		},
+		{
+			name: 'does not commit a move back to its starting position',
+			key: 'a',
+			moves: [ 'ArrowRight', 'ArrowLeft' ],
+		},
+		{
+			name: 'does not commit when dropped without moving',
+			key: 'a',
+			moves: [],
+		},
+		{
+			name: 'does not move beyond the first item',
+			key: 'a',
+			moves: [ 'ArrowLeft' ],
+		},
+	] )( '$name', async ( { key, moves, order, pinned, cancel } ) => {
+		const onChangeLayout = vi.fn();
+		const onPreviewLayout = vi.fn();
+		const layout = [
+			{ key: 'a', width: 1 },
+			{ key: 'b', width: 1, ...( pinned ? { draggable: false } : {} ) },
+			{ key: 'c', width: 1 },
+		];
+		const { container } = render(
+			<DashboardLanes
+				layout={ layout }
+				columns={ 3 }
+				data-testid="surface"
+				editMode
+				onChangeLayout={ onChangeLayout }
+				onPreviewLayout={ onPreviewLayout }
+			>
+				<div key="a">A</div>
+				<div key="b">B</div>
+				<div key="c">C</div>
+			</DashboardLanes>
+		);
+		const activator = container.querySelector(
+			`[data-wp-grid-item-key="${ key }"] [aria-roledescription="sortable"]`
+		);
+		expect( activator ).not.toBeNull();
+		fireEvent.keyDown( activator!, { code: 'Space' } );
+		// dnd-kit attaches its keyboard listener on the next timer tick.
+		act( () => {
+			vi.runOnlyPendingTimers();
+		} );
+		for ( const code of moves ) {
+			fireEvent.keyDown( activator!, { code } );
+		}
+		fireEvent.keyDown( activator!, { code: cancel ? 'Escape' : 'Space' } );
+		await act( async () => {
+			vi.runOnlyPendingTimers();
+		} );
+
+		const expectedCalls = order
+			? [
+					[
+						layout.map( ( item, index ) => ( {
+							...item,
+							order: order[ index ],
+						} ) ),
+					],
+			  ]
+			: [];
+		expect( onChangeLayout.mock.calls ).toEqual( expectedCalls );
+		expect( onPreviewLayout ).not.toHaveBeenCalled();
+	} );
+} );
+/* eslint-enable testing-library/no-container, testing-library/no-node-access */

--- a/packages/grid/src/dashboard-lanes/types.ts
+++ b/packages/grid/src/dashboard-lanes/types.ts
@@ -134,8 +134,9 @@ export interface DashboardLanesProps
 	onChangeLayout?: ( newLayout: DashboardLanesLayoutItem[] ) => void;
 
 	/**
-	 * Fired continuously during a gesture with the in-progress
-	 * layout. The committed result still emits via `onChangeLayout`.
+	 * Fired continuously during a pointer drag or resize with the in-progress
+	 * layout. The committed result still emits via `onChangeLayout`. Keyboard
+	 * reordering commits on drop without intermediate preview updates.
 	 */
 	onPreviewLayout?: ( previewLayout: DashboardLanesLayoutItem[] ) => void;
 


### PR DESCRIPTION
## What?

Closes #82508.

Commit keyboard reordering to the final drop target in `DashboardGrid` and `DashboardLanes`.

## Why?

A single arrow-key move can announce a new target and then leave the controlled layout unchanged. Movement callbacks can receive the preceding collision target, and the pointer insertion rule also treats an exact target center differently depending on direction.

## How?

Resolve keyboard order at drop from the final collision target. Preserve pinned positions, stored layout properties and cancellation behavior. Pointer dragging and resizing keep their existing preview path.

This proposes an intentional interaction choice: keyboard movement updates the overlay and target announcement, with one layout commit on drop and no intermediate `onPreviewLayout` calls. The README and callback documentation describe that behavior. Please review whether committing on drop is the preferred keyboard contract. WidgetDashboard consumes the commit callback; Grid stories that display preview state will retain committed state until drop.

## Testing Instructions

After rebasing onto trunk `980605ca93`, the Grid and WidgetDashboard Vitest suites pass (260 tests), and changed-file lint passes. These focused checks ran on the available Node 24.12 environment with npm's engine gate bypassed because the host is below trunk's current Node 24.18 and npm 11.16 minimums; GitHub CI is validating the supported Node 24 and 26 matrix. Before the rebase, the previous head also passed the full production build and repository type check. The rebased tests use Vitest APIs following trunk's test migration.

The mounted tests use the real dnd-kit keyboard sensor and collision handling, with geometry supplied because JSDOM has no layout. The corrected fixture produces eight reorder failures on the unchanged implementation and passes all eighteen cases with this change. Coverage includes both directions, multiple steps, pinned items, cancellation, returning to the starting position, dropping without movement and the first-item boundary.

1. Run `npm run test:unit:vitest -- packages/grid packages/widget-dashboard`.
2. Run `npm run build`, followed by `npm run typecheck`.
3. Render the controlled package-only fixture in #82508. Verify that pointer reordering and resizing still commit their changes.

### Testing Instructions for Keyboard

1. Tab to tile A. Press Space, ArrowRight once, then Space. The layout should commit B before A.
2. Start from the original layout with B focused. Press Space, ArrowLeft, then Space. B should precede A.
3. Pick up A, move to another target, then press Escape. The original layout should remain unchanged.
4. Add a third tile and repeat with multiple steps. Set the middle tile’s `draggable` property to `false`; moving across it should retain its position.
5. Repeat for DashboardLanes.

## Screenshots or screencast

Fresh Chrome checks against the built package confirm one-step right and left commits, Escape cancellation and focus restoration in both layouts. The controlled fixture shows the rendered order and commit count. Keyboard pickup, movement and drop were observed separately; an initial rapid automation burst in Lanes dropped over the original item before the movement was observed. No screencast is included.

## Use of AI Tools

I used OpenAI Codex to investigate, implement and test this change.
