### PR TITLE
Grid: preserve named widths when the horizontal span is unchanged

### DIFF
--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Preserve `DashboardGrid` layout items' `full` and `fill` widths when a resize ends at its starting horizontal span, including height-only resize gestures.
+
 ### New Features
 
 -   Layout items accept `draggable` and `resizable` flags. A non-draggable

--- a/packages/grid/CHANGELOG.md
+++ b/packages/grid/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Preserve `DashboardGrid` layout items' `full` and `fill` widths when a resize ends at its starting horizontal span, including height-only resize gestures.
+-   Preserve `DashboardGrid` layout items' `full` and `fill` widths when a resize ends at its starting horizontal span, including height-only resize gestures. ([#82522](https://github.com/WordPress/gutenberg/pull/82522))
 
 ### New Features
 

--- a/packages/grid/src/dashboard-grid/index.tsx
+++ b/packages/grid/src/dashboard-grid/index.tsx
@@ -153,6 +153,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 		const resizeBaselineRef = useRef< {
 			width: number;
 			height: number;
+			storedWidth: DashboardGridLayoutItem[ 'width' ];
 		} | null >( null );
 		const captureLayoutSnapshotRef = useRef< () => void >( () => {} );
 		const childrenCacheRef = useRef< Map< string, React.ReactElement > >(
@@ -533,8 +534,8 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			if ( ! resizeBaselineRef.current ) {
 				const baseItem = layoutMap.get( id );
 				const resolvedItem = resolvedItemMap.get( id );
-				// `'fill'`/`'full'` resize from the rendered span
-				// and convert to a numeric width.
+				// `'fill'`/`'full'` resize from the rendered span. Keep
+				// their stored meaning unless the horizontal span changes.
 				let baseWidth: number;
 				if ( baseItem?.width === 'full' ) {
 					baseWidth = bounds?.maxWidth ?? effectiveColumns;
@@ -549,6 +550,8 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 				resizeBaselineRef.current = {
 					width: baseWidth,
 					height: baseItem?.height ?? 1,
+					storedWidth: layout.find( ( item ) => item.key === id )
+						?.width,
 				};
 			}
 			const baseline = resizeBaselineRef.current;
@@ -562,6 +565,12 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 				bounds?.minHeight ?? 1,
 				bounds?.maxHeight ?? Infinity
 			);
+			const committedWidth =
+				newWidth === baseline.width &&
+				( baseline.storedWidth === 'full' ||
+					baseline.storedWidth === 'fill' )
+					? baseline.storedWidth
+					: newWidth;
 
 			setResizeSnapPreview( {
 				id,
@@ -584,7 +593,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			const currentItem = pendingItem ?? layoutMap.get( id );
 			if (
 				currentItem &&
-				currentItem.width === newWidth &&
+				currentItem.width === committedWidth &&
 				( currentItem.height ?? 1 ) === newHeight
 			) {
 				return;
@@ -596,7 +605,7 @@ export const DashboardGrid = forwardRef< HTMLDivElement, DashboardGridProps >(
 			const updatedLayout = ( latestLayoutRef.current ?? layout ).map(
 				( item ) =>
 					item.key === id
-						? { ...item, width: newWidth, height: newHeight }
+						? { ...item, width: committedWidth, height: newHeight }
 						: item
 			);
 

--- a/packages/grid/src/dashboard-grid/test/item-limits.jsdom.test.tsx
+++ b/packages/grid/src/dashboard-grid/test/item-limits.jsdom.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import { DashboardGrid } from '..';
-import type { DashboardGridLayoutItem } from '../types';
+import type { DashboardGridLayoutItem, DashboardGridProps } from '../types';
 
 class MockResizeObserver {
 	observe() {}
@@ -142,6 +142,137 @@ describe( 'DashboardGrid item limits', () => {
 		expect( committed.find( ( item ) => item.key === 'a' )?.width ).toBe(
 			1
 		);
+	} );
+} );
+
+describe( 'DashboardGrid resized width semantics', () => {
+	function renderResizableItem(
+		width: DashboardGridLayoutItem[ 'width' ],
+		props: Partial< DashboardGridProps > = {}
+	) {
+		const onChangeLayout = jest.fn();
+		const onPreviewLayout = jest.fn();
+		const { container } = render(
+			<DashboardGrid
+				layout={ [ { key: 'tile', width, height: 1 } ] }
+				columns={ 1 }
+				rowHeight={ 20 }
+				editMode
+				onChangeLayout={ onChangeLayout }
+				onPreviewLayout={ onPreviewLayout }
+				{ ...props }
+			>
+				<div key="tile">Tile</div>
+			</DashboardGrid>
+		);
+		const handle = container.querySelector(
+			'[data-wp-grid-item-key="tile"] [aria-roledescription="draggable"]'
+		)!;
+		return { handle, onChangeLayout, onPreviewLayout };
+	}
+
+	async function resizeWithKeyboard( handle: Element, keys: string[] ) {
+		fireEvent.keyDown( handle, { code: 'Space' } );
+		act( () => {
+			jest.runOnlyPendingTimers();
+		} );
+		for ( const code of keys ) {
+			fireEvent.keyDown( handle, { code } );
+			// Deliver each throttled resize before the next key or drop.
+			act( () => {
+				jest.advanceTimersByTime( 20 );
+			} );
+		}
+		fireEvent.keyDown( handle, { code: 'Space' } );
+		await act( async () => {
+			jest.runOnlyPendingTimers();
+		} );
+	}
+
+	it.each( [ 'full', 'fill' ] as const )(
+		'preserves %s when only the height changes in one column',
+		async ( width ) => {
+			const { handle, onChangeLayout } = renderResizableItem( width );
+
+			await resizeWithKeyboard( handle, [ 'ArrowDown' ] );
+
+			expect( onChangeLayout ).toHaveBeenCalledTimes( 1 );
+			expect( onChangeLayout ).toHaveBeenLastCalledWith( [
+				{ key: 'tile', width, height: 2 },
+			] );
+		}
+	);
+
+	it.each( [ 'full', 'fill' ] as const )(
+		'does not commit %s when movement stays within the starting span',
+		async ( width ) => {
+			const { handle, onChangeLayout, onPreviewLayout } =
+				renderResizableItem( width, { rowHeight: 300 } );
+
+			await resizeWithKeyboard( handle, [ 'ArrowDown', 'ArrowRight' ] );
+
+			expect( onChangeLayout ).not.toHaveBeenCalled();
+			expect( onPreviewLayout ).not.toHaveBeenCalled();
+		}
+	);
+
+	it.each( [ 'full', 'fill' ] as const )(
+		'converts %s to a numeric width after a horizontal span change',
+		async ( width ) => {
+			const { handle, onChangeLayout } = renderResizableItem( width, {
+				columns: 3,
+			} );
+
+			// Three columns in 240px have an 88px track including the gap.
+			await resizeWithKeyboard( handle, Array( 4 ).fill( 'ArrowLeft' ) );
+
+			expect( onChangeLayout ).toHaveBeenLastCalledWith( [
+				{ key: 'tile', width: 2, height: 1 },
+			] );
+		}
+	);
+
+	it.each( [ 'full', 'fill' ] as const )(
+		'restores %s when the horizontal resize returns to its starting span',
+		async ( width ) => {
+			const { handle, onChangeLayout, onPreviewLayout } =
+				renderResizableItem( width, { columns: 3 } );
+
+			await resizeWithKeyboard( handle, [
+				...Array( 4 ).fill( 'ArrowLeft' ),
+				...Array( 4 ).fill( 'ArrowRight' ),
+			] );
+
+			expect( onPreviewLayout ).toHaveBeenCalledWith( [
+				{ key: 'tile', width: 2, height: 1 },
+			] );
+			expect( onChangeLayout ).toHaveBeenLastCalledWith( [
+				{ key: 'tile', width, height: 1 },
+			] );
+		}
+	);
+
+	it( 'commits the rendered numeric width when height changes', async () => {
+		const { handle, onChangeLayout } = renderResizableItem( 4 );
+
+		await resizeWithKeyboard( handle, [ 'ArrowDown' ] );
+
+		expect( onChangeLayout ).toHaveBeenLastCalledWith( [
+			{ key: 'tile', width: 1, height: 2 },
+		] );
+	} );
+
+	it( 'preserves full when height changes at a maximum width limit', async () => {
+		const { handle, onChangeLayout } = renderResizableItem( 'full', {
+			columns: 3,
+			itemLimits: { tile: { maxWidth: 80 } },
+		} );
+
+		await resizeWithKeyboard( handle, [ 'ArrowDown' ] );
+
+		expect( onChangeLayout ).toHaveBeenLastCalledWith( [
+			{ key: 'tile', width: 'full', height: 2 },
+		] );
 	} );
 } );
 /* eslint-enable testing-library/no-container, testing-library/no-node-access */


### PR DESCRIPTION
## What?

Preserve a `DashboardGrid` item's `full` or `fill` width when a resize finishes at its starting horizontal span. Height-only resizing keeps the named width, and returning to the starting span within a gesture restores it.

Related to the [resize contract discussed in #81899](https://github.com/WordPress/gutenberg/pull/81899#discussion_r3871236958).

## Why?

A full-width tile can lose that intent when only its height changes. In a one-column container, the resize callback replaces `full` with numeric `1`. Widening the container then leaves the tile occupying one column. `fill` has the same problem. Even movement below the next snap threshold can stage a numeric width change.

## How?

Snapshot the stored width token alongside the rendered numeric gesture baseline. Keep the token when the final horizontal span matches that baseline; otherwise keep the existing numeric resize result. Pixel calculations, numeric-width clamping and untouched neighbors retain their existing behavior.

Please review the interpretation of resize intent: actual horizontal changes convert named widths to numbers, while returning to the starting span restores the original token. A reversal after an intermediate preview can still emit the restored layout through the existing callback lifecycle. This adds no width-choice API and does not change `DashboardLanes`.

## Testing Instructions

After rebasing onto trunk `980605ca93`, all Grid Vitest tests pass (98 tests), and changed-file lint passes. These focused checks ran on the available Node 24.12 environment with npm's engine gate bypassed because the host is below trunk's current Node 24.18 and npm 11.16 minimums; GitHub CI is validating the supported Node 24 and 26 matrix. Before the rebase, the previous head also passed the full repository type check. Seven regression cases fail on the unchanged handler and pass with this correction. The standalone package fixture builds for both versions; a full Gutenberg production build was not run for this patch.

```sh
npm run test:unit:vitest -- packages/grid
npm run lint:js -- packages/grid/src/dashboard-grid/index.tsx packages/grid/src/dashboard-grid/test/item-limits.jsdom.test.tsx
npm run typecheck
```

1. In a package harness or Grid story, render a controlled `DashboardGrid` with one tile, `columns={ 2 }`, `minColumnWidth={ 400 }`, `rowHeight={ 80 }` and edit mode enabled. Set `--wp-grid-gap: 24px` on the harness wrapper. Start with `{ key: 'tile', width: 'full', height: 2 }`. Display the committed layout and record `onPreviewLayout` callbacks.
2. Set the container to 320px. Drag the default resize handle straight down by one row, without horizontal movement. The result should be `{ width: 'full', height: 3 }`.
3. Widen the container to 992px. The tile should span both columns. Repeat starting with `fill` and confirm that the callback retains `fill`.
4. Start full-width in the wide container and resize horizontally to one column. The result should be numeric `1`. Reset the tile to `full`, then shrink and return to the starting span in one gesture before releasing; the result should retain `full`.
5. Repeat with movement that never crosses a snap threshold. There should be no new layout preview or commit. Numeric clamping, capped full-width tiles and untouched neighbors are covered by the component tests.

<details>
<summary>Minimal controlled setup</summary>

```tsx
import { useState } from '@wordpress/element';
import { DashboardGrid } from '@wordpress/grid';
import type { DashboardGridLayoutItem } from '@wordpress/grid';

function WidthResizeExample() {
    const [ narrow, setNarrow ] = useState( true );
    const [ layout, setLayout ] = useState< DashboardGridLayoutItem[] >( [
        { key: 'tile', width: 'full', height: 2 },
    ] );

    return (
        <>
            <button onClick={ () => setNarrow( ! narrow ) }>
                { narrow ? 'Widen container' : 'Narrow container' }
            </button>
            <div
                className="width-resize-example"
                style={ { width: narrow ? 320 : 992 } }
            >
                <DashboardGrid
                    layout={ layout }
                    columns={ 2 }
                    minColumnWidth={ 400 }
                    rowHeight={ 80 }
                    editMode
                    onPreviewLayout={ ( next ) => console.log( 'preview', next ) }
                    onChangeLayout={ setLayout }
                >
                    <div key="tile">Tile</div>
                </DashboardGrid>
            </div>
            <pre>{ JSON.stringify( layout, null, 2 ) }</pre>
        </>
    );
}
```

```css
.width-resize-example {
    --wp-grid-gap: 24px;
}
```

</details>

### Testing Instructions for Keyboard

1. Focus the resize handle and press Space to pick it up. Use ArrowDown until the preview gains one row, then Space to finish. Confirm that the named width remains unchanged.
2. In the wide container, use ArrowLeft to reach a smaller horizontal span and finish. Confirm that the width is numeric.
3. Reset the tile to `full`. Shrink with ArrowLeft and return to the starting span with ArrowRight before finishing. Confirm that `full` is restored.

The mounted regressions exercise the real keyboard sensor with supplied geometry. The browser comparison used pointer input; full keyboard and assistive-technology qualification was not performed.

## Screenshots or screencast

The package-only browser comparison used the same vertical pointer movement for both versions. Height changed from 2 to 3 before widening the container to 992px:

| Before | After |
| --- | --- |
| ![Before: a height-only resize saves width 1, leaving the tile at 484px after widening.](https://github.com/user-attachments/assets/3b6b41ea-7354-4169-929d-dbfbbacdefb7) | ![After: the same resize preserves full, leaving the tile at 992px after widening.](https://github.com/user-attachments/assets/99763603-916b-4584-b8ce-0d9cf0aff787) |
| Saved width `1`; tile rendered at 484px. | Saved width `full`; tile rendered at 992px. |

Both results survived the fixture's localStorage reload. The candidate also retained `fill` through narrow resizing, widening and reload. These checks cover a one-tile package fixture, not a host persistence integration or multi-row fill reflow with siblings. Neighbor stability is component-tested.

## Use of AI Tools

I used OpenAI Codex to investigate, implement and test this change, and to prepare this description.
