### PR TITLE
DataForm: Add a `showPlaceholderIfEmpty` option to the panel layout

### DIFF
--- a/backport-changelog/7.2/13438.md
+++ b/backport-changelog/7.2/13438.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13438
+
+* https://github.com/WordPress/gutenberg/pull/82527

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php
@@ -10,7 +10,7 @@
  * view configuration for a given entity type.
  *
  * Extends the 7.1 controller to describe the table column styles in the
- * item schema.
+ * item schema and to add the `empty` option of the panel form layout.
  *
  * @since 7.2.0
  *
@@ -47,6 +47,28 @@ class Gutenberg_REST_View_Config_Controller_7_2 extends Gutenberg_REST_View_Conf
 		$schema = parent::get_table_layout_schema();
 
 		$schema['properties']['styles']['description'] = __( 'Column styles keyed by field id, for the columns listed in the view fields. The primary column (title, media, and description fields) ignores these styles; in the table layout it takes the width left over by the other columns, or the last column does when there is no primary column.', 'gutenberg' );
+
+		return $schema;
+	}
+
+	/**
+	 * Returns the schema for a form layout object.
+	 *
+	 * @since 7.2.0 Added the `empty` property to the panel layout.
+	 *
+	 * @return array Schema for a form layout object.
+	 */
+	protected function get_form_layout_schema() {
+		$schema = parent::get_form_layout_schema();
+
+		foreach ( $schema['oneOf'] as $index => $layout ) {
+			if ( array( 'panel' ) === $layout['properties']['type']['enum'] ) {
+				$schema['oneOf'][ $index ]['properties']['empty'] = array(
+					'type' => 'string',
+					'enum' => array( 'render', 'placeholder' ),
+				);
+			}
+		}
 
 		return $schema;
 	}

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php
@@ -10,7 +10,8 @@
  * view configuration for a given entity type.
  *
  * Extends the 7.1 controller to describe the table column styles in the
- * item schema and to add the `empty` option of the panel form layout.
+ * item schema and to add the `showPlaceholderIfEmpty` option of the panel
+ * form layout.
  *
  * @since 7.2.0
  *
@@ -54,7 +55,7 @@ class Gutenberg_REST_View_Config_Controller_7_2 extends Gutenberg_REST_View_Conf
 	/**
 	 * Returns the schema for a form layout object.
 	 *
-	 * @since 7.2.0 Added the `empty` property to the panel layout.
+	 * @since 7.2.0 Added the `showPlaceholderIfEmpty` property to the panel layout.
 	 *
 	 * @return array Schema for a form layout object.
 	 */
