### PR TITLE
Block Library: Use 'useEntityProp' in Site Title and Tagline blocks

### DIFF
--- a/packages/block-library/src/site-tagline/edit.jsx
+++ b/packages/block-library/src/site-tagline/edit.jsx
@@ -1,5 +1,5 @@
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import {
 	useBlockProps,
 	BlockControls,
@@ -15,33 +15,24 @@ export default function SiteTaglineEdit( props ) {
 
 	const { attributes, setAttributes, insertBlocksAfter } = props;
 	const { level, levelOptions } = attributes;
-	const { canUserEdit, tagline } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEditedEntityRecord } =
-			select( coreStore );
-		const canEdit = canUser( 'update', {
-			kind: 'root',
-			name: 'site',
-		} );
-		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
-		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			canUserEdit: canEdit,
-			tagline: canEdit
-				? settings?.description
-				: readOnlySettings?.description,
-		};
-	}, [] );
+	const canUserEdit = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
+		[]
+	);
+	// Users who cannot edit the site settings cannot read them either, so the
+	// tagline comes from the base entity instead.
+	const [ tagline, setTagline ] = useEntityProp(
+		'root',
+		canUserEdit ? 'site' : '__unstableBase',
+		'description',
+		undefined
+	);
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
-	const { editEntityRecord } = useDispatch( coreStore );
-
-	function setTagline( newTagline ) {
-		editEntityRecord( 'root', 'site', undefined, {
-			description: newTagline,
-		} );
-	}
-
 	const blockProps = useBlockProps( {
 		className:
 			! canUserEdit && ! tagline && 'wp-block-site-tagline__placeholder',

--- a/packages/block-library/src/site-title/edit.jsx
+++ b/packages/block-library/src/site-title/edit.jsx
@@ -1,5 +1,5 @@
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
 	RichText,
@@ -22,38 +22,31 @@ export default function SiteTitleEdit( props ) {
 	useDeprecatedTextAlign( props );
 
 	const { attributes, setAttributes } = props;
-
 	const { level, levelOptions, isLink, linkTarget } = attributes;
-	const { canUserEdit, title } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEditedEntityRecord } =
-			select( coreStore );
-		const canEdit = canUser( 'update', {
-			kind: 'root',
-			name: 'site',
-		} );
-		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
-		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			canUserEdit: canEdit,
-			title: canEdit ? settings?.title : readOnlySettings?.name,
-		};
-	}, [] );
-	const { editEntityRecord } = useDispatch( coreStore );
+	const canUserEdit = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
+		[]
+	);
+	// Users who cannot edit the site settings cannot read them either, so the
+	// title comes from the base entity instead.
+	const [ title, setSiteTitle ] = useEntityProp(
+		'root',
+		canUserEdit ? 'site' : '__unstableBase',
+		canUserEdit ? 'title' : 'name',
+		undefined
+	);
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const blockEditingMode = useBlockEditingMode();
-
-	function setTitle( newTitle ) {
-		editEntityRecord( 'root', 'site', undefined, {
-			title: newTitle.trim(),
-		} );
-	}
-
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const blockProps = useBlockProps( {
 		className:
 			! canUserEdit && ! title && 'wp-block-site-title__placeholder',
 	} );
+
 	const siteTitleContent = canUserEdit ? (
 		<TagName { ...blockProps }>
 			<RichText
@@ -62,7 +55,7 @@ export default function SiteTitleEdit( props ) {
 				aria-label={ __( 'Site title text' ) }
 				placeholder={ __( 'Write site title…' ) }
 				value={ title }
-				onChange={ setTitle }
+				onChange={ ( newTitle ) => setSiteTitle( newTitle.trim() ) }
 				allowedFormats={ [] }
 				disableLineBreaks
 			/>


### PR DESCRIPTION
## What?
Extracted from #82275.
Requires #82517.

PR refactors Site Title and Tagline blocks to use the `useEntityProp` hook, which provides `value` and its setter callback out of the box. Less code, same results.

## Testing Instructions
1. Create a post or page as an admin role user.
2. Add Site Title and Tagline blocks.
3. Confirm they load the values correctly and that you can edit them.
4. Repeat the same step with an author role user.
5. Confirm blocks load values correctly, and there are no request errors in the console.
6. Confirm that editing is restricted.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

None.
