### PR TITLE
Core Data: resolve templates from the saved slug, not the edited one

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 
--   Resolve the default template from a post's saved slug rather than its edited one, so typing in the slug field no longer sends a `/templates/lookup` request per keystroke ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   Resolve the default template from a post's saved slug rather than its edited one, so typing in the slug field no longer sends a `/templates/lookup` request per keystroke ([#82515](https://github.com/WordPress/gutenberg/pull/82515)).
 -   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 
 ### Enhancements

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+-   Resolve the default template from a post's saved slug rather than its edited one, so typing in the slug field no longer sends a `/templates/lookup` request per keystroke ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 
 ### Enhancements

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -255,16 +255,25 @@ export const getTemplateId = createRegistrySelector(
 			}
 		}
 		// If no template is assigned, use the default template.
+		// Derive the slug from the saved record rather than the edited one. A
+		// slug only selects a template once it has been saved, and reading the
+		// edited value would send a lookup request for every keystroke while
+		// someone types in the slug field.
+		const savedEntity = select( STORE_NAME ).getRawEntityRecord(
+			'postType',
+			postType,
+			postId
+		);
 		let slugToCheck;
 		// In `draft` status we might not have a slug available, so we use the `single`
 		// post type templates slug(ex page, single-post, single-product etc..).
 		// Pages do not need the `single` prefix in the slug to be prioritized
 		// through template hierarchy.
-		if ( editedEntity.slug ) {
+		if ( savedEntity?.slug ) {
 			slugToCheck =
 				postType === 'page'
-					? `${ postType }-${ editedEntity.slug }`
-					: `single-${ postType }-${ editedEntity.slug }`;
+					? `${ postType }-${ savedEntity.slug }`
+					: `single-${ postType }-${ savedEntity.slug }`;
 		} else {
 			slugToCheck = postType === 'page' ? 'page' : `single-${ postType }`;
 		}

--- a/packages/core-data/src/test/private-selectors.jsdom.test.js
+++ b/packages/core-data/src/test/private-selectors.jsdom.test.js
@@ -64,19 +64,16 @@ describe( 'getUndoManager', () => {
 } );
 
 describe( 'getTemplateId', () => {
-	// Builds a registry whose core store returns a post with a saved slug and,
-	// optionally, an unsaved edit to that slug.
+	// Stands in for the core store. `getHomePage` and `getPostsPageId` are read
+	// through unlock(), so they are locked onto the same object.
 	const setup = ( { savedSlug, editedSlug } ) => {
-		const getDefaultTemplateId = jest.fn().mockReturnValue( 'default-id' );
-		// getHomePage and getPostsPageId are read through unlock(), so the
-		// store selectors need the private ones locked onto them.
+		const getDefaultTemplateId = jest.fn();
 		const storeSelectors = {
 			getEditedEntityRecord: () => ( {
-				slug: editedSlug ?? savedSlug,
+				slug: editedSlug,
 				template: '',
 			} ),
-			// An unsaved record has no raw entry at all, so the selector
-			// returns undefined rather than an object with an empty slug.
+			// A record that has never been saved has no raw entry at all.
 			getRawEntityRecord: () =>
 				savedSlug === undefined ? undefined : { slug: savedSlug },
 			getEntityRecords: () => [],
@@ -86,26 +83,12 @@ describe( 'getTemplateId', () => {
 			getHomePage: () => ( { postType: 'wp_template', postId: 'home' } ),
 			getPostsPageId: () => null,
 		} );
-		const select = () => storeSelectors;
-
-		// getTemplateId is a registry selector: it resolves its dependencies
-		// through the registry assigned to the selector itself.
-		getTemplateId.registry = { select };
-		return { getDefaultTemplateId };
+		getTemplateId.registry = { select: () => storeSelectors };
+		return getDefaultTemplateId;
 	};
 
-	it( 'looks up the template using the saved slug', () => {
-		const { getDefaultTemplateId } = setup( { savedSlug: 'hello' } );
-
-		getTemplateId( {}, 'page', 1 );
-
-		expect( getDefaultTemplateId ).toHaveBeenCalledWith( {
-			slug: 'page-hello',
-		} );
-	} );
-
 	it( 'ignores an unsaved slug edit, so typing does not trigger a lookup', () => {
-		const { getDefaultTemplateId } = setup( {
+		const getDefaultTemplateId = setup( {
 			savedSlug: 'hello',
 			editedSlug: 'hell',
 		} );
@@ -118,7 +101,7 @@ describe( 'getTemplateId', () => {
 	} );
 
 	it( 'falls back to the post type template when nothing is saved yet', () => {
-		const { getDefaultTemplateId } = setup( {
+		const getDefaultTemplateId = setup( {
 			savedSlug: undefined,
 			editedSlug: 'draft-in-progress',
 		} );

--- a/packages/core-data/src/test/private-selectors.jsdom.test.js
+++ b/packages/core-data/src/test/private-selectors.jsdom.test.js
@@ -1,5 +1,6 @@
-import { getUndoManager } from '../private-selectors';
+import { getUndoManager, getTemplateId } from '../private-selectors';
 import { getSyncManager } from '../sync';
+import { lock } from '../lock-unlock';
 
 jest.mock( '../sync', () => ( {
 	getSyncManager: jest.fn(),
@@ -59,5 +60,68 @@ describe( 'getUndoManager', () => {
 				},
 			} )
 		).toBe( fallbackUndoManager );
+	} );
+} );
+
+describe( 'getTemplateId', () => {
+	// Builds a registry whose core store returns a post with a saved slug and,
+	// optionally, an unsaved edit to that slug.
+	const setup = ( { savedSlug, editedSlug } ) => {
+		const getDefaultTemplateId = jest.fn().mockReturnValue( 'default-id' );
+		// getHomePage and getPostsPageId are read through unlock(), so the
+		// store selectors need the private ones locked onto them.
+		const storeSelectors = {
+			getEditedEntityRecord: () => ( {
+				slug: editedSlug ?? savedSlug,
+				template: '',
+			} ),
+			getRawEntityRecord: () => ( { slug: savedSlug } ),
+			getEntityRecords: () => [],
+			getDefaultTemplateId,
+		};
+		lock( storeSelectors, {
+			getHomePage: () => ( { postType: 'wp_template', postId: 'home' } ),
+			getPostsPageId: () => null,
+		} );
+		const select = () => storeSelectors;
+
+		// getTemplateId is a registry selector: it resolves its dependencies
+		// through the registry assigned to the selector itself.
+		getTemplateId.registry = { select };
+		return { getDefaultTemplateId };
+	};
+
+	it( 'looks up the template using the saved slug', () => {
+		const { getDefaultTemplateId } = setup( { savedSlug: 'hello' } );
+
+		getTemplateId( {}, 'page', 1 );
+
+		expect( getDefaultTemplateId ).toHaveBeenCalledWith( {
+			slug: 'page-hello',
+		} );
+	} );
+
+	it( 'ignores an unsaved slug edit, so typing does not trigger a lookup', () => {
+		const { getDefaultTemplateId } = setup( {
+			savedSlug: 'hello',
+			editedSlug: 'hell',
+		} );
+
+		getTemplateId( {}, 'page', 1 );
+
+		expect( getDefaultTemplateId ).toHaveBeenCalledWith( {
+			slug: 'page-hello',
+		} );
+	} );
+
+	it( 'falls back to the post type template when nothing is saved yet', () => {
+		const { getDefaultTemplateId } = setup( {
+			savedSlug: undefined,
+			editedSlug: 'draft-in-progress',
+		} );
+
+		getTemplateId( {}, 'page', 1 );
+
+		expect( getDefaultTemplateId ).toHaveBeenCalledWith( { slug: 'page' } );
 	} );
 } );

--- a/packages/core-data/src/test/private-selectors.jsdom.test.js
+++ b/packages/core-data/src/test/private-selectors.jsdom.test.js
@@ -75,7 +75,10 @@ describe( 'getTemplateId', () => {
 				slug: editedSlug ?? savedSlug,
 				template: '',
 			} ),
-			getRawEntityRecord: () => ( { slug: savedSlug } ),
+			// An unsaved record has no raw entry at all, so the selector
+			// returns undefined rather than an object with an empty slug.
+			getRawEntityRecord: () =>
+				savedSlug === undefined ? undefined : { slug: savedSlug },
 			getEntityRecords: () => [],
 			getDefaultTemplateId,
 		};

--- a/packages/core-data/src/test/private-selectors.jsdom.test.js
+++ b/packages/core-data/src/test/private-selectors.jsdom.test.js
@@ -1,6 +1,5 @@
-import { getUndoManager, getTemplateId } from '../private-selectors';
+import { getUndoManager } from '../private-selectors';
 import { getSyncManager } from '../sync';
-import { lock } from '../lock-unlock';
 
 jest.mock( '../sync', () => ( {
 	getSyncManager: jest.fn(),
@@ -60,54 +59,5 @@ describe( 'getUndoManager', () => {
 				},
 			} )
 		).toBe( fallbackUndoManager );
-	} );
-} );
-
-describe( 'getTemplateId', () => {
-	// Stands in for the core store. `getHomePage` and `getPostsPageId` are read
-	// through unlock(), so they are locked onto the same object.
-	const setup = ( { savedSlug, editedSlug } ) => {
-		const getDefaultTemplateId = jest.fn();
-		const storeSelectors = {
-			getEditedEntityRecord: () => ( {
-				slug: editedSlug,
-				template: '',
-			} ),
-			// A record that has never been saved has no raw entry at all.
-			getRawEntityRecord: () =>
-				savedSlug === undefined ? undefined : { slug: savedSlug },
-			getEntityRecords: () => [],
-			getDefaultTemplateId,
-		};
-		lock( storeSelectors, {
-			getHomePage: () => ( { postType: 'wp_template', postId: 'home' } ),
-			getPostsPageId: () => null,
-		} );
-		getTemplateId.registry = { select: () => storeSelectors };
-		return getDefaultTemplateId;
-	};
-
-	it( 'ignores an unsaved slug edit, so typing does not trigger a lookup', () => {
-		const getDefaultTemplateId = setup( {
-			savedSlug: 'hello',
-			editedSlug: 'hell',
-		} );
-
-		getTemplateId( {}, 'page', 1 );
-
-		expect( getDefaultTemplateId ).toHaveBeenCalledWith( {
-			slug: 'page-hello',
-		} );
-	} );
-
-	it( 'falls back to the post type template when nothing is saved yet', () => {
-		const getDefaultTemplateId = setup( {
-			savedSlug: undefined,
-			editedSlug: 'draft-in-progress',
-		} );
-
-		getTemplateId( {}, 'page', 1 );
-
-		expect( getDefaultTemplateId ).toHaveBeenCalledWith( { slug: 'page' } );
 	} );
 } );


### PR DESCRIPTION
## What

Template resolution no longer runs while you type in the slug field. 

Noticed by @Mamaduka in https://github.com/WordPress/gutenberg/pull/78135

### Before

https://github.com/user-attachments/assets/2b446966-71e9-4627-a2b3-43888ba73afc

### After


https://github.com/user-attachments/assets/27444a18-a05e-41ec-aa15-8f46d8790bf4


## Why

`getTemplateId` built its lookup slug from `getEditedEntityRecord`, which includes unsaved edits. Every keystroke produced a new lookup slug. Each distinct query is its own resolver cache key, so each one fired a `GET /wp/v2/templates/lookup` request.

Typing `hello` sent five requests. Four asked about half-typed slugs the user was still in the middle of writing.

The endpoint is a fallback resolver, so each of those returned the same template the post already had. The requests were wasted, not wrong.

## How

Read the slug from `getRawEntityRecord` instead. A slug only selects a template once saved.

The assigned template still comes from the edited record, so picking a template in the UI updates the canvas immediately.

## Testing instructions

Open DevTools, Network tab, filter on `templates/lookup`.

1. Open a saved post or page.
2. Type in the Slug field.
3. On trunk: one request per keystroke, partial slugs visible in the query string (`?slug=page-h`, `?slug=page-he`). With this branch: none.
4. Save. The template resolves once, from the saved slug.

Also check:

- A brand-new draft has no saved slug. It should fall back to the `page` or `single-post` template.
- Changing the template in the sidebar dropdown still updates the canvas straight away.
- After saving a changed slug, the right template still resolves.


