### PR TITLE
Fields: Declare the caption, alt text, description and ping status controls through the Field API

### DIFF
--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Internal
 
+-   `pingStatusField`: Replace the custom `Edit` component with the built-in checkbox control of the `boolean` field type. The field now exposes the REST API's `open` / `closed` value as a boolean through `getValue` and `setValue`, and passes the help link as the field's `description`.
 -   `MediaEdit`: Space `ValidityIndicator` with `Stack` now that the indicator has no outer margin. ([#82267](https://github.com/WordPress/gutenberg/pull/82267))
 -   Remove the template activation (`active_templates`) experiment checks from the rename, reset, and duplicate actions ([#82241](https://github.com/WordPress/gutenberg/pull/82241)).
 -   Remove unused dependencies `@wordpress/hooks`, `@wordpress/primitives`, `@wordpress/router`, etc. ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Internal
 
--   `pingStatusField`: Replace the custom `Edit` component with the built-in checkbox control of the `boolean` field type. The field now exposes the REST API's `open` / `closed` value as a boolean through `getValue` and `setValue`, and passes the help link as the field's `description`.
+-   `pingStatusField`: Replace the custom `Edit` component with the built-in checkbox control of the `boolean` field type. The field now exposes the REST API's `open` / `closed` value as a boolean through `getValue` and `setValue`, and passes the help link as the field's `description` ([#82539](https://github.com/WordPress/gutenberg/pull/82539)).
 -   `MediaEdit`: Space `ValidityIndicator` with `Stack` now that the indicator has no outer margin. ([#82267](https://github.com/WordPress/gutenberg/pull/82267))
 -   Remove the template activation (`active_templates`) experiment checks from the rename, reset, and duplicate actions ([#82241](https://github.com/WordPress/gutenberg/pull/82241)).
 -   Remove unused dependencies `@wordpress/hooks`, `@wordpress/primitives`, `@wordpress/router`, etc. ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/fields/src/fields/ping-status/index.tsx
+++ b/packages/fields/src/fields/ping-status/index.tsx
@@ -1,63 +1,33 @@
-import type { DataFormControlProps, Field } from '@wordpress/dataviews';
+import type { Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import type { BasePost } from '../../types';
-
-function PingStatusEdit( {
-	data,
-	onChange,
-}: DataFormControlProps< BasePost > ) {
-	const pingStatus = data?.ping_status ?? 'open';
-
-	const onTogglePingback = ( checked: boolean ) => {
-		onChange( {
-			...data,
-			ping_status: checked ? 'open' : 'closed',
-		} );
-	};
-
-	return (
-		<CheckboxControl
-			label={ __( 'Enable pingbacks & trackbacks' ) }
-			checked={ pingStatus === 'open' }
-			onChange={ onTogglePingback }
-			help={
-				<ExternalLink
-					href={ __(
-						'https://wordpress.org/documentation/article/trackbacks-and-pingbacks/'
-					) }
-				>
-					{ __( 'Learn more about pingbacks & trackbacks' ) }
-				</ExternalLink>
-			}
-		/>
-	);
-}
 
 const pingStatusField: Field< BasePost > = {
 	id: 'ping_status',
-	label: __( 'Trackbacks & Pingbacks' ),
-	type: 'text',
-	Edit: PingStatusEdit,
+	label: __( 'Enable pingbacks & trackbacks' ),
+	header: __( 'Trackbacks & Pingbacks' ),
+	type: 'boolean',
+	description: (
+		<ExternalLink
+			href={ __(
+				'https://wordpress.org/documentation/article/trackbacks-and-pingbacks/'
+			) }
+		>
+			{ __( 'Learn more about pingbacks & trackbacks' ) }
+		</ExternalLink>
+	),
+	// The REST API stores the setting as `open` / `closed`; the field
+	// exposes it as a boolean so the built-in checkbox control can edit it.
+	getValue: ( { item } ) => ( item.ping_status ?? 'open' ) === 'open',
+	setValue: ( { value } ) => ( {
+		ping_status: value ? 'open' : 'closed',
+	} ),
+	render: ( { item, field } ) =>
+		field.getValue( { item } ) ? __( 'Allow' ) : __( "Don't allow" ),
 	enableSorting: false,
 	enableHiding: false,
 	filterBy: false,
-	elements: [
-		{
-			value: 'open',
-			label: __( 'Allow' ),
-			description: __(
-				'Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.'
-			),
-		},
-		{
-			value: 'closed',
-			label: __( "Don't allow" ),
-			description: __(
-				"Don't allow link notifications from other blogs (pingbacks and trackbacks) on new articles."
-			),
-		},
-	],
 };
 
 /**

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### Internal
 
--   `caption`: Replace the custom `Edit` component with the built-in `textarea` control.
--   `alt_text`: Replace the custom `Edit` component with the built-in `textarea` control, passing the help text as the field's `description`.
--   `description`: Replace the custom `Edit` component with the built-in `textarea` control.
+-   `caption`: Replace the custom `Edit` component with the built-in `textarea` control ([#82539](https://github.com/WordPress/gutenberg/pull/82539)).
+-   `alt_text`: Replace the custom `Edit` component with the built-in `textarea` control, passing the help text as the field's `description` ([#82539](https://github.com/WordPress/gutenberg/pull/82539)).
+-   `description`: Replace the custom `Edit` component with the built-in `textarea` control ([#82539](https://github.com/WordPress/gutenberg/pull/82539)).
 -   Remove unused dependencies `@wordpress/date` and `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
 

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `caption`: Replace the custom `Edit` component with the built-in `textarea` control.
 -   `alt_text`: Replace the custom `Edit` component with the built-in `textarea` control, passing the help text as the field's `description`.
+-   `description`: Replace the custom `Edit` component with the built-in `textarea` control.
 -   Remove unused dependencies `@wordpress/date` and `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
 

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Internal
 
 -   `caption`: Replace the custom `Edit` component with the built-in `textarea` control.
+-   `alt_text`: Replace the custom `Edit` component with the built-in `textarea` control, passing the help text as the field's `description`.
 -   Remove unused dependencies `@wordpress/date` and `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
 

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Internal
 
+-   `caption`: Replace the custom `Edit` component with the built-in `textarea` control.
 -   Remove unused dependencies `@wordpress/date` and `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
 

--- a/packages/media-fields/src/alt_text/index.tsx
+++ b/packages/media-fields/src/alt_text/index.tsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { TextareaControl as WCTextareaControl } from '@wordpress/components';
 import { Link } from '@wordpress/ui';
 import type { Field } from '@wordpress/dataviews';
 import type { Attachment, Updatable } from '@wordpress/core-data';
@@ -8,35 +7,28 @@ const altTextField: Partial< Field< Updatable< Attachment > > > = {
 	id: 'alt_text',
 	type: 'text',
 	label: __( 'Alt text' ),
+	description: (
+		<>
+			<Link
+				href={
+					// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
+					__(
+						'https://www.w3.org/WAI/tutorials/images/decision-tree/'
+					)
+				}
+				openInNewTab
+			>
+				{ __( 'Describe the purpose of the image.' ) }
+			</Link>
+			<br />
+			{ __( 'Leave empty if decorative.' ) }
+		</>
+	),
 	isVisible: ( item ) => item?.media_type === 'image',
 	render: ( { item } ) => item?.alt_text || '-',
-	Edit: ( { field, onChange, data } ) => {
-		return (
-			<WCTextareaControl
-				label={ field.label }
-				value={ data.alt_text || '' }
-				onChange={ ( value ) => onChange( { alt_text: value } ) }
-				help={
-					<>
-						<Link
-							href={
-								// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-								__(
-									'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-								)
-							}
-							openInNewTab
-						>
-							{ __( 'Describe the purpose of the image.' ) }
-						</Link>
-						<br />
-						{ __( 'Leave empty if decorative.' ) }
-					</>
-				}
-				disabled={ field.isDisabled( { item: data, field } ) }
-				rows={ 2 }
-			/>
-		);
+	Edit: {
+		control: 'textarea',
+		rows: 2,
 	},
 	enableSorting: false,
 	filterBy: false,

--- a/packages/media-fields/src/caption/index.tsx
+++ b/packages/media-fields/src/caption/index.tsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { TextareaControl as WCTextareaControl } from '@wordpress/components';
 import type { Attachment, Updatable } from '@wordpress/core-data';
 import type { Field } from '@wordpress/dataviews';
 import { getRawContent } from '../utils/get-raw-content';
@@ -10,16 +9,9 @@ const captionField: Partial< Field< Updatable< Attachment > > > = {
 	label: __( 'Caption' ),
 	getValue: ( { item } ) => getRawContent( item?.caption ),
 	render: ( { item } ) => getRawContent( item?.caption ) || '-',
-	Edit: ( { field, onChange, data } ) => {
-		return (
-			<WCTextareaControl
-				label={ field.label }
-				value={ getRawContent( data.caption ) || '' }
-				onChange={ ( value ) => onChange( { caption: value } ) }
-				disabled={ field.isDisabled( { item: data, field } ) }
-				rows={ 2 }
-			/>
-		);
+	Edit: {
+		control: 'textarea',
+		rows: 2,
 	},
 	enableSorting: false,
 	filterBy: false,

--- a/packages/media-fields/src/description/index.tsx
+++ b/packages/media-fields/src/description/index.tsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { TextareaControl as WCTextareaControl } from '@wordpress/components';
 import type { Attachment, Updatable } from '@wordpress/core-data';
 import type { Field } from '@wordpress/dataviews';
 import { getRawContent } from '../utils/get-raw-content';
@@ -12,16 +11,9 @@ const descriptionField: Partial< Field< Updatable< Attachment > > > = {
 	render: ( { item } ) => (
 		<div>{ getRawContent( item?.description ) || '-' }</div>
 	),
-	Edit: ( { field, onChange, data } ) => {
-		return (
-			<WCTextareaControl
-				label={ field.label }
-				value={ getRawContent( data.description ) || '' }
-				onChange={ ( value ) => onChange( { description: value } ) }
-				disabled={ field.isDisabled( { item: data, field } ) }
-				rows={ 5 }
-			/>
-		);
+	Edit: {
+		control: 'textarea',
+		rows: 5,
 	},
 	enableSorting: false,
 	filterBy: false,

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -7809,11 +7809,6 @@
 			"count": 1
 		}
 	},
-	"packages/media-fields/src/alt_text/index.tsx": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/media-fields/src/author/view.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -7819,11 +7819,6 @@
 			"count": 1
 		}
 	},
-	"packages/media-fields/src/caption/index.tsx": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/media-fields/src/description/index.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -7814,11 +7814,6 @@
 			"count": 1
 		}
 	},
-	"packages/media-fields/src/description/index.tsx": {
-		"@wordpress/use-recommended-components": {
-			"count": 1
-		}
-	},
 	"packages/media-fields/src/media_thumbnail/view.tsx": {
 		"@wordpress/use-recommended-components": {
 			"count": 1


### PR DESCRIPTION
## What?

Follow up to #82516.

Removes the custom `Edit` components from four fields and declares their controls through the Field API instead: the media `caption`, `alt_text` and `description` fields now use the built-in `textarea` control, and `pingStatusField` uses the built-in checkbox of the `boolean` type.

## Why?

These fields were written before the Field API could express their controls. Each custom component reimplemented what the built-in control already does (read through `getValue`, write through `setValue`, pass `isDisabled`, set the number of rows), so bugs like #82516 had to be fixed field by field. The only extra the custom components brought was a help text with a link, and the Field API now covers that too: `description` accepts a React element, and the built-in controls render it in the slot meant for help text with links. Using the declarative form means these fields pick up validation, placeholders, `hideLabelFromVision` and future control improvements for free.

## How?

The three media fields replace their `Edit` component with an `Edit` config (`{ control: 'textarea', rows }`), and `alt_text` moves its help text to the field's `description`. `pingStatusField` becomes a `boolean` field: `getValue` and `setValue` map the REST API's `open` / `closed` value to a checked state, the help link moves to `description`, and a small `render` keeps the "Allow" / "Don't allow" labels the old `elements` provided (the `elements` array had to go, because the boolean value would fail the automatic elements validation). Its `label` becomes the checkbox copy the custom control used, while `header` keeps the previous wording for views. Each field is its own commit, and the stale lint suppressions for the legacy textarea import are removed.

## Testing Instructions

1. Enable the media editor experiment and open an image attachment in the media editor. Edit the caption, alt text and description, and confirm the values save and the alt text help link still opens the W3C decision tree.
2. In the extensible site editor, open the posts list and use Quick Edit on a post. In the Discussion panel, toggle "Enable pingbacks & trackbacks", save, and confirm `ping_status` flips between `open` and `closed`.
3. Run `npm run test:unit -- packages/fields packages/media-fields` and `npm run typecheck`.

### Testing Instructions for Keyboard

Tab into each textarea and type; tab to the alt text help link and press Enter to open it. In Quick Edit, tab to the pingbacks checkbox and press Space to toggle it, then tab to the help link and press Enter.

## Screenshots or screencast

Captured in Storybook with a DataForm rendering each field on its own, `trunk` on the left and this branch on the right.

**Caption**

|Before|After|
|-|-|
|<img width="392" alt="caption_before" src="https://github.com/user-attachments/assets/6cb3c218-14c0-434e-876e-e248e9ca10ba" />|<img width="392" alt="caption_after" src="https://github.com/user-attachments/assets/c80c1c1e-e8a9-4e58-85b7-1a095815fab2" />|

**Alt text**

|Before|After|
|-|-|
|<img width="392" alt="alt_before" src="https://github.com/user-attachments/assets/8894c9a9-7875-43e6-b157-f0a8a9b76b18" />|<img width="392" alt="alt_after" src="https://github.com/user-attachments/assets/889d1c3b-6894-4ba6-a207-24dd1c2f3771" />|

**Description**

|Before|After|
|-|-|
|<img width="392" alt="desc_before" src="https://github.com/user-attachments/assets/d7771de2-c063-4890-85dd-84dadcfed1b8" />|<img width="392" alt="desc_after" src="https://github.com/user-attachments/assets/0e0e1945-e358-4ff8-8294-922c45788726" />|

**Pingbacks & trackbacks**

To test this one, I had to add support for trackbacks to pages (then visit "Discussion" in Site Editor > Pages > Quick edit). For example, copy this in a PHP file:

```php
add_action( 'init', fn() => add_post_type_support( 'page', 'trackbacks' ) );
```

Before | After 
--- | ---
<img width="355" height="300" alt="Image" src="https://github.com/user-attachments/assets/4cb7aa07-2ebd-444c-90c4-00443511fa5d" /> | <img width="355" height="300" alt="Image" src="https://github.com/user-attachments/assets/6106d0a6-93f5-46a6-84d9-31aa27679f84" />


## Use of AI Tools

Claude Code (Claude Fable 5.1) surveyed the field definitions against the Field API, wrote the code changes, the commits and this description, and captured the screenshots. I reviewed and take responsibility for the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
