### PR TITLE
Docs: Document isolated worktree setup

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -9,6 +9,10 @@ description: Use when writing, running, or debugging tests in the Gutenberg repo
 
 Before writing any test bodies, draft the test names — behavior from the user's perspective, one behavior per case (see [Describing tests](../../../docs/contributors/code/testing-overview.md#describing-tests)) — and confirm the list with the author. Every proposed case must trace to the behavior being added or changed; do not pad the list with adjacent or unrelated coverage. If working unattended, put the proposed list in your summary for review instead.
 
+## Prepare isolated worktrees once
+
+Before the first focused test or commit in a fresh or isolated worktree, complete the setup in the root `AGENTS.md`. Confirm that the required test runner and generated package artifacts are available. Do not use dependencies or generated artifacts from another lockfile revision as verification evidence; run the repository setup in this worktree instead. If installation skipped lifecycle scripts and a commit is in scope, run `npm run prepare` before committing. Build only the package artifacts required by the focused test.
+
 ## Never make a failing test pass by weakening it
 
 No loosened assertions, no added waits or timeouts, no skipped cases without saying so. Diagnose the root cause, or report the failure honestly.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -9,10 +9,6 @@ description: Use when writing, running, or debugging tests in the Gutenberg repo
 
 Before writing any test bodies, draft the test names — behavior from the user's perspective, one behavior per case (see [Describing tests](../../../docs/contributors/code/testing-overview.md#describing-tests)) — and confirm the list with the author. Every proposed case must trace to the behavior being added or changed; do not pad the list with adjacent or unrelated coverage. If working unattended, put the proposed list in your summary for review instead.
 
-## Prepare isolated worktrees once
-
-Before the first focused test or commit in a fresh or isolated worktree, complete the setup in the root `AGENTS.md`. Confirm that the required test runner and generated package artifacts are available. Do not use dependencies or generated artifacts from another lockfile revision as verification evidence; run the repository setup in this worktree instead. If installation skipped lifecycle scripts and a commit is in scope, run `npm run prepare` before committing. Build only the package artifacts required by the focused test.
-
 ## Never make a failing test pass by weakening it
 
 No loosened assertions, no added waits or timeouts, no skipped cases without saying so. Diagnose the root cause, or report the failure honestly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ npm start     # Development with watch
 npm run build # Production build; emits types with --noCheck, does NOT type check
 ```
 
+Before verification or a commit in a fresh Git worktree, follow the [worktree setup instructions](docs/contributors/code/getting-started-with-code-contribution.md#set-up-each-worktree).
+
 `npm run build` never fails on type errors. After changing TypeScript or checked JS, run `npm run typecheck`.
 
 ### Key Directories

--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -42,6 +42,12 @@ npm run dev
 
 > Note: The install scripts require [Python](https://www.python.org/) to be installed and in the path of the local system. This might be installed by default for your operating system, or require downloading and installing.
 
+### Set up each worktree
+
+Install dependencies in each fresh Git worktree before you build, test, lint, or commit. Do not reuse `node_modules` or generated package files from a worktree whose `package-lock.json` is at a different revision. Results from that setup might not match the current checkout.
+
+If you install dependencies with `--ignore-scripts`, run `npm run prepare` before committing so Husky installs the repository Git hooks. If a focused command needs generated package files, build the affected package in the current worktree before you interpret its result.
+
 There are two ways to build your code. While developing, you probably will want to use `npm run dev` to run continuous builds automatically as source files change. The dev build also includes additional warnings and errors to help troubleshoot while developing. Once you are happy with your changes, you can run `npm run build` to create optimized production build.
 
 Once built, Gutenberg is ready to be used as a WordPress plugin!


### PR DESCRIPTION
## What?

Document how to prepare a fresh Git worktree before verification or a commit.

## Why?

Several agent runs lost time or produced unreliable verification when a fresh worktree lacked dependencies, generated package files, or Husky hooks. This setup applies across repository work, not only testing.

## How?

The contributor guide now covers dependency installation in each worktree, cross-revision dependency reuse, skipped lifecycle scripts, and focused package builds. Root `AGENTS.md` links to that guidance so every agent sees it, while the testing skill remains task-specific.

## Testing Instructions

1. Follow the new link in root `AGENTS.md` and confirm it opens the "Set up each worktree" section.
2. Run `npm run agents:setup -- --if-safe` and confirm it does not create tracked changes.
3. Run `git diff --check origin/trunk...HEAD`.

The existing contributor guide has unrelated Markdown lint violations outside the changed lines. This change adds no new lint findings.

## Use of AI Tools

Codex was used to assess the skill report, draft this change, and run the listed checks.
