### PR TITLE
Release: Verify SVN deployment after publication

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -56,6 +56,24 @@ jobs:
                           # Other workflows, and everything under .github that this one does not use.
                           - '!.github/{*,!(workflows|setup-node|setup-playwright)/**,workflows/!(unit-test.yml)}'
 
+    svn-release:
+        name: SVN release recovery
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+                  sparse-checkout: tools/release
+
+            - name: Install Subversion
+              run: sudo apt-get update -y && sudo apt-get install -y subversion
+
+            - name: Test SVN publication and recovery
+              run: bash tools/release/test/publish-to-svn.sh
+
     unit-js:
         name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
         runs-on: 'ubuntu-24.04'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -59,6 +59,7 @@ jobs:
     svn-release:
         name: SVN release recovery
         runs-on: 'ubuntu-24.04'
+        timeout-minutes: 5
         permissions:
             contents: read
         steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -464,7 +464,15 @@ jobs:
         permissions:
             contents: read
             actions: read
-        needs: [detect-relevant-changes, unit-js, unit-js-date, test-php, phpcs]
+        needs:
+            [
+                detect-relevant-changes,
+                svn-release,
+                unit-js,
+                unit-js-date,
+                test-php,
+                phpcs,
+            ]
         if: ${{ ! cancelled() && ( github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' ) }}
         steps:
             - name: Checkout repository

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -60,17 +60,23 @@ jobs:
         name: SVN release recovery
         runs-on: 'ubuntu-24.04'
         timeout-minutes: 5
+        needs: [detect-relevant-changes]
         permissions:
             contents: read
+        if: ${{ ( github.repository == 'WordPress/gutenberg' && github.event_name != 'pull_request' ) || ( github.event_name == 'pull_request' && needs.detect-relevant-changes.outputs.relevant == 'true' ) }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
                   sparse-checkout: tools/release
 
             - name: Install Subversion
               run: sudo apt-get update -y && sudo apt-get install -y subversion
+
+            - name: Lint release scripts
+              run: shellcheck tools/release/*.sh tools/release/test/*.sh
 
             - name: Test SVN publication and recovery
               run: bash tools/release/test/publish-to-svn.sh

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -258,7 +258,8 @@ jobs:
     upload:
         name: Publish as trunk (and tag)
         runs-on: 'ubuntu-24.04'
-        permissions: {}
+        permissions:
+            contents: read
         environment: wp.org plugin
         needs:
             [
@@ -276,6 +277,13 @@ jobs:
             VERSION: ${{ needs.get-release-metadata.outputs.version }}
 
         steps:
+            - name: Check out release tooling
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  ref: ${{ github.workflow_sha }}
+                  sparse-checkout: tools/release
+                  persist-credentials: false
+
             - name: Install Subversion
               run: |
                   sudo apt-get update -y && sudo apt-get install -y subversion
@@ -309,44 +317,14 @@ jobs:
                   name: changelog trunk
                   path: trunk
 
-            - name: Check if SVN tag already exists
-              id: check_svn_tag
-              run: |
-                  svn_error_file="$(mktemp)"
-                  if svn list "$PLUGIN_REPO_URL/tags/$VERSION" \
-                    --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                    --non-interactive --no-auth-cache >/dev/null 2>"$svn_error_file"; then
-                    echo "::warning::SVN tag tags/$VERSION already exists. Skipping release commit to avoid E150002."
-                    echo "exists=true" >> "$GITHUB_OUTPUT"
-                  else
-                    svn_status=$?
-                    # WP.org SVN may report a missing tag as W160013 followed by E200009.
-                    if grep -Eq 'E160013|W160013|E200009|non-existent' "$svn_error_file"; then
-                      echo "exists=false" >> "$GITHUB_OUTPUT"
-                    else
-                      cat "$svn_error_file" >&2
-                      rm -f "$svn_error_file"
-                      exit "$svn_status"
-                    fi
-                  fi
-                  rm -f "$svn_error_file"
-
-            - name: Commit the release
-              if: steps.check_svn_tag.outputs.exists != 'true'
-              working-directory: ./trunk
-              run: |
-                  svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
-                  svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn cp . "../tags/$VERSION"
-                  svn commit . "../tags/$VERSION" \
-                   -m "Releasing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                   --config-option=servers:global:http-timeout=600
+            - name: Publish and verify the release
+              run: bash tools/release/publish-to-svn.sh "$GITHUB_WORKSPACE/trunk" trunk
 
     upload-tag:
         name: Publish as tag
         runs-on: 'ubuntu-24.04'
-        permissions: {}
+        permissions:
+            contents: read
         environment: wp.org plugin
         needs:
             [
@@ -364,6 +342,13 @@ jobs:
             VERSION: ${{ needs.get-release-metadata.outputs.version }}
 
         steps:
+            - name: Check out release tooling
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  ref: ${{ github.workflow_sha }}
+                  sparse-checkout: tools/release
+                  persist-credentials: false
+
             - name: Install Subversion
               run: |
                   sudo apt-get update -y && sudo apt-get install -y subversion
@@ -389,31 +374,5 @@ jobs:
                   name: changelog trunk
                   path: ${{ needs.get-release-metadata.outputs.version }}
 
-            - name: Check if SVN tag already exists
-              id: check_svn_tag
-              run: |
-                  svn_error_file="$(mktemp)"
-                  if svn list "$PLUGIN_REPO_URL/tags/$VERSION" \
-                    --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                    --non-interactive --no-auth-cache >/dev/null 2>"$svn_error_file"; then
-                    echo "::warning::SVN tag tags/$VERSION already exists. Skipping import to avoid E150002."
-                    echo "exists=true" >> "$GITHUB_OUTPUT"
-                  else
-                    svn_status=$?
-                    # WP.org SVN may report a missing tag as W160013 followed by E200009.
-                    if grep -Eq 'E160013|W160013|E200009|non-existent' "$svn_error_file"; then
-                      echo "exists=false" >> "$GITHUB_OUTPUT"
-                    else
-                      cat "$svn_error_file" >&2
-                      rm -f "$svn_error_file"
-                      exit "$svn_status"
-                    fi
-                  fi
-                  rm -f "$svn_error_file"
-
-            - name: Add the new version directory and commit changes to the SVN repository
-              if: steps.check_svn_tag.outputs.exists != 'true'
-              run: |
-                  svn import "$VERSION" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Committing version $VERSION" \
-                  --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                  --config-option=servers:global:http-timeout=300
+            - name: Publish and verify the release
+              run: bash tools/release/publish-to-svn.sh "$GITHUB_WORKSPACE/$VERSION" tag

--- a/docs/contributors/code/release/plugin-release.md
+++ b/docs/contributors/code/release/plugin-release.md
@@ -322,7 +322,13 @@ It's important to check that:
 -   the ZIP contents (see [Downloads](https://plugins.trac.wordpress.org/browser/gutenberg/)) looks correct (doesn't have anything obvious missing)
 -   the [Gutenberg SVN repo](https://plugins.trac.wordpress.org/browser/gutenberg/) has the expected `trunk` contents and a matching `tags/X.Y.Z` folder (see [the log](https://plugins.trac.wordpress.org/browser/gutenberg/))
 
-The current WordPress.org upload workflow replaces SVN `trunk`, copies that local `trunk` checkout to `tags/$VERSION`, then commits `trunk` and `tags/$VERSION` together. Before rerunning the workflow or any mutating SVN command, inspect the existing SVN state and avoid creating a second tag for the same version.
+The WordPress.org upload workflow replaces SVN `trunk`, copies that local `trunk` checkout to `tags/$VERSION`, then commits `trunk` and `tags/$VERSION` together. Releases for older versions only import `tags/$VERSION`.
+
+After publication, the workflow exports the expected SVN paths at one revision and compares every file with the prepared release, including the updated stable tag and changelog. It retries verification for up to 15 minutes to allow changes to become readable. A failed commit response is treated as success only when this comparison succeeds. The workflow also verifies existing tags before accepting them, without overwriting them or repeating an uncertain write.
+
+A successful verification reports the SVN revision in the logs and job summary. It confirms SVN contents, not whether WordPress.org has finished generating or distributing the plugin ZIP. If verification fails, use the logged SVN or file differences to investigate. Matching version headers alone are not proof of a complete deployment. A later rerun can also fail verification if its prepared changelog differs from the published one.
+
+Before rerunning the workflow or any mutating SVN command, inspect the existing SVN state and avoid creating a second tag for the same version.
 
 Either substitute `SVN_USERNAME`, `SVN_PASSWORD`, and `VERSION` for the proper values or set them as global environment variables first:
 

--- a/tools/release/publish-to-svn.sh
+++ b/tools/release/publish-to-svn.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Publish a prepared release, then verify its contents independently of the
+# commit response. Requires Subversion and GNU diff/timeout, as on Ubuntu runners.
+set -euo pipefail
+
+source_dir="$(cd "$1" && pwd)"
+mode="$2"
+: "${PLUGIN_REPO_URL:?}" "${VERSION:?}" "${SVN_USERNAME:?}" "${SVN_PASSWORD:?}"
+if [[ "$mode" != trunk && "$mode" != tag ]]; then
+	echo 'Expected publish mode trunk or tag.' >&2
+	exit 1
+fi
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo 'Expected a stable release version.' >&2
+	exit 1
+fi
+
+verify_timeout="${SVN_VERIFY_TIMEOUT:-900}"
+retry_interval="${SVN_VERIFY_RETRY_INTERVAL:-30}"
+if [[ ! "$verify_timeout" =~ ^[1-9][0-9]*$ || ! "$retry_interval" =~ ^[1-9][0-9]*$ ]]; then
+	echo 'SVN verification timeout and retry interval must be positive seconds.' >&2
+	exit 1
+fi
+
+svn_args=(--no-auth-cache --non-interactive --username "$SVN_USERNAME" --password "$SVN_PASSWORD")
+tag_url="$PLUGIN_REPO_URL/tags/$VERSION"
+verification_dir="$(mktemp -d)"
+trap 'rm -rf "$verification_dir"' EXIT
+mkdir "$verification_dir/expected"
+# Preserve the exact prepared payload before SVN can change the working copy.
+tar -C "$source_dir" --exclude=.svn -cf - . | tar -C "$verification_dir/expected" -xf -
+
+# Listing the parent must succeed. An authentication or network error must not
+# be mistaken for an absent tag and trigger a new write.
+svn list "$PLUGIN_REPO_URL/tags" "${svn_args[@]}" \
+	--config-option=servers:global:http-timeout=60 > "$verification_dir/tags"
+if grep -Fxq "$VERSION/" "$verification_dir/tags"; then
+	echo "SVN tag tags/$VERSION already exists. Verifying its contents before accepting the release."
+else
+	if [[ "$mode" == trunk ]]; then
+		svn add --force "$source_dir"
+		while IFS= read -r missing; do
+			svn rm "$missing"
+		done < <(svn status "$source_dir" | sed -n 's/^! *//p')
+		tag_dir="$(dirname "$source_dir")/tags/$VERSION"
+		svn copy "$source_dir" "$tag_dir"
+		publish_command=(commit "$source_dir" "$tag_dir" -m "Releasing version $VERSION")
+	else
+		publish_command=(import "$source_dir" "$tag_url" -m "Committing version $VERSION")
+	fi
+	if ! svn "${publish_command[@]}" "${svn_args[@]}" --config-option=servers:global:http-timeout=600; then
+		echo '::warning::SVN reported a publish error. Checking the repository to determine whether the release was committed.'
+	fi
+fi
+
+# A commit may have succeeded even when SVN returned an error. Retry only reads;
+# never repeat a write whose outcome is uncertain. Each attempt pins all exports
+# to one revision, so trunk and tag cannot be verified at different revisions.
+deadline=$((SECONDS + verify_timeout))
+read_svn() {
+	local remaining=$((deadline - SECONDS))
+	if (( remaining <= 0 )); then
+		return 1
+	fi
+	timeout "$remaining" svn "$@" "${svn_args[@]}" --config-option=servers:global:http-timeout=60
+}
+
+verify_release() {
+	local revision remote_path
+	if ! revision=$(read_svn info --show-item revision "$PLUGIN_REPO_URL"); then
+		return 1
+	fi
+	if [[ ! "$revision" =~ ^[0-9]+$ ]]; then
+		echo 'SVN did not return a valid revision.' >&2
+		return 1
+	fi
+	local paths=("tags/$VERSION")
+	if [[ "$mode" == trunk ]]; then
+		paths+=(trunk)
+	fi
+	for remote_path in "${paths[@]}"; do
+		rm -rf "$verification_dir/actual"
+		if ! read_svn export --quiet --ignore-externals --ignore-keywords \
+			-r "$revision" "$PLUGIN_REPO_URL/$remote_path@$revision" "$verification_dir/actual"; then
+			return 1
+		fi
+		if ! diff --recursive --brief --no-dereference "$verification_dir/expected" "$verification_dir/actual"; then
+			echo "SVN $remote_path at revision $revision does not match the prepared release." >&2
+			return 1
+		fi
+	done
+	echo "Verified SVN release $VERSION at revision $revision: ${paths[*]} match the prepared release."
+	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		echo "Verified SVN release $VERSION at revision $revision. All files in ${paths[*]} match the prepared release." >> "$GITHUB_STEP_SUMMARY"
+	fi
+}
+
+while (( SECONDS < deadline )); do
+	if verify_release; then
+		exit 0
+	fi
+	remaining=$((deadline - SECONDS))
+	if (( remaining <= 0 )); then
+		break
+	fi
+	delay="$retry_interval"
+	if (( delay > remaining )); then
+		delay="$remaining"
+	fi
+	echo "Release not yet verified. Retrying in $delay seconds; $remaining seconds remain."
+	sleep "$delay"
+done
+
+echo "::error::Could not verify SVN release $VERSION within $verify_timeout seconds. Inspect the SVN tag and trunk against the prepared release before retrying publication."
+exit 1

--- a/tools/release/publish-to-svn.sh
+++ b/tools/release/publish-to-svn.sh
@@ -35,10 +35,40 @@ mkdir "$verification_dir/expected"
 # Preserve the exact prepared payload before SVN can change the working copy.
 tar -C "$source_dir" --exclude=.svn -cf - . | tar -C "$verification_dir/expected" -xf -
 
+# Bound and retry all remote reads. A transient tag lookup failure must not
+# force a manual rerun, while a persistent failure must not trigger a write.
+read_svn() {
+	local deadline="$1"
+	shift
+	local remaining=$((deadline - SECONDS))
+	if (( remaining <= 0 )); then
+		return 1
+	fi
+	timeout "$remaining" svn "$@" "${svn_args[@]}" --config-option=servers:global:http-timeout=60
+}
+
 # Listing the parent must succeed. An authentication or network error must not
 # be mistaken for an absent tag and trigger a new write.
-svn list "$PLUGIN_REPO_URL/tags" "${svn_args[@]}" \
-	--config-option=servers:global:http-timeout=60 > "$verification_dir/tags"
+lookup_deadline=$((SECONDS + verify_timeout))
+retry_delay="$retry_interval"
+while ! read_svn "$lookup_deadline" list "$PLUGIN_REPO_URL/tags" > "$verification_dir/tags"; do
+	remaining=$((lookup_deadline - SECONDS))
+	if (( remaining <= 0 )); then
+		echo "::error::Could not read SVN tags within $verify_timeout seconds. No publication was attempted. Check SVN access, then rerun the workflow."
+		exit 1
+	fi
+	delay="$retry_delay"
+	if (( delay > remaining )); then
+		delay="$remaining"
+	fi
+	echo "Could not read SVN tags. Retrying in $delay seconds; $remaining seconds remain."
+	sleep "$delay"
+	if (( retry_delay <= verify_timeout / 2 )); then
+		retry_delay=$((retry_delay * 2))
+	else
+		retry_delay="$verify_timeout"
+	fi
+done
 if grep -Fxq "$VERSION/" "$verification_dir/tags"; then
 	echo "SVN tag tags/$VERSION already exists. Verifying its contents before accepting the release."
 else
@@ -62,17 +92,10 @@ fi
 # never repeat a write whose outcome is uncertain. Each attempt pins all exports
 # to one revision, so trunk and tag cannot be verified at different revisions.
 deadline=$((SECONDS + verify_timeout))
-read_svn() {
-	local remaining=$((deadline - SECONDS))
-	if (( remaining <= 0 )); then
-		return 1
-	fi
-	timeout "$remaining" svn "$@" "${svn_args[@]}" --config-option=servers:global:http-timeout=60
-}
 
 verify_release() {
 	local revision remote_path
-	if ! revision=$(read_svn info --show-item revision "$PLUGIN_REPO_URL"); then
+	if ! revision=$(read_svn "$deadline" info --show-item revision "$PLUGIN_REPO_URL"); then
 		return 1
 	fi
 	if [[ ! "$revision" =~ ^[0-9]+$ ]]; then
@@ -85,11 +108,11 @@ verify_release() {
 	fi
 	for remote_path in "${paths[@]}"; do
 		rm -rf "$verification_dir/actual"
-		if ! read_svn export --quiet --ignore-externals --ignore-keywords \
+		if ! read_svn "$deadline" export --quiet --ignore-externals --ignore-keywords \
 			-r "$revision" "$PLUGIN_REPO_URL/$remote_path@$revision" "$verification_dir/actual"; then
 			return 1
 		fi
-		if ! diff --recursive --brief --no-dereference "$verification_dir/expected" "$verification_dir/actual"; then
+		if ! ( cd "$verification_dir" && diff --recursive --brief --no-dereference expected actual ); then
 			echo "SVN $remote_path at revision $revision does not match the prepared release." >&2
 			return 1
 		fi
@@ -100,6 +123,7 @@ verify_release() {
 	fi
 }
 
+retry_delay="$retry_interval"
 while (( SECONDS < deadline )); do
 	if verify_release; then
 		exit 0
@@ -108,12 +132,17 @@ while (( SECONDS < deadline )); do
 	if (( remaining <= 0 )); then
 		break
 	fi
-	delay="$retry_interval"
+	delay="$retry_delay"
 	if (( delay > remaining )); then
 		delay="$remaining"
 	fi
 	echo "Release not yet verified. Retrying in $delay seconds; $remaining seconds remain."
 	sleep "$delay"
+	if (( retry_delay <= verify_timeout / 2 )); then
+		retry_delay=$((retry_delay * 2))
+	else
+		retry_delay="$verify_timeout"
+	fi
 done
 
 echo "::error::Could not verify SVN release $VERSION within $verify_timeout seconds. Inspect the SVN tag and trunk against the prepared release before retrying publication."

--- a/tools/release/publish-to-svn.sh
+++ b/tools/release/publish-to-svn.sh
@@ -3,6 +3,11 @@
 # commit response. Requires Subversion and GNU diff/timeout, as on Ubuntu runners.
 set -euo pipefail
 
+if (( $# != 2 )); then
+	echo "Usage: $0 <source-dir> <trunk|tag>" >&2
+	exit 1
+fi
+
 source_dir="$(cd "$1" && pwd)"
 mode="$2"
 : "${PLUGIN_REPO_URL:?}" "${VERSION:?}" "${SVN_USERNAME:?}" "${SVN_PASSWORD:?}"

--- a/tools/release/test/publish-to-svn.sh
+++ b/tools/release/test/publish-to-svn.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+# Integration tests against a disposable SVN repository. Requires svn, svnadmin,
+# and GNU diff/timeout. No WordPress.org credentials or network access are used.
+set -euo pipefail
+
+SCRIPT="${PUBLISH_SCRIPT:-$(cd "$(dirname "$0")/.." && pwd)/publish-to-svn.sh}"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+REAL_SVN="$(command -v svn)"
+export REAL_SVN
+mkdir "$TEST_ROOT/bin"
+cat > "$TEST_ROOT/bin/svn" <<'WRAPPER'
+#!/bin/bash
+set -euo pipefail
+case "$1" in
+	list)
+		if [[ "${SCENARIO:-}" == list-error ]]; then
+			echo 'svn: E170001: Authorization failed' >&2
+			exit 1
+		fi
+		;;
+	commit|import)
+		if [[ "${SCENARIO:-}" == reject-write ]]; then
+			echo 'svn: E170001: Authorization failed' >&2
+			exit 1
+		fi
+		"$REAL_SVN" "$@"
+		if [[ "${SCENARIO:-}" == commit-error ]]; then
+			echo "svn: E160013: '/gutenberg' path not found" >&2
+			exit 1
+		fi
+		exit 0
+		;;
+	info|export)
+		if [[ "${SCENARIO:-}" == stalled-read ]]; then
+			sleep 30
+		fi
+		if [[ "${SCENARIO:-}" == delayed-content && "$1" == info ]]; then
+			count=$(cat "$READ_COUNT")
+			echo "$((count + 1))" > "$READ_COUNT"
+			if (( count == 1 )); then
+				"$REAL_SVN" checkout "$PLUGIN_REPO_URL/tags/$VERSION" "$MUTATION_DIR" -q
+				cp -R "$PAYLOAD/." "$MUTATION_DIR/"
+				"$REAL_SVN" add --force "$MUTATION_DIR" >/dev/null
+				"$REAL_SVN" commit "$MUTATION_DIR" -m 'Release becomes available' -q
+			fi
+		fi
+		if [[ "${SCENARIO:-}" == read-error ]]; then
+			echo 'svn: E175012: Connection timed out' >&2
+			exit 1
+		fi
+		if [[ "${SCENARIO:-}" == delayed-read && "$1" == info ]]; then
+			count=$(cat "$READ_COUNT")
+			echo "$((count + 1))" > "$READ_COUNT"
+			if (( count < 2 )); then
+				echo 'svn: E160013: Revision not yet available' >&2
+				exit 1
+			fi
+		fi
+		;;
+esac
+if [[ "${SCENARIO:-}" == mixed-revisions && "$1" == export && ! -f "$READ_COUNT.changed" ]]; then
+	"$REAL_SVN" "$@"
+	touch "$READ_COUNT.changed"
+	"$REAL_SVN" checkout "$PLUGIN_REPO_URL" "$MUTATION_DIR" -q
+	cp -R "$PAYLOAD/." "$MUTATION_DIR/trunk/"
+	echo 'wrong release' > "$MUTATION_DIR/tags/$VERSION/gutenberg.php"
+	"$REAL_SVN" add --force "$MUTATION_DIR" >/dev/null
+	"$REAL_SVN" commit "$MUTATION_DIR" -m 'Concurrent change' -q
+	exit 0
+fi
+exec "$REAL_SVN" "$@"
+WRAPPER
+chmod +x "$TEST_ROOT/bin/svn"
+export PATH="$TEST_ROOT/bin:$PATH"
+export SVN_USERNAME=test SVN_PASSWORD=test VERSION=23.9.0
+export SVN_VERIFY_TIMEOUT=3 SVN_VERIFY_RETRY_INTERVAL=1
+
+setup() {
+	CASE_ROOT="$TEST_ROOT/$1"
+	mkdir -p "$CASE_ROOT/release/build"
+	svnadmin create "$CASE_ROOT/repository"
+	export PLUGIN_REPO_URL="file://$CASE_ROOT/repository"
+	"$REAL_SVN" mkdir "$PLUGIN_REPO_URL/trunk" "$PLUGIN_REPO_URL/tags" -m init -q
+	printf 'Version: 23.9.0\n' > "$CASE_ROOT/release/gutenberg.php"
+	printf 'Stable tag: 23.9.0\n' > "$CASE_ROOT/release/readme.txt"
+	printf 'release code\n' > "$CASE_ROOT/release/build/file with spaces.js"
+	printf 'Release notes\n' > "$CASE_ROOT/release/changelog.txt"
+	export READ_COUNT="$CASE_ROOT/reads" MUTATION_DIR="$CASE_ROOT/mutation" PAYLOAD="$CASE_ROOT/release"
+	echo 0 > "$READ_COUNT"
+	unset SCENARIO
+}
+
+prepare_trunk() {
+	"$REAL_SVN" checkout "$PLUGIN_REPO_URL/trunk" "$CASE_ROOT/trunk" -q
+	"$REAL_SVN" checkout "$PLUGIN_REPO_URL/tags" "$CASE_ROOT/tags" --depth=immediates -q
+	cp -R "$CASE_ROOT/release/." "$CASE_ROOT/trunk/"
+}
+
+publish() {
+	bash "$SCRIPT" "$@" > "$CASE_ROOT/output" 2>&1
+}
+
+expect_success() {
+	if ! publish "$@"; then
+		cat "$CASE_ROOT/output"
+		exit 1
+	fi
+	grep -q 'Verified SVN release 23.9.0 at revision' "$CASE_ROOT/output"
+}
+
+expect_failure() {
+	if publish "$@"; then
+		echo 'Unexpected success'
+		cat "$CASE_ROOT/output"
+		exit 1
+	fi
+	if grep -q 'Verified SVN release' "$CASE_ROOT/output"; then
+		echo 'Failed deployment was reported as verified'
+		exit 1
+	fi
+}
+
+setup successful-trunk
+"$REAL_SVN" checkout "$PLUGIN_REPO_URL/trunk" "$CASE_ROOT/old-trunk" -q
+echo obsolete > "$CASE_ROOT/old-trunk/removed file.js"
+"$REAL_SVN" add "$CASE_ROOT/old-trunk/removed file.js" -q
+"$REAL_SVN" commit "$CASE_ROOT/old-trunk" -m old -q
+prepare_trunk
+rm "$CASE_ROOT/trunk/removed file.js"
+expect_success "$CASE_ROOT/trunk" trunk
+"$REAL_SVN" export "$PLUGIN_REPO_URL/tags/$VERSION" "$CASE_ROOT/export" -q
+diff -r "$CASE_ROOT/release" "$CASE_ROOT/export"
+echo 'PASS: publish and verify both trunk and tag'
+before=$("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL")
+expect_success "$CASE_ROOT/trunk" trunk
+[[ $("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL") == "$before" ]]
+echo 'PASS: accept an identical existing trunk release without a write'
+
+setup lost-commit-response
+prepare_trunk
+export SCENARIO=commit-error
+expect_success "$CASE_ROOT/trunk" trunk
+grep -q 'E160013' "$CASE_ROOT/output"
+echo 'PASS: recover after a committed release reports failure'
+
+setup existing-tag
+"$REAL_SVN" import "$CASE_ROOT/release" "$PLUGIN_REPO_URL/tags/$VERSION" -m tag -q
+before=$("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL")
+expect_success "$CASE_ROOT/release" tag
+[[ $("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL") == "$before" ]]
+echo 'PASS: accept an identical existing tag without a write'
+
+for difference in missing changed extra; do
+	setup "$difference-file"
+	"$REAL_SVN" import "$CASE_ROOT/release" "$PLUGIN_REPO_URL/tags/$VERSION" -m tag -q
+	case "$difference" in
+		missing) echo 'not deployed' > "$CASE_ROOT/release/missing.js" ;;
+		changed) echo 'different code' > "$CASE_ROOT/release/build/file with spaces.js" ;;
+		extra) rm "$CASE_ROOT/release/build/file with spaces.js" ;;
+	esac
+	expect_failure "$CASE_ROOT/release" tag
+	echo "PASS: reject $difference files despite matching version headers"
+done
+
+setup missing-trunk
+prepare_trunk
+"$REAL_SVN" import "$CASE_ROOT/release" "$PLUGIN_REPO_URL/tags/$VERSION" -m tag -q
+expect_failure "$CASE_ROOT/trunk" trunk
+echo 'PASS: a matching tag cannot hide an incomplete trunk release'
+
+setup rejected-write
+export SCENARIO=reject-write
+expect_failure "$CASE_ROOT/release" tag
+grep -q 'Authorization failed' "$CASE_ROOT/output"
+echo 'PASS: a rejected write with no deployment remains a failure'
+
+setup unreadable-deployment
+export SCENARIO=read-error
+expect_failure "$CASE_ROOT/release" tag
+grep -q 'Connection timed out' "$CASE_ROOT/output"
+echo 'PASS: a successful write cannot hide failed verification reads'
+
+setup delayed-visibility
+prepare_trunk
+export SCENARIO=delayed-read SVN_VERIFY_TIMEOUT=10
+expect_success "$CASE_ROOT/trunk" trunk
+[[ $(cat "$READ_COUNT") -ge 3 ]]
+echo 'PASS: retry verification until SVN reads become available'
+
+setup tag-only
+export SCENARIO=commit-error
+trunk_revision=$("$REAL_SVN" info --show-item last-changed-revision "$PLUGIN_REPO_URL/trunk")
+expect_success "$CASE_ROOT/release" tag
+[[ $("$REAL_SVN" info --show-item last-changed-revision "$PLUGIN_REPO_URL/trunk") == "$trunk_revision" ]]
+echo 'PASS: recover tag-only imports without changing trunk'
+
+setup failed-tag-lookup
+export SCENARIO=list-error
+before=$("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL")
+expect_failure "$CASE_ROOT/release" tag
+[[ $("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL") == "$before" ]]
+echo 'PASS: failed tag lookup cannot trigger publication'
+
+setup mixed-revisions
+prepare_trunk
+"$REAL_SVN" import "$CASE_ROOT/release" "$PLUGIN_REPO_URL/tags/$VERSION" -m tag -q
+export SCENARIO=mixed-revisions SVN_VERIFY_TIMEOUT=3
+expect_failure "$CASE_ROOT/trunk" trunk
+[[ -f "$READ_COUNT.changed" ]]
+echo 'PASS: never combine matching trees from different revisions'
+
+setup delayed-content
+"$REAL_SVN" import "$CASE_ROOT/release" "$PLUGIN_REPO_URL/tags/$VERSION" -m tag -q
+echo 'new file' > "$CASE_ROOT/release/new.js"
+export SCENARIO=delayed-content SVN_VERIFY_TIMEOUT=10
+expect_success "$CASE_ROOT/release" tag
+[[ $(cat "$READ_COUNT") -ge 2 ]]
+echo 'PASS: retry content differences against a fresh revision'
+
+setup stalled-read
+export SCENARIO=stalled-read SVN_VERIFY_TIMEOUT=3
+started=$SECONDS
+expect_failure "$CASE_ROOT/release" tag
+(( SECONDS - started < 10 ))
+echo 'PASS: bound a stalled SVN read by the verification deadline'

--- a/tools/release/test/publish-to-svn.sh
+++ b/tools/release/test/publish-to-svn.sh
@@ -121,6 +121,18 @@ expect_failure() {
 	fi
 }
 
+usage_output="$TEST_ROOT/usage-output"
+if bash "$SCRIPT" > "$usage_output" 2>&1; then
+	echo 'Unexpected success without required arguments'
+	exit 1
+fi
+grep -q '^Usage: ' "$usage_output"
+if grep -q 'unbound variable' "$usage_output"; then
+	echo 'Missing arguments reported an unbound variable'
+	exit 1
+fi
+echo 'PASS: reject missing arguments with usage guidance'
+
 setup successful-trunk
 "$REAL_SVN" checkout "$PLUGIN_REPO_URL/trunk" "$CASE_ROOT/old-trunk" -q
 echo obsolete > "$CASE_ROOT/old-trunk/removed file.js"

--- a/tools/release/test/publish-to-svn.sh
+++ b/tools/release/test/publish-to-svn.sh
@@ -194,8 +194,25 @@ setup rejected-write
 export SCENARIO=reject-write SVN_VERIFY_TIMEOUT=4
 expect_failure "$CASE_ROOT/release" tag
 grep -q 'Authorization failed' "$CASE_ROOT/output"
-grep -q 'Retrying in 1 seconds' "$CASE_ROOT/output"
-grep -q 'Retrying in 2 seconds' "$CASE_ROOT/output"
+retry_count=0
+expected_delay="$SVN_VERIFY_RETRY_INTERVAL"
+while read -r actual_delay remaining; do
+	(( retry_count += 1 ))
+	expected_attempt_delay="$expected_delay"
+	if (( expected_attempt_delay > remaining )); then
+		expected_attempt_delay="$remaining"
+	fi
+	if (( actual_delay != expected_attempt_delay )); then
+		echo "Expected a $expected_attempt_delay-second retry delay, got $actual_delay seconds"
+		exit 1
+	fi
+	if (( expected_delay <= SVN_VERIFY_TIMEOUT / 2 )); then
+		expected_delay=$((expected_delay * 2))
+	else
+		expected_delay="$SVN_VERIFY_TIMEOUT"
+	fi
+done < <(sed -n 's/^Release not yet verified\. Retrying in \([0-9][0-9]*\) seconds; \([0-9][0-9]*\) seconds remain\.$/\1 \2/p' "$CASE_ROOT/output")
+(( retry_count > 0 ))
 echo 'PASS: a rejected write with no deployment remains a failure'
 
 setup unreadable-deployment

--- a/tools/release/test/publish-to-svn.sh
+++ b/tools/release/test/publish-to-svn.sh
@@ -18,6 +18,14 @@ case "$1" in
 			echo 'svn: E170001: Authorization failed' >&2
 			exit 1
 		fi
+		if [[ "${SCENARIO:-}" == delayed-list ]]; then
+			count=$(cat "$READ_COUNT")
+			echo "$((count + 1))" > "$READ_COUNT"
+			if (( count < 2 )); then
+				echo 'svn: E175012: Connection timed out' >&2
+				exit 1
+			fi
+		fi
 		;;
 	commit|import)
 		if [[ "${SCENARIO:-}" == reject-write ]]; then
@@ -172,6 +180,7 @@ for difference in missing changed extra; do
 		extra) rm "$CASE_ROOT/release/build/file with spaces.js" ;;
 	esac
 	expect_failure "$CASE_ROOT/release" tag