@@ -63,9 +64,8 @@ class Gutenberg_REST_View_Config_Controller_7_2 extends Gutenberg_REST_View_Conf
 
 		foreach ( $schema['oneOf'] as $index => $layout ) {
 			if ( array( 'panel' ) === $layout['properties']['type']['enum'] ) {
-				$schema['oneOf'][ $index ]['properties']['empty'] = array(
-					'type' => 'string',
-					'enum' => array( 'render', 'placeholder' ),
+				$schema['oneOf'][ $index ]['properties']['showPlaceholderIfEmpty'] = array(
+					'type' => 'boolean',
 				);
 			}
 		}

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Enhancements
 
+-   DataForm: Add an `empty` option to the `panel` layout. `empty: 'placeholder'` shows the field's `placeholder` in the summary when the value is empty ([#82527](https://github.com/WordPress/gutenberg/pull/82527)).
 -   Give unselected multi-selection filter indicators solid, themed backgrounds. ([#82391](https://github.com/WordPress/gutenberg/pull/82391))
 -   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring and border ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   DataForm: Communicate the timezone a `datetime` value is edited in. When the site timezone differs from the visitor's, the control renders help text under the input naming the site timezone: the zone name (e.g. `(CEST) Europe/Madrid`) or the UTC offset for sites pinned to one ([#82291](https://github.com/WordPress/gutenberg/pull/82291)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### Enhancements
 
--   DataForm: Add an `empty` option to the `panel` layout. `empty: 'placeholder'` shows the field's `placeholder` in the summary when the value is empty ([#82527](https://github.com/WordPress/gutenberg/pull/82527)).
+-   DataForm: Add a `showPlaceholderIfEmpty` option to the `panel` layout, which shows the field's `placeholder` in the summary when the value is empty ([#82527](https://github.com/WordPress/gutenberg/pull/82527)).
 -   Give unselected multi-selection filter indicators solid, themed backgrounds. ([#82391](https://github.com/WordPress/gutenberg/pull/82391))
 -   Validated form controls: Use `--wpds-color-stroke-interactive-error` for the invalid-state focus ring and border ([#82410](https://github.com/WordPress/gutenberg/pull/82410)).
 -   DataForm: Communicate the timezone a `datetime` value is edited in. When the site timezone differs from the visitor's, the control renders help text under the input naming the site timezone: the zone name (e.g. `(CEST) Europe/Madrid`) or the UTC offset for sites pinned to one ([#82291](https://github.com/WordPress/gutenberg/pull/82291)).

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -2200,6 +2200,7 @@ For example:
 -   `type`: `panel`. Required.
 -   `labelPosition`: one of `side`, `top`, or `none`. Optional. `side` by default.
 -   `editVisibility`: one of `always`, or `on-hover`. Optional. `on-hover` by default.
+-   `empty`: one of `render`, or `placeholder`. Optional. `render` by default. What the summary shows when the field's value is `undefined`, `null`, or an empty string: the field's `render` output, or the field's `placeholder`.
 -   `openAs`: one of `dropdown`, `modal`. Optional. `dropdown` by default.
 -   `summary`: Summary field configuration. Optional. Specifies which field(s) to display in the panel header. Can be:
     -   A string (single field ID)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -2200,7 +2200,7 @@ For example:
 -   `type`: `panel`. Required.
 -   `labelPosition`: one of `side`, `top`, or `none`. Optional. `side` by default.
 -   `editVisibility`: one of `always`, or `on-hover`. Optional. `on-hover` by default.
--   `empty`: one of `render`, or `placeholder`. Optional. `render` by default. What the summary shows when the field's value is `undefined`, `null`, or an empty string: the field's `render` output, or the field's `placeholder`.
+-   `showPlaceholderIfEmpty`: boolean. Optional. `false` by default. Whether the summary shows the field's `placeholder` instead of its `render` output when the field's value is `undefined`, `null`, or an empty string.
 -   `openAs`: one of `dropdown`, `modal`. Optional. `dropdown` by default.
 -   `summary`: Summary field configuration. Optional. Specifies which field(s) to display in the panel header. Can be:
     -   A string (single field ID)

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -77,6 +77,7 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			openAs: normalizedOpenAs,
 			summary: normalizedSummary,
 			editVisibility: layout?.editVisibility ?? 'on-hover',
+			empty: layout?.empty ?? 'render',
 		} satisfies NormalizedPanelLayout;
 	} else if ( layout?.type === 'card' ) {
 		if ( layout.withHeader === false ) {

--- a/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/normalize-form.ts
@@ -77,7 +77,7 @@ function normalizeLayout( layout?: Layout ): NormalizedLayout {
 			openAs: normalizedOpenAs,
 			summary: normalizedSummary,
 			editVisibility: layout?.editVisibility ?? 'on-hover',
-			empty: layout?.empty ?? 'render',
+			showPlaceholderIfEmpty: layout?.showPlaceholderIfEmpty ?? false,
 		} satisfies NormalizedPanelLayout;
 	} else if ( layout?.type === 'card' ) {
 		if ( layout.withHeader === false ) {

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -32,8 +32,7 @@
 			opacity: 1;
 		}
 
-		.dataforms-layouts-panel__field-label,
-		.dataforms-layouts-panel__field-placeholder {
+		.dataforms-layouts-panel__field-label {
 			color: var(--wpds-color-foreground-interactive-brand);
 		}
 	}
@@ -146,11 +145,6 @@
 	> * {
 		min-width: 0;
 	}
-}
-
-.dataforms-layouts-panel__field-placeholder {
-	color: var(--wpds-color-foreground-content-neutral-weak);
-	font-weight: var(--wpds-typography-font-weight-default);
 }
 
 .dataforms-layouts-panel__field-trigger--label-top

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -32,7 +32,8 @@
 			opacity: 1;
 		}
 
-		.dataforms-layouts-panel__field-label {
+		.dataforms-layouts-panel__field-label,
+		.dataforms-layouts-panel__field-placeholder {
 			color: var(--wpds-color-foreground-interactive-brand);
 		}
 	}
@@ -145,6 +146,11 @@
 	> * {
 		min-width: 0;
 	}
+}
+
+.dataforms-layouts-panel__field-placeholder {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	font-weight: var(--wpds-typography-font-weight-default);
 }
 
 .dataforms-layouts-panel__field-trigger--label-top

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -16,16 +16,16 @@ import getFirstValidationError from './utils/get-first-validation-error';
 function SummaryValue< Item >( {
 	item,
 	field,
-	showPlaceholder,
+	showPlaceholderIfEmpty,
 }: {
 	item: Item;
 	field: NormalizedField< Item >;
-	showPlaceholder: boolean;
+	showPlaceholderIfEmpty: boolean;
 } ) {
 	// The same notion of empty as the `required` validator: a field whose
 	// empty value differs (an id of `0`, an object) normalizes it in `getValue`.
 	if (
-		showPlaceholder &&
+		showPlaceholderIfEmpty &&
 		field.placeholder &&
 		[ undefined, null, '' ].includes( field.getValue( { item } ) )
 	) {
@@ -60,9 +60,8 @@ export default function SummaryButton< Item >( {
 	isOpen: boolean;
 	onClick: () => void;
 } ) {
-	const { labelPosition, editVisibility, empty } =
+	const { labelPosition, editVisibility, showPlaceholderIfEmpty } =
 		field.layout as NormalizedPanelLayout;
-	const showPlaceholder = empty === 'placeholder';
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
 	const labelClassName = getLabelClassName( labelPosition, showError );
@@ -136,7 +135,9 @@ export default function SummaryButton< Item >( {
 								<SummaryValue
 									item={ data }
 									field={ summaryField }
-									showPlaceholder={ showPlaceholder }
+									showPlaceholderIfEmpty={
+										showPlaceholderIfEmpty
+									}
 								/>
 							</span>
 						) ) }
@@ -147,7 +148,7 @@ export default function SummaryButton< Item >( {
 							key={ summaryField.id }
 							item={ data }
 							field={ summaryField }
-							showPlaceholder={ showPlaceholder }
+							showPlaceholderIfEmpty={ showPlaceholderIfEmpty }
 						/>
 					) )
 				) }

--- a/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/components/dataform-layouts/panel/summary-button.tsx
@@ -13,6 +13,32 @@ import getLabelClassName from './utils/get-label-classname';
 import FieldLabelContent from './field-label-content';
 import getFirstValidationError from './utils/get-first-validation-error';
 
+function SummaryValue< Item >( {
+	item,
+	field,
+	showPlaceholder,
+}: {
+	item: Item;
+	field: NormalizedField< Item >;
+	showPlaceholder: boolean;
+} ) {
+	// The same notion of empty as the `required` validator: a field whose
+	// empty value differs (an id of `0`, an object) normalizes it in `getValue`.
+	if (
+		showPlaceholder &&
+		field.placeholder &&
+		[ undefined, null, '' ].includes( field.getValue( { item } ) )
+	) {
+		return (
+			<span className="dataforms-layouts-panel__field-placeholder">
+				{ field.placeholder }
+			</span>
+		);
+	}
+
+	return <field.render item={ item } field={ field } />;
+}
+
 export default function SummaryButton< Item >( {
 	data,
 	field,
@@ -34,8 +60,9 @@ export default function SummaryButton< Item >( {
 	isOpen: boolean;
 	onClick: () => void;
 } ) {
-	const { labelPosition, editVisibility } =
+	const { labelPosition, editVisibility, empty } =
 		field.layout as NormalizedPanelLayout;
+	const showPlaceholder = empty === 'placeholder';
 	const errorMessage = getFirstValidationError( validity );
 	const showError = touched && !! errorMessage;
 	const labelClassName = getLabelClassName( labelPosition, showError );
@@ -106,19 +133,21 @@ export default function SummaryButton< Item >( {
 								key={ summaryField.id }
 								style={ { width: '100%' } }
 							>
-								<summaryField.render
+								<SummaryValue
 									item={ data }
 									field={ summaryField }
+									showPlaceholder={ showPlaceholder }
 								/>
 							</span>
 						) ) }
 					</span>
 				) : (
 					summaryFields.map( ( summaryField ) => (
-						<summaryField.render
+						<SummaryValue
 							key={ summaryField.id }
 							item={ data }
 							field={ summaryField }
+							showPlaceholder={ showPlaceholder }
 						/>
 					) )
 				) }

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -138,6 +138,7 @@ describe( 'normalizeFormFields', () => {
 					openAs: { type: 'dropdown' },
 					summary: [],
 					editVisibility: 'on-hover',
+					empty: 'render',
 				},
 				fields: [
 					{
@@ -148,6 +149,7 @@ describe( 'normalizeFormFields', () => {
 							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
+							empty: 'render',
 						},
 					},
 				],
@@ -167,6 +169,7 @@ describe( 'normalizeFormFields', () => {
 					openAs: { type: 'dropdown' },
 					summary: [],
 					editVisibility: 'on-hover',
+					empty: 'render',
 				},
 				fields: [
 					{
@@ -177,6 +180,7 @@ describe( 'normalizeFormFields', () => {
 							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
+							empty: 'render',
 						},
 					},
 				],
@@ -199,6 +203,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
+				empty: 'render',
 			} );
 		} );
 
@@ -225,6 +230,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
+				empty: 'render',
 			} );
 		} );
 
