### PR TITLE
DataForm: render untyped fields without an edit control that are read-only

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -45,7 +45,7 @@
 ### Bug Fixes
 
 -   Fix `Field.sort` TypeScript type definition to reflect that `sort` receives extracted field values rather than `Item` objects ([#82162](https://github.com/WordPress/gutenberg/pull/82162)).
--   DataForm: Render read-only fields without requiring an edit control.
+-   DataForm: Render read-only fields without requiring an edit control ([#82514](https://github.com/WordPress/gutenberg/pull/82514)).
 -   Operators: Support the `isAny` and `isNone` filter operators for numeric field values, which previously matched nothing ([#77942](https://github.com/WordPress/gutenberg/pull/77942)).
 -   Field types: Drop `isAll` from the valid operators of the `number`, `integer`, `text`, `email`, `url` and `telephone` types. Their values are scalars, so "includes all of" can never hold for more than one selected value ([#82463](https://github.com/WordPress/gutenberg/pull/82463)).
 -   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### Bug Fixes
 
 -   Fix `Field.sort` TypeScript type definition to reflect that `sort` receives extracted field values rather than `Item` objects ([#82162](https://github.com/WordPress/gutenberg/pull/82162)).
+-   DataForm: Render read-only fields without requiring an edit control.
 -   Operators: Support the `isAny` and `isNone` filter operators for numeric field values, which previously matched nothing ([#77942](https://github.com/WordPress/gutenberg/pull/77942)).
 -   Field types: Drop `isAll` from the valid operators of the `number`, `integer`, `text`, `email`, `url` and `telephone` types. Their values are scalars, so "includes all of" can never hold for more than one selected value ([#82463](https://github.com/WordPress/gutenberg/pull/82463)).
 -   `DataViews` and `DataViewsPicker`: move the view back to the last available page when it points past the end of the collection, for instance after deleting the only item of the last page ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).

--- a/packages/dataviews/src/components/dataform-layouts/can-render-field.ts
+++ b/packages/dataviews/src/components/dataform-layouts/can-render-field.ts
@@ -1,0 +1,13 @@
+import type { NormalizedField } from '../../types';
+
+/**
+ * Whether a field can render its read-only value or an edit control.
+ *
+ * @param field The normalized field definition.
+ * @return Whether the field can render.
+ */
+export function canRenderField< Item >(
+	field: NormalizedField< Item > | undefined
+): field is NormalizedField< Item > {
+	return !! field && ( field.readOnly === true || !! field.Edit );
+}

--- a/packages/dataviews/src/components/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/card/index.tsx
@@ -11,6 +11,7 @@ import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/com
 import { Card, CollapsibleCard, Stack } from '@wordpress/ui';
 import { getFormFieldLayout } from '..';
 import DataFormContext from '../../dataform-context';
+import { canRenderField } from '../can-render-field';
 import type {
 	FieldLayoutProps,
 	NormalizedCardLayout,
@@ -272,7 +273,7 @@ export default function FormCardField< Item >( {
 			( fieldDef ) => fieldDef.id === field.id
 		);
 
-		if ( ! fieldDefinition || ! fieldDefinition.Edit ) {
+		if ( ! canRenderField( fieldDefinition ) ) {
 			return null;
 		}
 

--- a/packages/dataviews/src/components/dataform-layouts/regular/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/regular/index.tsx
@@ -11,6 +11,7 @@ import type {
 	NormalizedRegularLayout,
 } from '../../../types';
 import DataFormContext from '../../dataform-context';
+import { canRenderField } from '../can-render-field';
 import { DataFormLayout } from '../data-form-layout';
 import { DEFAULT_LAYOUT } from '../normalize-form';
 
@@ -70,10 +71,7 @@ export default function FormRegularField< Item >( {
 		( fieldDef ) => fieldDef.id === field.id
 	);
 
-	if (
-		! fieldDefinition ||
-		( fieldDefinition.readOnly !== true && ! fieldDefinition.Edit )
-	) {
+	if ( ! canRenderField( fieldDefinition ) ) {
 		return null;
 	}
 

--- a/packages/dataviews/src/components/dataform-layouts/regular/index.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/regular/index.tsx
@@ -70,7 +70,10 @@ export default function FormRegularField< Item >( {
 		( fieldDef ) => fieldDef.id === field.id
 	);
 
-	if ( ! fieldDefinition || ! fieldDefinition.Edit ) {
+	if (
+		! fieldDefinition ||
+		( fieldDefinition.readOnly !== true && ! fieldDefinition.Edit )
+	) {
 		return null;
 	}
 
@@ -98,15 +101,17 @@ export default function FormRegularField< Item >( {
 							field={ fieldDefinition }
 						/>
 					) : (
-						<fieldDefinition.Edit
-							key={ fieldDefinition.id }
-							data={ data }
-							field={ fieldDefinition }
-							onChange={ onChange }
-							hideLabelFromVision
-							markWhenOptional={ markWhenOptional }
-							validity={ validity }
-						/>
+						fieldDefinition.Edit && (
+							<fieldDefinition.Edit
+								key={ fieldDefinition.id }
+								data={ data }
+								field={ fieldDefinition }
+								onChange={ onChange }
+								hideLabelFromVision
+								markWhenOptional={ markWhenOptional }
+								validity={ validity }
+							/>
+						)
 					) }
 				</div>
 			</Stack>
@@ -130,16 +135,20 @@ export default function FormRegularField< Item >( {
 					</>
 				</>
 			) : (
-				<fieldDefinition.Edit
-					data={ data }
-					field={ fieldDefinition }
-					onChange={ onChange }
-					hideLabelFromVision={
-						labelPosition === 'none' ? true : hideLabelFromVision
-					}
-					markWhenOptional={ markWhenOptional }
-					validity={ validity }
-				/>
+				fieldDefinition.Edit && (
+					<fieldDefinition.Edit
+						data={ data }
+						field={ fieldDefinition }
+						onChange={ onChange }
+						hideLabelFromVision={
+							labelPosition === 'none'
+								? true
+								: hideLabelFromVision
+						}
+						markWhenOptional={ markWhenOptional }
+						validity={ validity }
+					/>
+				)
 			) }
 		</div>
 	);

--- a/packages/dataviews/src/dataform/stories/layout-card.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-card.tsx
@@ -28,6 +28,9 @@ const LayoutCardComponent = ( {
 		hasVat: boolean;
 		vat: number;
 		commission: number;
+		fileSize: number;
+		dimensions: string;
+		fileType: string;
 		dueDate: string;
 	};
 
@@ -72,6 +75,24 @@ const LayoutCardComponent = ( {
 			id: 'displayPayments',
 			label: 'Display payments?',
 			type: 'boolean',
+		},
+		{
+			id: 'fileSize',
+			label: 'File size',
+			type: 'integer',
+			readOnly: true,
+		},
+		{
+			id: 'dimensions',
+			label: 'Dimensions',
+			type: 'text',
+			readOnly: true,
+		},
+		{
+			// No type and no Edit: a read-only field without an edit control.
+			id: 'fileType',
+			label: 'File type',
+			readOnly: true,
 		},
 		{
 			id: 'payments',
@@ -128,6 +149,9 @@ const LayoutCardComponent = ( {
 		displayPayments: true,
 		totalOrders: 2,
 		totalRevenue: 1430,
+		fileSize: 1024,
+		dimensions: '1920x1080',
+		fileType: 'JPEG',
 		averageOrderValue: 715,
 		hasVat: true,
 		vat: 10,
@@ -229,6 +253,17 @@ const LayoutCardComponent = ( {
 					layout: getCardLayoutFromStoryArgs( {
 						withHeader: false,
 					} ),
+				},
+				{
+					id: 'fileDetails',
+					label: 'File details',
+					layout: getCardLayoutFromStoryArgs( {
+						withHeader,
+						withSummary,
+						isCollapsible,
+						isOpened,
+					} ),
+					children: [ 'fileSize', 'dimensions', 'fileType' ],
 				},
 				{
 					id: 'taxConfiguration',

--- a/packages/dataviews/src/dataform/stories/layout-card.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-card.tsx
@@ -95,9 +95,9 @@ const LayoutCardComponent = ( {
 			readOnly: true,
 		},
 		{
+			// No type and no Edit: a read-only field rendered as its own card.
 			id: 'payments',
 			label: 'Payments',
-			type: 'text',
 			readOnly: true, // Triggers using the render method instead of Edit.
 			isVisible: ( item ) => item.displayPayments,
 			render: ( { item } ) => {

--- a/packages/dataviews/src/dataform/stories/layout-details.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-details.tsx
@@ -13,6 +13,7 @@ type SamplePost = {
 	password?: string;
 	filesize?: number;
 	dimensions?: string;
+	file_type?: string;
 	tags?: string[];
 	address1?: string;
 	address2?: string;
@@ -124,6 +125,12 @@ const fields: Field< SamplePost >[] = [
 		id: 'dimensions',
 		label: 'Dimensions',
 		type: 'text',
+		readOnly: true,
+	},
+	{
+		// No type and no Edit: a read-only field without an edit control.
+		id: 'file_type',
+		label: 'File type',
 		readOnly: true,
 	},
 	{
@@ -261,6 +268,7 @@ const LayoutDetailsComponent = () => {
 		birthdate: '1950-02-23T12:00:00',
 		filesize: 1024,
 		dimensions: '1920x1080',
+		file_type: 'JPEG',
 		comment_status: 'open',
 		ping_status: true,
 		tags: [ 'photography' ],
@@ -280,7 +288,7 @@ const LayoutDetailsComponent = () => {
 			{
 				id: 'metadata',
 				label: 'Metadata',
-				children: [ 'filesize', 'dimensions' ],
+				children: [ 'filesize', 'dimensions', 'file_type' ],
 				layout: {
 					type: 'details',
 					summary: 'metadata_summary',

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -19,6 +19,7 @@ type SamplePost = {
 	password?: string;
 	filesize?: number;
 	dimensions?: string;
+	file_type?: string;
 	tags?: string[];
 	address1?: string;
 	address2?: string;
@@ -134,6 +135,12 @@ const fields: Field< SamplePost >[] = [
 		id: 'dimensions',
 		label: 'Dimensions',
 		type: 'text',
+		readOnly: true,
+	},
+	{
+		// No type and no Edit: a read-only field without an edit control.
+		id: 'file_type',
+		label: 'File type',
 		readOnly: true,
 	},
 	{
@@ -318,6 +325,7 @@ const LayoutPanelComponent = ( {
 		birthdate: '1950-02-23T12:00:00',
 		filesize: 1024,
 		dimensions: '1920x1080',
+		file_type: 'JPEG',
 		tags: [ 'photography' ],
 		address1: '123 Main St',
 		address2: 'Apt 4B',
@@ -366,6 +374,7 @@ const LayoutPanelComponent = ( {
 				'author',
 				'filesize',
 				'dimensions',
+				'file_type',
 				'tags',
 				{
 					id: 'discussion',

--- a/packages/dataviews/src/dataform/stories/layout-regular.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-regular.tsx
@@ -20,6 +20,7 @@ type SamplePost = {
 	password?: string;
 	filesize?: number;
 	dimensions?: string;
+	file_type?: string;
 	tags?: string[];
 	address1?: string;
 	address2?: string;
@@ -136,6 +137,12 @@ const fields: Field< SamplePost >[] = [
 		id: 'dimensions',
 		label: 'Dimensions',
 		type: 'text',
+		readOnly: true,
+	},
+	{
+		// No type and no Edit: a read-only field without an edit control.
+		id: 'file_type',
+		label: 'File type',
 		readOnly: true,
 	},
 	{
@@ -329,6 +336,7 @@ const LayoutRegularComponent = ( {
 		can_comment: false,
 		filesize: 1024,
 		dimensions: '1920x1080',
+		file_type: 'JPEG',
 		tags: [ 'photography' ],
 		description: 'This is a sample description.',
 	} );
@@ -366,6 +374,7 @@ const LayoutRegularComponent = ( {
 				'birthdate',
 				'filesize',
 				'dimensions',
+				'file_type',
 				'tags',
 				'description',
 				'longDescription',

--- a/packages/dataviews/src/dataform/stories/layout-row.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-row.tsx
@@ -30,6 +30,9 @@ const LayoutRowComponent = ( {
 		tax: number;
 		quantity: number;
 		total: number;
+		fileSize: number;
+		dimensions: string;
+		fileType: string;
 	};
 
 	const customerFields: Field< Customer >[] = [
@@ -156,6 +159,24 @@ const LayoutRowComponent = ( {
 			type: 'integer',
 			readOnly: true,
 		},
+		{
+			id: 'fileSize',
+			label: 'File size',
+			type: 'integer',
+			readOnly: true,
+		},
+		{
+			id: 'dimensions',
+			label: 'Dimensions',
+			type: 'text',
+			readOnly: true,
+		},
+		{
+			// No type and no Edit: a read-only field without an edit control.
+			id: 'fileType',
+			label: 'File type',
+			readOnly: true,
+		},
 	];
 
 	const [ customer, setCustomer ] = useState< Customer >( {
@@ -181,6 +202,9 @@ const LayoutRowComponent = ( {
 		tax: 20,
 		quantity: 5,
 		total: 600,
+		fileSize: 1024,
+		dimensions: '1920x1080',
+		fileType: 'JPEG',
 	} );
 
 	const getRowLayoutFromStoryArgs = ( {
@@ -242,6 +266,15 @@ const LayoutRowComponent = ( {
 					],
 				},
 
+				{
+					id: 'fileDetails',
+					label: 'File details',
+					layout: getRowLayoutFromStoryArgs( {
+						alignment:
+							alignment === 'default' ? 'start' : alignment,
+					} ),
+					children: [ 'fileSize', 'dimensions', 'fileType' ],
+				},
 				{
 					id: 'planRow',
 					label: 'Subscription',

--- a/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
@@ -98,6 +98,59 @@ const fieldsSelector = {
 
 describe( 'DataForm component', () => {
 	describe( 'in regular mode', () => {
+		it.each( [ 'top', 'side', 'none' ] as const )(
+			'renders a read-only field without an edit control with %s labels',
+			( labelPosition ) => {
+				render(
+					<Dataform
+						onChange={ noop }
+						fields={ [
+							{
+								id: 'status',
+								label: 'Account status',
+								readOnly: true,
+								render: () => <span>Account connected</span>,
+							},
+						] }
+						form={ {
+							layout: { type: 'regular', labelPosition },
+							fields: [ 'status' ],
+						} }
+						data={ {} }
+					/>
+				);
+
+				expect( screen.getByText( 'Account connected' ) ).toBeVisible();
+				expect(
+					screen.queryAllByText( 'Account status' )
+				).toHaveLength( labelPosition === 'none' ? 0 : 1 );
+			}
+		);
+
+		it( 'keeps an editable field without an edit control hidden', () => {
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ [
+						{
+							id: 'status',
+							label: 'Account status',
+							render: () => <span>Account connected</span>,
+						},
+					] }
+					form={ { fields: [ 'status' ] } }
+					data={ {} }
+				/>
+			);
+
+			expect(
+				screen.queryByText( 'Account connected' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Account status' )
+			).not.toBeInTheDocument();
+		} );
+
 		it( 'should display fields', () => {
 			render(
 				<Dataform

--- a/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
@@ -757,6 +757,56 @@ describe( 'DataForm component', () => {
 	} );
 
 	describe( 'in card mode', () => {
+		it( 'renders a read-only field without an edit control as its own card', () => {
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ [
+						{
+							id: 'status',
+							label: 'Account status',
+							readOnly: true,
+							render: () => <span>Account connected</span>,
+						},
+					] }
+					form={ { layout: { type: 'card' }, fields: [ 'status' ] } }
+					data={ {} }
+				/>
+			);
+
+			expect( screen.getByText( 'Account connected' ) ).toBeVisible();
+			expect( screen.getAllByText( 'Account status' ) ).toHaveLength( 1 );
+		} );
+
+		it( 'does not render an empty card for an editable field without an edit control', () => {
+			const { container } = render(
+				<Dataform
+					onChange={ noop }
+					fields={ [
+						{
+							id: 'status',
+							label: 'Account status',
+							render: () => <span>Account connected</span>,
+						},
+					] }
+					form={ { layout: { type: 'card' }, fields: [ 'status' ] } }
+					data={ {} }
+				/>
+			);
+
+			expect(
+				screen.queryByText( 'Account connected' )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Account status' )
+			).not.toBeInTheDocument();
+			expect(
+				// An empty card has no accessible role or text to query.
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				container.querySelector( '.dataforms-layouts-card__field' )
+			).not.toBeInTheDocument();
+		} );
+
 		const fieldsWithRequiredTitle = fields.map( ( field ) =>
 			field.id === 'title'
 				? { ...field, isValid: { required: true } }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- In a few words, what is the PR actually doing? -->

Render read-only DataForm fields that have no edit control.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A field with `readOnly: true` and a custom `render` disappears unless it also defines `Edit` or a type that supplies one. Information-only fields should be able to use their display renderer without declaring an unused input control.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Only require `Edit` for editable fields in the regular layout. Keep editable fields without a control hidden, and check the optional control before rendering it.

Add regression coverage for top, side and hidden labels. All three read-only cases fail before the fix and pass afterwards. This changes no field API or saving behaviour.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Render a DataForm with this field definition and `form.fields: [ 'status' ]`:

   ```jsx
   {
       id: 'status',
       label: 'Account status',
       readOnly: true,
       render: () => <span>Account connected</span>,
   }
   ```

2. Confirm the text appears without adding `type` or `Edit`.
3. Set `form.layout` to `{ type: 'regular', labelPosition: 'side' }`, then repeat with `'top'` and `'none'`. Confirm the value appears in every layout and the label is omitted for `'none'`.
4. Remove `readOnly` and confirm the field is hidden because it has no edit control.

Validation completed:

- All 36 tests in `packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx` pass.
- `npm run typecheck -- packages/dataviews`, lint on the changed TypeScript files and `npm run build` pass.
- Verified all three label layouts in a local browser harness using the built DataForm package.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Tab through a form containing editable fields and the read-only field above. The read-only text should remain visible without adding an input or a tab stop.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="1280" height="577" alt="readonly" src="https://github.com/user-attachments/assets/eb9b24ac-124a-4cb8-889e-b3b82a5eef62" />

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Codex investigated the rendering guard, implemented the fix and regression tests, ran validation, and drafted this PR. This draft is awaiting human review.