+	grep -Eq 'Only in (expected|actual)|Files expected/.+ and actual/.+ differ' "$CASE_ROOT/output"
 	echo "PASS: reject $difference files despite matching version headers"
 done
 
@@ -182,9 +191,11 @@ expect_failure "$CASE_ROOT/trunk" trunk
 echo 'PASS: a matching tag cannot hide an incomplete trunk release'
 
 setup rejected-write
-export SCENARIO=reject-write
+export SCENARIO=reject-write SVN_VERIFY_TIMEOUT=4
 expect_failure "$CASE_ROOT/release" tag
 grep -q 'Authorization failed' "$CASE_ROOT/output"
+grep -q 'Retrying in 1 seconds' "$CASE_ROOT/output"
+grep -q 'Retrying in 2 seconds' "$CASE_ROOT/output"
 echo 'PASS: a rejected write with no deployment remains a failure'
 
 setup unreadable-deployment
@@ -213,6 +224,12 @@ before=$("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL")
 expect_failure "$CASE_ROOT/release" tag
 [[ $("$REAL_SVN" info --show-item revision "$PLUGIN_REPO_URL") == "$before" ]]
 echo 'PASS: failed tag lookup cannot trigger publication'
+
+setup delayed-tag-lookup
+export SCENARIO=delayed-list SVN_VERIFY_TIMEOUT=10
+expect_success "$CASE_ROOT/release" tag
+[[ $(cat "$READ_COUNT") -ge 3 ]]
+echo 'PASS: retry a transient tag lookup before publication'
 
 setup mixed-revisions
 prepare_trunk