@@ -247,6 +253,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
+				empty: 'render',
 			} );
 		} );
 
@@ -273,6 +280,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
+				empty: 'render',
 			} );
 		} );
 
@@ -452,6 +460,7 @@ describe( 'normalizeFormFields', () => {
 							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
+							empty: 'render',
 						},
 					},
 				],

--- a/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
+++ b/packages/dataviews/src/components/dataform-layouts/test/normalize-form.ts
@@ -138,7 +138,7 @@ describe( 'normalizeFormFields', () => {
 					openAs: { type: 'dropdown' },
 					summary: [],
 					editVisibility: 'on-hover',
-					empty: 'render',
+					showPlaceholderIfEmpty: false,
 				},
 				fields: [
 					{
@@ -149,7 +149,7 @@ describe( 'normalizeFormFields', () => {
 							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
-							empty: 'render',
+							showPlaceholderIfEmpty: false,
 						},
 					},
 				],
@@ -169,7 +169,7 @@ describe( 'normalizeFormFields', () => {
 					openAs: { type: 'dropdown' },
 					summary: [],
 					editVisibility: 'on-hover',
-					empty: 'render',
+					showPlaceholderIfEmpty: false,
 				},
 				fields: [
 					{
@@ -180,7 +180,7 @@ describe( 'normalizeFormFields', () => {
 							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
-							empty: 'render',
+							showPlaceholderIfEmpty: false,
 						},
 					},
 				],
@@ -203,7 +203,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
-				empty: 'render',
+				showPlaceholderIfEmpty: false,
 			} );
 		} );
 
