### PR TITLE
Media Fields: Pass the field's disabled state to the textarea controls

### DIFF
--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `alt_text`, `caption`, `description`: Pass the field's disabled state to the textarea control, so disabling one of these fields stops it accepting input. ([#82516](https://github.com/WordPress/gutenberg/pull/82516))
+
 ### Internal
 
 -   Remove unused dependencies `@wordpress/date` and `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/media-fields/src/alt_text/index.tsx
+++ b/packages/media-fields/src/alt_text/index.tsx
@@ -33,6 +33,7 @@ const altTextField: Partial< Field< Updatable< Attachment > > > = {
 						{ __( 'Leave empty if decorative.' ) }
 					</>
 				}
+				disabled={ field.isDisabled( { item: data, field } ) }
 				rows={ 2 }
 			/>
 		);

--- a/packages/media-fields/src/caption/index.tsx
+++ b/packages/media-fields/src/caption/index.tsx
@@ -16,6 +16,7 @@ const captionField: Partial< Field< Updatable< Attachment > > > = {
 				label={ field.label }
 				value={ getRawContent( data.caption ) || '' }
 				onChange={ ( value ) => onChange( { caption: value } ) }
+				disabled={ field.isDisabled( { item: data, field } ) }
 				rows={ 2 }
 			/>
 		);

--- a/packages/media-fields/src/description/index.tsx
+++ b/packages/media-fields/src/description/index.tsx
@@ -18,6 +18,7 @@ const descriptionField: Partial< Field< Updatable< Attachment > > > = {
 				label={ field.label }
 				value={ getRawContent( data.description ) || '' }
 				onChange={ ( value ) => onChange( { description: value } ) }
+				disabled={ field.isDisabled( { item: data, field } ) }
 				rows={ 5 }
 			/>
 		);


### PR DESCRIPTION
## What?

Make the alt text, caption and description fields honour their own disabled state.

Follow-up to https://github.com/WordPress/gutenberg/pull/82417.

## Why?

These three fields render their own textarea rather than one of the DataForm controls, and none of them read `field.isDisabled`. Setting a field disabled left the textarea fully editable, so typing into it looked like it worked while the value went nowhere.

This turned up in #82417, which disables the Details fields while an image edit is saving. The title field greyed out; these three did not.

## How?

Read `field.isDisabled( { item, field } )` and pass it to the control, as the built-in DataForm controls already do.

"Attached to" is left alone. It renders a `ComboboxControl`, which has no control-level `disabled` prop, only a per-option one. `@wordpress/dataviews`' own combobox control skips `isDisabled` for the same reason.

## Testing Instructions

Test through the media editor:

1. Add an Image block, upload an image, and
2. Click the Crop icon in the block toolbar.
3. Open the Details tab, drag the crop area, and click Save.
4. While the save runs, confirm the alt text, caption and description fields are greyed out and refuse typing, the same as the title field above them.
5. Confirm they become editable again once the save finishes, and also if the save fails and the modal stays open.

Alternatively, in Storybook, set `isDisabled: true` on an attachment field and confirm the rendered textarea is disabled.
