### PR TITLE
CodeRabbit: Disable the review status comment

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,8 @@ reviews:
     # Post the summary in CodeRabbit's own walkthrough comment rather than
     # editing the pull request description.
     high_level_summary_in_walkthrough: true
+    # Don't post the review status comment.
+    review_status: false
     auto_review:
         # Don't review every pull request. Reviews run when someone comments
         # `@coderabbitai review`, or when the keyword below is in the description.


### PR DESCRIPTION
## What?

Sets `reviews.review_status: false` in `.coderabbit.yaml` so CodeRabbit no longer posts its review status comment on pull requests.

## Why?

Reviews are already opt-in in this repository (`auto_review.enabled: false`), so the status comment adds noise to every pull request without conveying anything useful.

## How?

Adds the `review_status: false` key under `reviews:` in `.coderabbit.yaml`.

## Testing Instructions

Once merged, open a pull request and confirm CodeRabbit does not add a review status comment. Requesting a review with `@coderabbitai review` should still work as before.

## Use of AI Tools

This pull request was authored with Claude Code. The change is a two-line configuration edit that I reviewed and take responsibility for.