@@ -230,7 +230,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
-				empty: 'render',
+				showPlaceholderIfEmpty: false,
 			} );
 		} );
 
@@ -253,7 +253,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
-				empty: 'render',
+				showPlaceholderIfEmpty: false,
 			} );
 		} );
 
@@ -280,7 +280,7 @@ describe( 'normalizeFormFields', () => {
 				},
 				summary: [],
 				editVisibility: 'on-hover',
-				empty: 'render',
+				showPlaceholderIfEmpty: false,
 			} );
 		} );
 
@@ -460,7 +460,7 @@ describe( 'normalizeFormFields', () => {
 							openAs: { type: 'dropdown' },
 							summary: [],
 							editVisibility: 'on-hover',
-							empty: 'render',
+							showPlaceholderIfEmpty: false,
 						},
 					},
 				],

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -66,11 +66,10 @@ export const LayoutPanel = {
 			description: 'Chooses when the edit icon is visible.',
 			options: [ 'default', 'always', 'on-hover' ],
 		},
-		empty: {
-			control: { type: 'select' },
+		showPlaceholderIfEmpty: {
+			control: { type: 'boolean' },
 			description:
-				'Chooses what the summary shows when the field value is empty.',
-			options: [ 'default', 'render', 'placeholder' ],
+				'Whether the summary shows the field placeholder when the value is empty.',
 		},
 		applyLabel: {
 			control: { type: 'text' },
@@ -87,6 +86,7 @@ export const LayoutPanel = {
 	},
 	args: {
 		openAs: 'default',
+		showPlaceholderIfEmpty: false,
 	},
 };
 

--- a/packages/dataviews/src/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/dataform/stories/index.story.tsx
@@ -66,6 +66,12 @@ export const LayoutPanel = {
 			description: 'Chooses when the edit icon is visible.',
 			options: [ 'default', 'always', 'on-hover' ],
 		},
+		empty: {
+			control: { type: 'select' },
+			description:
+				'Chooses what the summary shows when the field value is empty.',
+			options: [ 'default', 'render', 'placeholder' ],
+		},
 		applyLabel: {
 			control: { type: 'text' },
 			description:

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -6,6 +6,7 @@ import type {
 	Layout,
 	PanelLayout,
 	EditVisibility,
+	EmptySummary,
 } from '../../types';
 
 type SamplePost = {
@@ -39,6 +40,7 @@ const fields: Field< SamplePost >[] = [
 		id: 'title',
 		label: 'Title',
 		type: 'text',
+		placeholder: 'Add a title',
 	},
 	{
 		id: 'order',
@@ -272,11 +274,13 @@ const getPanelLayoutFromStoryArgs = ( {
 	labelPosition,
 	openAs,
 	editVisibility,
+	empty,
 }: {
 	summary?: string[];
 	labelPosition?: 'default' | 'top' | 'side' | 'none';
 	openAs?: PanelLayout[ 'openAs' ];
 	editVisibility?: 'default' | EditVisibility;
+	empty?: 'default' | EmptySummary;
 } ): Layout | undefined => {
 	const panelLayout: PanelLayout = {
 		type: 'panel',
@@ -298,6 +302,10 @@ const getPanelLayoutFromStoryArgs = ( {
 		panelLayout.editVisibility = editVisibility;
 	}
 
+	if ( empty !== 'default' ) {
+		panelLayout.empty = empty;
+	}
+
 	return panelLayout;
 };
 
@@ -305,6 +313,7 @@ const LayoutPanelComponent = ( {
 	labelPosition,
 	openAs: openAsArg,
 	editVisibility,
+	empty,
 	applyLabel,
 	cancelLabel,
 }: {
@@ -312,6 +321,7 @@ const LayoutPanelComponent = ( {
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 	openAs: 'default' | 'dropdown' | 'modal';
 	editVisibility: 'default' | EditVisibility;
+	empty: 'default' | EmptySummary;
 	applyLabel?: string;
 	cancelLabel?: string;
 } ) => {
@@ -356,6 +366,7 @@ const LayoutPanelComponent = ( {
 				labelPosition,
 				openAs,
 				editVisibility,
+				empty,
 			} ),
 			fields: [
 				'title',
@@ -368,6 +379,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
+						empty,
 					} ),
 				},
 				'order',
@@ -385,6 +397,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
+						empty,
 					} ),
 				},
 				{
@@ -396,6 +409,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
+						empty,
 					} ),
 				},
 				{
@@ -412,6 +426,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
+						empty,
 					} ),
 				},
 				{
@@ -423,11 +438,19 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
+						empty,
 					} ),
 				},
 			],
 		};
