### PR TITLE
Editor: Show revision data in Post Title component

### DIFF
--- a/packages/editor/src/components/post-title/use-post-title.js
+++ b/packages/editor/src/components/post-title/use-post-title.js
@@ -1,4 +1,5 @@
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
 
 /**
@@ -7,18 +8,21 @@ import { store as editorStore } from '../../store';
  * @return {Object} An object containing the current title and a function to update the title.
  */
 export default function usePostTitle() {
-	const { editPost } = useDispatch( editorStore );
-	const { title } = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( editorStore );
+	const { postType, postId } = useSelect( ( select ) => {
+		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
 
 		return {
-			title: getEditedPostAttribute( 'title' ),
+			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
 		};
 	}, [] );
 
-	function updateTitle( newTitle ) {
-		editPost( { title: newTitle } );
-	}
+	const [ title, setTitle ] = useEntityProp(
+		'postType',
+		postType,
+		'title',
+		postId
+	);
 
-	return { title, setTitle: updateTitle };
+	return { title, setTitle };
 }


### PR DESCRIPTION
## What?
PR updates the editor's post title component to use the `useEntityProp` hook. The hook handles revision values automatically and enables their display, improving the revision post previews.

## Testing Instructions
1. Create a post.
2. Change the title and save. Repeat a couple of times.
3. Switch to revisions view.
4. Confirm that the post title changes with each revision.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/6d6d051b-6e59-42d1-b75f-950c89996f16



## Use of AI Tools

None.