### PR TITLE
Theme: Clarify color seed and warning guarantees

### DIFF
--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -106,7 +106,9 @@ The `color` prop accepts an object with the following optional properties:
 -   `primary`: The primary/accent seed color (default: `'#3858e9'`).
 -   `background`: The background seed color (default: `'#fcfcfc'`).
 
-Both properties accept a fully opaque sRGB-parseable string: a hex value (e.g. `#3858e9`), an `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Non-opaque alpha values, `transparent`, and other CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and will throw an error. The theme system automatically generates appropriate color ramps from these seed colors.
+Both properties accept a fully opaque sRGB-parseable string: a hex value (e.g. `#3858e9`), an `rgb()`/`rgba()` string, or a CSS named color (e.g. `'blue'`). Non-opaque alpha values, `transparent`, and other CSS color spaces (e.g. `hsl()`, `oklch()`, `lab()`) are not accepted and will throw an error.
+
+The seed values guide the generated color ramps but are not guaranteed to appear unchanged in the resulting tokens. The ramp builder may adjust their lightness to meet its contrast targets.
 
 Use `onColorWarnings` to receive structured warnings after the provider calculates its colors. Warnings identify generated ramp steps or semantic foreground/background pairs that do not meet their contrast targets:
 
@@ -124,7 +126,7 @@ Use `onColorWarnings` to receive structured warnings after the provider calculat
 </ThemeProvider>
 ```
 
-The callback receives an empty array when all checked targets are met. Ramp warnings identify the affected ramp and step. Contrast warnings identify the semantic foreground/background token pair and include the required and achieved contrast values. React may invoke the callback more than once in development under Strict Mode.
+The callback reports failures from the generated ramp checks and a defined set of semantic foreground/background pairs. It does not validate every possible token pairing. It receives an empty array when all checked targets are met. Ramp warnings identify the affected ramp and step. Contrast warnings identify the semantic foreground/background token pair and include the required and achieved contrast values. React may invoke the callback more than once in development under Strict Mode.
 
 The `cursor` prop accepts an object with the following optional properties:
 

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -5,7 +5,9 @@ export type CornerRadiusPreset = 'none' | 'subtle' | 'moderate' | 'pronounced';
 
 export interface ThemeProviderSettings {
 	/**
-	 * The set of color options to apply to the theme.
+	 * Seeds for the generated theme colors. The ramp builder may adjust their
+	 * lightness to meet its contrast targets, so generated tokens are not
+	 * guaranteed to contain the seeds unchanged.
 	 */
 	color?: {
 		/**
@@ -75,8 +77,10 @@ export interface ThemeProviderProps extends ThemeProviderSettings {
 	children?: ReactNode;
 
 	/**
-	 * Called after the provider calculates its colors. Receives an empty array
-	 * when all contrast targets are met.
+	 * Called after the provider calculates its colors. Reports failures from the
+	 * generated ramp checks and defined semantic foreground/background pairs. It
+	 * does not validate every possible token pairing. Receives an empty array
+	 * when all checked targets are met.
 	 * The callback may run more than once in development under React Strict Mode.
 	 */
 	onColorWarnings?: (


### PR DESCRIPTION
Follow up to #82294.

## What?

Clarifies that `ThemeProvider` color seeds guide generated ramps but may be lightness-adjusted, and that `onColorWarnings` reports the defined ramp and semantic-pair checks rather than every possible token pairing.

## Why?

The current documentation can imply that generated tokens preserve seed values exactly and that an empty warnings array validates every token combination. Neither is guaranteed by the current implementation.

## How?

Updates the package README and public type comments only. Runtime behavior, types, and public APIs are unchanged.

## Testing Instructions

1. Read the `ThemeProvider` section in `packages/theme/README.md`.
2. Confirm that the seed and warning limits match the corresponding comments in `packages/theme/src/types.ts`.

## Use of AI Tools

OpenAI Codex verified the implementation, edited the documentation and type comments, ran the checks, and drafted this pull request.