-	}, [ labelPosition, openAsArg, applyLabel, cancelLabel, editVisibility ] );
+	}, [
+		labelPosition,
+		openAsArg,
+		applyLabel,
+		cancelLabel,
+		editVisibility,
+		empty,
+	] );
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/dataform/stories/layout-panel.tsx
+++ b/packages/dataviews/src/dataform/stories/layout-panel.tsx
@@ -6,7 +6,6 @@ import type {
 	Layout,
 	PanelLayout,
 	EditVisibility,
-	EmptySummary,
 } from '../../types';
 
 type SamplePost = {
@@ -274,13 +273,13 @@ const getPanelLayoutFromStoryArgs = ( {
 	labelPosition,
 	openAs,
 	editVisibility,
-	empty,
+	showPlaceholderIfEmpty,
 }: {
 	summary?: string[];
 	labelPosition?: 'default' | 'top' | 'side' | 'none';
 	openAs?: PanelLayout[ 'openAs' ];
 	editVisibility?: 'default' | EditVisibility;
-	empty?: 'default' | EmptySummary;
+	showPlaceholderIfEmpty?: boolean;
 } ): Layout | undefined => {
 	const panelLayout: PanelLayout = {
 		type: 'panel',
@@ -302,8 +301,8 @@ const getPanelLayoutFromStoryArgs = ( {
 		panelLayout.editVisibility = editVisibility;
 	}
 
-	if ( empty !== 'default' ) {
-		panelLayout.empty = empty;
+	if ( showPlaceholderIfEmpty ) {
+		panelLayout.showPlaceholderIfEmpty = true;
 	}
 
 	return panelLayout;
@@ -313,7 +312,7 @@ const LayoutPanelComponent = ( {
 	labelPosition,
 	openAs: openAsArg,
 	editVisibility,
-	empty,
+	showPlaceholderIfEmpty,
 	applyLabel,
 	cancelLabel,
 }: {
@@ -321,7 +320,7 @@ const LayoutPanelComponent = ( {
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 	openAs: 'default' | 'dropdown' | 'modal';
 	editVisibility: 'default' | EditVisibility;
-	empty: 'default' | EmptySummary;
+	showPlaceholderIfEmpty: boolean;
 	applyLabel?: string;
 	cancelLabel?: string;
 } ) => {
@@ -366,7 +365,7 @@ const LayoutPanelComponent = ( {
 				labelPosition,
 				openAs,
 				editVisibility,
-				empty,
+				showPlaceholderIfEmpty,
 			} ),
 			fields: [
 				'title',
@@ -379,7 +378,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						empty,
+						showPlaceholderIfEmpty,
 					} ),
 				},
 				'order',
@@ -397,7 +396,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						empty,
+						showPlaceholderIfEmpty,
 					} ),
 				},
 				{
@@ -409,7 +408,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						empty,
+						showPlaceholderIfEmpty,
 					} ),
 				},
 				{
@@ -426,7 +425,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						empty,
+						showPlaceholderIfEmpty,
 					} ),
 				},
 				{
@@ -438,7 +437,7 @@ const LayoutPanelComponent = ( {
 						labelPosition,
 						openAs,
 						editVisibility,
-						empty,
+						showPlaceholderIfEmpty,
 					} ),
 				},
 			],
