### PR TITLE
Theme: Build default ramps before token artifacts

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Internal
 
+-   Generate the default ramps before derived token artifacts so one build uses the current ramp algorithm throughout.
 -   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))
 -   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
 

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Internal
 
--   Generate the default ramps before derived token artifacts so one build uses the current ramp algorithm throughout.
+-   Generate the default ramps before derived token artifacts so one build uses the current ramp algorithm throughout. ([#82525](https://github.com/WordPress/gutenberg/pull/82525))
 -   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))
 -   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -222,10 +222,11 @@ This package is built in two steps. When `npm run build` is run at the root of t
 
 This step will:
 
-1. Generate primitive tokens.
-2. Build CSS and JavaScript token files.
-3. Update the design tokens documentation.
-4. Format all generated files.
+1. Generate default color ramps.
+2. Generate primitive tokens.
+3. Build CSS and JavaScript token files.
+4. Update the design tokens documentation.
+5. Format all generated files.
 
 The files generated in this step will all be committed to the repo.
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -146,7 +146,7 @@
 	"scripts": {
 		"build:default-ramps": "node --import=esbuild-esm-loader/register bin/generate-default-ramps/index.ts",
 		"build:tokens": "node --import=esbuild-esm-loader/register bin/generate-primitive-tokens/index.ts && node --import=esbuild-esm-loader/register bin/build-design-tokens/index.ts",
-		"build": "npm run build:tokens && npm run build:default-ramps",
+		"build": "npm run build:default-ramps && npm run build:tokens",
 		"lint:package-contents": "wp-validate-package-contents . --disallow-path src",
 		"postbuild": "prettier --write tokens/color.json tokens/modes prebuilt src/prebuilt src/color-ramps/lib/default-ramps.ts docs ../base-styles/internal/_wpds-token-fallbacks.scss"
 	}


### PR DESCRIPTION
Split from #82294.

## What?

Runs `build:default-ramps` before `build:tokens` in `@wordpress/theme` and updates the build documentation.

## Why?

Token fallback generation imports `src/color-ramps/lib/default-ramps.ts`. Running `build:tokens` first can generate token artifacts from stale ramps and require a second build to converge.

## How?

Reorders the existing build scripts. This does not change ramp values or solver code.

## Testing Instructions

1. Run `npm run build --workspace @wordpress/theme`.
2. Confirm the generated artifacts are unchanged:
   ```sh
   git diff --exit-code HEAD -- packages/theme/tokens packages/theme/prebuilt packages/theme/src/prebuilt packages/theme/src/color-ramps/lib/default-ramps.ts packages/theme/docs packages/base-styles/internal/_wpds-token-fallbacks.scss
   ```
3. Repeat steps 1 and 2. Both artifact checks should exit cleanly.

### Testing Instructions for Keyboard

Not applicable. This PR does not change the UI.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to inspect the build dependency, make the scoped edits, run the two-build verification, and draft this description.
