### PR TITLE
Block Fields: Fix video not rendering when added from the inspector panel

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/media/index.jsx
+++ b/packages/block-editor/src/hooks/block-fields/media/index.jsx
@@ -92,6 +92,29 @@ function MediaThumbnail( { data, field, attachment, config } ) {
 	return <WCIcon icon={ mediaIcon } size={ 20 } />;
 }
 
+/**
+ * Resolves the specific media type for a selected attachment.
+ *
+ * Selections made in the media library already carry a normalized `type`, while
+ * uploads return a REST attachment whose `media_type` is only ever `image` or
+ * `file`. Deriving from the mime type keeps video, audio and documents from all
+ * collapsing into `file`.
+ *
+ * @param {Object} media The selected media object.
+ * @return {string|undefined} The media type, e.g. `image`, `video` or `audio`.
+ */
+function getMediaType( media ) {
+	if ( media?.type ) {
+		return media.type;
+	}
+
+	if ( media?.mime_type ) {
+		return media.mime_type.split( '/' )[ 0 ];
+	}
+
+	return media?.media_type;
+}
+
 export default function Media( { data, field, onChange, config = {} } ) {
 	const { popoverProps } = useInspectorPopoverPlacement( {
 		isControl: true,
@@ -182,7 +205,7 @@ export default function Media( { data, field, onChange, config = {} } ) {
 						if ( selectedMedia.id && selectedMedia.url ) {
 							const newValue = {
 								...selectedMedia,
-								mediaType: selectedMedia.media_type,
+								mediaType: getMediaType( selectedMedia ),
 							};
 
 							// Turn off featured image when manually selecting media

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -78,7 +78,7 @@ if ( window.__experimentalContentOnlyInspectorFields ) {
 				id: value.id,
 				url: value.url,
 				alt: value.alt,
-				mediaType: value.backgroundType,
+				backgroundType: value.mediaType,
 				useFeaturedImage: value.featuredImage,
 			} ),
 		},


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/66563

Fixes video selected from the inspector panel not rendering in Cover and Media & Text.

## Why?
Adding a video from the inspector panel doesn't work, the video never shows. The same video added from the toolbar works fine. Affects Cover and Media & Text.

## How

- The panel now recognises what kind of file was picked, so videos are treated as videos.
- Cover now correctly records that its background is a video.

## Testing Instructions
1. Enable Experiments → Data Views → "Block fields: Show dataform driven inspector fields on blocks that support them", then reload.
2. Insert a **Cover** block, add a **video** from the inspector panel, it renders as a video.
3. Repeat with **Media & Text**.

## Screenshots or screencast

### Before

https://github.com/user-attachments/assets/459dceb0-fcda-4110-9cc2-2dcc31396021 


### After

https://github.com/user-attachments/assets/f12ec006-4129-4307-97da-6a49d01faa52 








## Use of AI Tools
Claude Code