@@ -449,7 +448,7 @@ const LayoutPanelComponent = ( {
 		applyLabel,
 		cancelLabel,
 		editVisibility,
-		empty,
+		showPlaceholderIfEmpty,
 	] );
 
 	return (

--- a/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
@@ -671,7 +671,7 @@ describe( 'DataForm component', () => {
 						},
 					] }
 					form={ {
-						layout: { type: 'panel', empty: 'placeholder' },
+						layout: { type: 'panel', showPlaceholderIfEmpty: true },
 						fields: [ 'title' ],
 					} }
 					data={ { title: '' } }
@@ -694,7 +694,7 @@ describe( 'DataForm component', () => {
 						},
 					] }
 					form={ {
-						layout: { type: 'panel', empty: 'placeholder' },
+						layout: { type: 'panel', showPlaceholderIfEmpty: true },
 						fields: [ 'title' ],
 					} }
 					data={ { title: 'Hello World' } }
@@ -720,7 +720,7 @@ describe( 'DataForm component', () => {
 						},
 					] }
 					form={ {
-						layout: { type: 'panel', empty: 'placeholder' },
+						layout: { type: 'panel', showPlaceholderIfEmpty: true },
 						fields: [ 'title' ],
 					} }
 					data={ { title: '' } }

--- a/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
@@ -658,6 +658,108 @@ describe( 'DataForm component', () => {
 			expect( authorField ).toBeInTheDocument();
 		} );
 
