### PR TITLE
Project Management: Restore CODEOWNERS exclusions for suppression lists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,3 +66,9 @@
 /lib/block-supports/layout.php                  @tellthemachines
 /lib/class-wp-theme-json-gutenberg.php          @tellthemachines
 /lib/compat/*/html-api                          @dmsnell
+
+# Exclusions
+# An entry without an owner cancels the rules above it, and last match wins,
+# so these stay at the end. Removing them brings back the review requests.
+/tools/eslint/suppressions.json
+/tools/stylelint/stylelint-suppressions.json


### PR DESCRIPTION
## What?

Follow up to #82292. Restores the two ownerless entries for the lint suppression lists, in a new `Exclusions` section at the end of `.github/CODEOWNERS`

## Why?

They were not empty entries. An entry without an owner cancels the broader rules above it, and these cancelled `/tools` for two files that change constantly as a side effect of unrelated work. Since their removal, every change to them sends a review request.

## How?

CODEOWNERS is last match wins, so the exclusions live at the end of the file where they override every rule above, with a comment saying why they must not be removed again.

## Testing Instructions

1. Open a PR that touches `tools/eslint/suppressions.json`.
2. Confirm no review is requested for it.

## Use of AI Tools

Claude Code, to restore the entries and draft this description. Reviewed by me.