### PR DESCRIPTION
Closes #55295. Closes #79804. Related: #79919.

## What?

Verify the complete SVN deployment before reporting a release as successful, including when SVN reports a publish error or the release tag already exists. Make the required unit-test status wait for the new SVN recovery job.

## Why?

The [23.9.0 upload](https://github.com/WordPress/gutenberg/actions/runs/33642580182/job/100289344254) failed with `E160013: '/gutenberg' path not found` after SVN had committed both trunk and the tag in revision `3678189`. All 2,181 files match the release ZIP after applying the workflow's stable-tag substitution and changelog artifact. This matches the failure pattern reported in both issues; the underlying SVN server or network cause remains unconfirmed.

The required unit-test status previously did not wait for the new recovery job. On documentation-only pull requests, it could evaluate the workflow while that job was still queued or running and fail before the SVN tests finished.

## How?

Share the publication logic between trunk and tag-only uploads. Retry the initial tag lookup before any write. After publication, export each required path at the same SVN revision and compare all paths and file contents against the prepared release. Retry remote reads for up to 15 minutes with exponential backoff, a fresh revision per verification attempt, and bounded SVN commands.

Only a complete match succeeds. Missing, different, or unreadable content remains a failure. Existing tags receive the same verification, and uncertain writes are never repeated automatically. The verified revision appears in the logs and job summary.

The unit-test workflow runs ShellCheck and the disposable SVN recovery suite when a pull request changes files that can affect unit-test results. `Unit Tests - Status Check` waits for the job whether it runs or is skipped.

This retains the atomic trunk-and-tag commit. #79919 separately proposes changing the upload strategy. Verification covers SVN contents; WordPress.org ZIP generation and distribution can finish later.

## Testing Instructions

Run `bash tools/release/test/publish-to-svn.sh` on Linux with Subversion and GNU diff/timeout installed. The tests use disposable local SVN repositories and need no WordPress.org credentials.

They cover successful publication, a committed transaction followed by a simulated failed response, identical existing releases, missing or different files despite matching version headers, failed and stalled reads, delayed tag lookup and content visibility, tag-only releases, and concurrent changes that must not produce a match across different revisions. They also check the argument error, exponential retry intervals, and stable mismatch labels.

In the pull request's Unit Tests workflow, confirm that `Unit Tests - Status Check` starts only after `SVN release recovery` completes. On a documentation-only pull request, confirm that `SVN release recovery` is skipped and the status check succeeds after change detection completes.

<details>
<summary>Validation</summary>

- Reproduced the failed-response case with the previous publication commands.
- Verified the 23.9.0 SVN trunk and tag at revision `3678189` against the release ZIP and original workflow changelog artifact.
- Full build, ShellCheck, and Actionlint passed.
- No production release was triggered or SVN content changed during testing.

</details>

## Use of AI Tools

Codex investigated the failure, implemented the change, and ran the verification described above.