+		it( 'should show the placeholder of an empty field when the layout opts in', () => {
+			const fieldsWithPlaceholder = fields.map( ( field ) =>
+				field.id === 'title'
+					? { ...field, placeholder: 'Add a title' }
+					: field
+			);
+			const formWithPlaceholder = {
+				...formPanelMode,
+				layout: {
+					...formPanelMode.layout,
+					empty: 'placeholder' as const,
+				},
+			};
+
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ fieldsWithPlaceholder }
+					form={ formWithPlaceholder }
+					data={ { ...data, title: '' } }
+				/>
+			);
+
+			expect( screen.getByText( 'Add a title' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should render the value of a non-empty field instead of its placeholder', () => {
+			const fieldsWithPlaceholder = fields.map( ( field ) =>
+				field.id === 'title'
+					? { ...field, placeholder: 'Add a title' }
+					: field
+			);
+			const formWithPlaceholder = {
+				...formPanelMode,
+				layout: {
+					...formPanelMode.layout,
+					empty: 'placeholder' as const,
+				},
+			};
+
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ fieldsWithPlaceholder }
+					form={ formWithPlaceholder }
+					data={ data }
+				/>
+			);
+
+			expect( screen.getByText( 'Hello World' ) ).toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Add a title' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should render an empty field without a placeholder when the layout opts in', () => {
+			const fieldsWithCustomRender = fields.map( ( field ) =>
+				field.id === 'title'
+					? { ...field, render: () => <span>No title yet</span> }
+					: field
+			);
+			const formWithPlaceholder = {
+				...formPanelMode,
+				layout: {
+					...formPanelMode.layout,
+					empty: 'placeholder' as const,
+				},
+			};
+
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ fieldsWithCustomRender }
+					form={ formWithPlaceholder }
+					data={ { ...data, title: '' } }
+				/>
+			);
+
+			expect( screen.getByText( 'No title yet' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should not show the placeholder of an empty field by default', () => {
+			const fieldsWithPlaceholder = fields.map( ( field ) =>
+				field.id === 'title'
+					? { ...field, placeholder: 'Add a title' }
+					: field
+			);
+
+			render(
+				<Dataform
+					onChange={ noop }
+					fields={ fieldsWithPlaceholder }
+					form={ formPanelMode }
+					data={ { ...data, title: '' } }
+				/>
+			);
+
+			expect(
+				screen.queryByText( 'Add a title' )
+			).not.toBeInTheDocument();
+		} );
+
 		it( 'should render custom Edit component', async () => {
 			const fieldsWithTitleCustomEditComponent = fields.map(
 				( field ) => {

--- a/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
+++ b/packages/dataviews/src/dataform/test/dataform.jsdom.test.tsx
@@ -659,51 +659,45 @@ describe( 'DataForm component', () => {
 		} );
 
 		it( 'should show the placeholder of an empty field when the layout opts in', () => {
-			const fieldsWithPlaceholder = fields.map( ( field ) =>
-				field.id === 'title'
-					? { ...field, placeholder: 'Add a title' }
-					: field
-			);
-			const formWithPlaceholder = {
-				...formPanelMode,
-				layout: {
-					...formPanelMode.layout,
-					empty: 'placeholder' as const,
-				},
-			};
-
 			render(
 				<Dataform
 					onChange={ noop }
-					fields={ fieldsWithPlaceholder }
-					form={ formWithPlaceholder }
-					data={ { ...data, title: '' } }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text',
+							placeholder: 'Add a title',
+						},
+					] }
+					form={ {
+						layout: { type: 'panel', empty: 'placeholder' },
+						fields: [ 'title' ],
+					} }
+					data={ { title: '' } }
 				/>
 			);
 
 			expect( screen.getByText( 'Add a title' ) ).toBeInTheDocument();
 		} );
 
-		it( 'should render the value of a non-empty field instead of its placeholder', () => {
-			const fieldsWithPlaceholder = fields.map( ( field ) =>
-				field.id === 'title'
-					? { ...field, placeholder: 'Add a title' }
-					: field
-			);
-			const formWithPlaceholder = {
-				...formPanelMode,
-				layout: {
-					...formPanelMode.layout,
-					empty: 'placeholder' as const,
-				},
-			};
-
+		it( 'should show the value of a non-empty field instead of its placeholder', () => {
 			render(
 				<Dataform
 					onChange={ noop }
-					fields={ fieldsWithPlaceholder }
-					form={ formWithPlaceholder }
-					data={ data }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text',
+							placeholder: 'Add a title',
+						},
+					] }
+					form={ {
+						layout: { type: 'panel', empty: 'placeholder' },
+						fields: [ 'title' ],
+					} }
+					data={ { title: 'Hello World' } }
 				/>
 			);
 
@@ -713,26 +707,23 @@ describe( 'DataForm component', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		it( 'should render an empty field without a placeholder when the layout opts in', () => {
-			const fieldsWithCustomRender = fields.map( ( field ) =>
-				field.id === 'title'
-					? { ...field, render: () => <span>No title yet</span> }
-					: field
-			);
-			const formWithPlaceholder = {
-				...formPanelMode,
-				layout: {
-					...formPanelMode.layout,
-					empty: 'placeholder' as const,
-				},
-			};
-
+		it( 'should fall back to the render output when an empty field has no placeholder', () => {
 			render(
 				<Dataform
 					onChange={ noop }
-					fields={ fieldsWithCustomRender }
-					form={ formWithPlaceholder }
-					data={ { ...data, title: '' } }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text',
+							render: () => <span>No title yet</span>,
+						},
+					] }
+					form={ {
+						layout: { type: 'panel', empty: 'placeholder' },
+						fields: [ 'title' ],
+					} }
+					data={ { title: '' } }
 				/>
 			);
 
@@ -740,18 +731,22 @@ describe( 'DataForm component', () => {
 		} );
 
 		it( 'should not show the placeholder of an empty field by default', () => {
-			const fieldsWithPlaceholder = fields.map( ( field ) =>
-				field.id === 'title'
-					? { ...field, placeholder: 'Add a title' }
-					: field
-			);
-
 			render(
 				<Dataform
 					onChange={ noop }
-					fields={ fieldsWithPlaceholder }
-					form={ formPanelMode }
-					data={ { ...data, title: '' } }
+					fields={ [
+						{
+							id: 'title',
+							label: 'Title',
+							type: 'text',
+							placeholder: 'Add a title',
+						},
+					] }
+					form={ {
+						layout: { type: 'panel' },
+						fields: [ 'title' ],
+					} }
+					data={ { title: '' } }
 				/>
 			);
 

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -66,12 +66,6 @@ export type NormalizedRegularLayout = {
 export type EditVisibility = 'always' | 'on-hover';
 
 /**
- * What the summary of a panel field shows when the field's value is empty:
- * the field's `render` output, or the field's `placeholder`.
- */
-export type EmptySummary = 'render' | 'placeholder';
-
-/**
  * Configuration to open a panel's edit control in a dropdown.
  */
 type PanelOpenAsDropdown = {
@@ -137,11 +131,11 @@ export type PanelLayout = {
 	editVisibility?: EditVisibility;
 
 	/**
-	 * What the summary shows when the field's value is `undefined`, `null`,
-	 * or an empty string: the field's `render` output (default), or the
-	 * field's `placeholder`.
+	 * Whether the summary shows the field's `placeholder` instead of its
+	 * `render` output when the value is `undefined`, `null`, or an empty
+	 * string. `false` by default.
 	 */
-	empty?: EmptySummary;
+	showPlaceholderIfEmpty?: boolean;
 };
 
 /**
@@ -174,9 +168,9 @@ export type NormalizedPanelLayout = {
 	editVisibility: EditVisibility;
 
 	/**
-	 * What the summary shows when the field's value is empty.
+	 * Whether the summary shows the field's `placeholder` when the value is empty.
 	 */
-	empty: EmptySummary;
+	showPlaceholderIfEmpty: boolean;
 };
 
 /**

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -66,6 +66,12 @@ export type NormalizedRegularLayout = {
 export type EditVisibility = 'always' | 'on-hover';
 
 /**
+ * What the summary of a panel field shows when the field's value is empty:
+ * the field's `render` output, or the field's `placeholder`.
+ */
+export type EmptySummary = 'render' | 'placeholder';
+
+/**
  * Configuration to open a panel's edit control in a dropdown.
  */
 type PanelOpenAsDropdown = {
@@ -129,6 +135,13 @@ export type PanelLayout = {
 	 * When the edit trigger is visible: always, or only on hover/focus (default).
 	 */
 	editVisibility?: EditVisibility;
+
+	/**
+	 * What the summary shows when the field's value is `undefined`, `null`,
+	 * or an empty string: the field's `render` output (default), or the
+	 * field's `placeholder`.
+	 */
+	empty?: EmptySummary;
 };
 
 /**
@@ -159,6 +172,11 @@ export type NormalizedPanelLayout = {
 	 * When the edit trigger is visible.
 	 */
 	editVisibility: EditVisibility;
+
+	/**
+	 * What the summary shows when the field's value is empty.
+	 */
+	empty: EmptySummary;
 };
 
 /**


### PR DESCRIPTION
## What?

Follow up of: https://github.com/WordPress/gutenberg/pull/82423#issuecomment-5540561724

This PR adds a `showPlaceholderIfEmpty` option to the `panel` layout. When `true`, the panel summary shows the field's `placeholder` when the value is empty (`undefined`, `null` or an empty string), instead of the field's `render` output. It's `false` by default, so existing forms don't change.

1. In Storybook open `DataForm > Layout Panel` and turn on the `showPlaceholderIfEmpty` control.
2. Clear the title. The row should show `Add a title` and the pencil should still open the dropdown.
3. Turn the control off and observe the row is empty like before.


## Use of AI Tools

Generated with Fable 5 and adjusted/reviewed manually.