### PR TITLE
Patterns: Let core/block reference a registered pattern by slug, add a synced opt-in for registered patterns

### DIFF
--- a/docs/reference-guides/block-api/block-patterns.md
+++ b/docs/reference-guides/block-api/block-patterns.md
@@ -25,6 +25,7 @@ The properties available for block patterns are:
 -   `templateTypes` (optional): An array of template types where the pattern makes sense, for example, `404` if the pattern is for a 404 page, `single-post` if the pattern is for showing a single post.
 -   `inserter` (optional): By default, all patterns will appear in the inserter. To hide a pattern so that it can only be inserted programmatically, set the `inserter` to `false`.
 -   `source` (optional): A string that denotes the source of the pattern. For a plugin registering a pattern, pass the string `plugin`. For a theme, pass the string `theme`.
+-   `synced` (optional): When `true`, inserting the pattern adds a Pattern block (`core/block`) that references the pattern by its name instead of copying its blocks, so every instance follows the registered content and changes to the registered pattern show up everywhere. Blocks inside a synced pattern are only editable per instance through pattern overrides (a `core/pattern-overrides` binding). Defaults to `false`. In a theme's `patterns/` file, use the `Synced: yes` header.
 
 The following code sample registers a block pattern named `my-plugin/my-awesome-pattern`:
 

--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -93,7 +93,7 @@ Reuse this design across your site.
 -	**Name:** [core/block](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-reusable/core-block-block/)
 -	**Category:** [reusable](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-reusable/)
 -	**Supports:** interactivity (clientNavigation), ~~customCSS~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~, ~~visibility~~
--	**Attributes:** content, ref
+-	**Attributes:** content, ref, slug
 
 ## Breadcrumbs
 

--- a/lib/compat/wordpress-7.2/block-patterns.php
+++ b/lib/compat/wordpress-7.2/block-patterns.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Synced registered block patterns.
+ *
+ * A registered pattern (theme, plugin or core) can opt into being synced with
+ * `'synced' => true` in its registration properties, or a `Synced: yes` header
+ * in a theme's `patterns/` file. Inserting a synced pattern adds a `core/block`
+ * that references the pattern by `slug` instead of copying its content, so
+ * every instance follows the registered source. Patterns are unsynced by
+ * default, which keeps the current copy-on-insert behavior.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Whether a registered block pattern is synced.
+ *
+ * @param array $pattern Registered pattern properties.
+ * @return bool True when inserting the pattern should reference it, false when
+ *              it should copy its content.
+ */
+function gutenberg_is_block_pattern_synced( $pattern ) {
+	return ! empty( $pattern['synced'] );
+}
+
+/**
+ * Applies the `Synced` header of the active theme's `patterns/` files.
+ *
+ * Core's `WP_Theme::get_block_patterns()` only reads a fixed list of headers,
+ * so patterns that opt in with `Synced: yes` are re-registered here with
+ * `synced => true`. Runs after `_register_theme_block_patterns()`.
+ */
+function gutenberg_register_synced_theme_block_patterns() {
+	if ( empty( wp_get_active_and_valid_themes() ) ) {
+		return;
+	}
+
+	$themes   = array();
+	$theme    = wp_get_theme();
+	$themes[] = $theme;
+	if ( $theme->parent() ) {
+		$themes[] = $theme->parent();
+	}
+	$registry = WP_Block_Patterns_Registry::get_instance();
+	$seen     = array();
+
+	foreach ( $themes as $theme ) {
+		$patterns    = $theme->get_block_patterns();
+		$dirpath     = $theme->get_stylesheet_directory() . '/patterns/';
+		$text_domain = $theme->get( 'TextDomain' );
+
+		foreach ( $patterns as $file => $pattern_data ) {
+			$slug = $pattern_data['slug'];
+			// A child theme pattern wins over a parent theme pattern with the same slug.
+			if ( isset( $seen[ $slug ] ) ) {
+				continue;
+			}
+			$seen[ $slug ] = true;
+
+			$file_path = $dirpath . $file;
+			if ( ! file_exists( $file_path ) || ! $registry->is_registered( $slug ) ) {
+				continue;
+			}
+
+			$headers = get_file_data( $file_path, array( 'synced' => 'Synced' ) );
+			if ( ! in_array( strtolower( trim( $headers['synced'] ) ), array( 'yes', 'true', '1' ), true ) ) {
+				continue;
+			}
+
+			// Mirror the registration in `_register_theme_block_patterns()`;
+			// `WP_Block_Patterns_Registry::register()` overwrites the entry.
+			$pattern_data['filePath'] = $file_path;
+			$pattern_data['synced']   = true;
+			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain,WordPress.WP.I18n.LowLevelTranslationFunction
+			$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', $text_domain );
+			if ( ! empty( $pattern_data['description'] ) ) {
+				// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain,WordPress.WP.I18n.LowLevelTranslationFunction
+				$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', $text_domain );
+			}
+
+			register_block_pattern( $slug, $pattern_data );
+		}
+	}
+}
+add_action( 'init', 'gutenberg_register_synced_theme_block_patterns', 11 );

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-block-patterns-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-block-patterns-controller-7-2.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Block_Patterns_Controller_7_2 class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds the `synced` field to the block patterns REST API.
+ *
+ * @see Gutenberg_REST_Block_Patterns_Controller_7_0
+ */
+class Gutenberg_REST_Block_Patterns_Controller_7_2 extends Gutenberg_REST_Block_Patterns_Controller_7_0 {
+	/**
+	 * Prepares a raw block pattern before it gets output in a REST API response.
+	 *
+	 * @param array           $item    Raw pattern as registered, before any changes.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$response = parent::prepare_item_for_response( $item, $request );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$fields = $this->get_fields_for_response( $request );
+		if ( rest_is_field_included( 'synced', $fields ) ) {
+			$data           = $response->get_data();
+			$data['synced'] = gutenberg_is_block_pattern_synced( $item );
+			$response->set_data( $data );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Retrieves the block pattern schema, conforming to JSON Schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['synced'] = array(
+			'description' => __( 'Whether inserting the pattern references it instead of copying its content.', 'gutenberg' ),
+			'type'        => 'boolean',
+			'readonly'    => true,
+			'context'     => array( 'view', 'edit', 'embed' ),
+		);
+
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/lib/compat/wordpress-7.2/rest-api.php
+++ b/lib/compat/wordpress-7.2/rest-api.php
@@ -35,3 +35,16 @@ function gutenberg_modify_template_post_type_args_7_2( $args ) {
 }
 add_filter( 'register_wp_template_post_type_args', 'gutenberg_modify_template_post_type_args_7_2' );
 add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_modify_template_post_type_args_7_2' );
+
+/**
+ * Registers the block patterns REST API route.
+ *
+ * Replaces the 7.0 registration so the route is served by the 7.2 controller,
+ * which adds the `synced` field.
+ */
+function gutenberg_register_block_patterns_controller_endpoints_7_2() {
+	$block_patterns_controller = new Gutenberg_REST_Block_Patterns_Controller_7_2();
+	$block_patterns_controller->register_routes();
+}
+remove_action( 'rest_api_init', 'gutenberg_register_block_patterns_controller_endpoints' );
+add_action( 'rest_api_init', 'gutenberg_register_block_patterns_controller_endpoints_7_2' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -73,6 +73,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 7.2 compat.
 	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php';
+	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-block-patterns-controller-7-2.php';
 	require __DIR__ . '/compat/wordpress-7.2/view-config-api.php';
 	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php';
 	require __DIR__ . '/compat/wordpress-7.2/rest-api.php';
@@ -127,6 +128,9 @@ require __DIR__ . '/compat/wordpress-7.1/kses.php';
 require __DIR__ . '/compat/wordpress-7.1/media.php';
 require __DIR__ . '/compat/wordpress-7.1/preload.php';
 require __DIR__ . '/compat/wordpress-7.1/icons.php';
+
+// WordPress 7.2 compat.
+require __DIR__ . '/compat/wordpress-7.2/block-patterns.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   Inserter: Registered patterns that opt in with `synced` are inserted as a Pattern block referencing them by `slug` instead of as a copy of their blocks ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 
 ### Internal

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   Inserter: Registered patterns that opt in with `synced` are inserted as a Pattern block referencing them by `slug` instead of as a copy of their blocks ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   Inserter: Registered patterns that opt in with `synced` are inserted as a Pattern block referencing them by `slug` instead of as a copy of their blocks ([#82544](https://github.com/WordPress/gutenberg/pull/82544)).
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 
 ### Internal

--- a/packages/block-editor/src/components/block-inspector/edit-contents.jsx
+++ b/packages/block-editor/src/components/block-inspector/edit-contents.jsx
@@ -16,11 +16,11 @@ function IsolatedEditButton( {
 		? theme && slug && `${ theme }//${ slug }`
 		: ref;
 
-	const handleClick = () => {
-		if ( ! entityId ) {
-			return;
-		}
+	if ( ! entityId ) {
+		return null;
+	}
 
+	const handleClick = () => {
 		onNavigateToEntityRecord( {
 			postId: entityId,
 			postType: isTemplatePartBlock ? 'wp_template_part' : 'wp_block',
@@ -37,8 +37,6 @@ function IsolatedEditButton( {
 				__next40pxDefaultSize
 				variant="secondary"
 				onClick={ handleClick }
-				accessibleWhenDisabled
-				disabled={ ! entityId }
 			>
 				{ __( 'Edit original' ) }
 			</Button>

--- a/packages/block-editor/src/components/block-patterns-list/index.jsx
+++ b/packages/block-editor/src/components/block-patterns-list/index.jsx
@@ -12,7 +12,10 @@ import { Icon, symbol } from '@wordpress/icons';
 import BlockPreview from '../block-preview';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 import BlockPatternsPaging from '../block-patterns-paging';
-import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
+import {
+	INSERTER_PATTERN_TYPES,
+	isPatternSynced,
+} from '../inserter/block-patterns-tab/utils';
 
 const WithToolTip = ( { showTooltip, title, children } ) => {
 	if ( showTooltip ) {
@@ -105,9 +108,7 @@ function BlockPattern( {
 										'block-editor-block-patterns-list__item',
 										{
 											'block-editor-block-patterns-list__list-item-synced':
-												pattern.type ===
-													INSERTER_PATTERN_TYPES.user &&
-												! pattern.syncStatus,
+												isPatternSynced( pattern ),
 											'is-selected': isSelected,
 										}
 									) }
@@ -139,7 +140,7 @@ function BlockPattern( {
 									className="block-editor-patterns__pattern-details"
 									spacing={ 2 }
 								>
-									{ isUserPattern && ! pattern.syncStatus && (
+									{ isPatternSynced( pattern ) && (
 										<div className="block-editor-patterns__pattern-icon-wrapper">
 											<Icon
 												className="block-editor-patterns__pattern-icon"

--- a/packages/block-editor/src/components/block-toolbar/change-design.jsx
+++ b/packages/block-editor/src/components/block-toolbar/change-design.jsx
@@ -10,6 +10,7 @@ import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import BlockPatternsList from '../block-patterns-list';
+import { isPatternSynced } from '../inserter/block-patterns-tab/utils';
 
 const EMPTY_ARRAY = [];
 const MAX_PATTERNS_TO_SHOW = 6;
@@ -67,7 +68,7 @@ export default function ChangeDesign( { clientId } ) {
 						return categories.includes( category );
 					} ) &&
 					// Check if the pattern is not a synced pattern.
-					( pattern.syncStatus === 'unsynced' || ! pattern.id )
+					! isPatternSynced( pattern )
 				);
 			} )
 			.slice( 0, MAX_PATTERNS_TO_SHOW );

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.jsx
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.jsx
@@ -1,9 +1,12 @@
 import { Draggable } from '@wordpress/components';
-import { createBlock, store as blocksStore } from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import BlockDraggableChip from '../block-draggable/draggable-chip';
-import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
+import {
+	isPatternSynced,
+	createSyncedPatternBlock,
+} from '../inserter/block-patterns-tab/utils';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
@@ -30,11 +33,10 @@ const InserterDraggableBlocks = ( {
 	);
 
 	const patternBlock = useMemo( () => {
-		return pattern?.type === INSERTER_PATTERN_TYPES.user &&
-			pattern?.syncStatus !== 'unsynced'
-			? [ createBlock( 'core/block', { ref: pattern.id } ) ]
+		return pattern && isPatternSynced( pattern )
+			? [ createSyncedPatternBlock( pattern ) ]
 			: undefined;
-	}, [ pattern?.type, pattern?.syncStatus, pattern?.id ] );
+	}, [ pattern ] );
 
 	if ( ! isEnabled ) {
 		return children( {

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -1,4 +1,5 @@
 import { __, _x } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 
 export const INSERTER_PATTERN_TYPES = {
 	user: 'user',
@@ -25,6 +26,37 @@ export const starterPatternsCategory = {
 	name: 'core/starter-content',
 	label: __( 'Starter content' ),
 };
+
+/**
+ * Whether inserting a pattern adds a reference to it (a `core/block`) rather
+ * than a copy of its blocks. User patterns carry a `syncStatus`; registered
+ * patterns carry a `synced` flag from the REST API.
+ *
+ * @param {Object} pattern Pattern object.
+ * @return {boolean} Whether the pattern is synced.
+ */
+export function isPatternSynced( pattern ) {
+	if ( pattern.type === INSERTER_PATTERN_TYPES.user ) {
+		return pattern.syncStatus !== INSERTER_SYNC_TYPES.unsynced;
+	}
+	return !! pattern.synced;
+}
+
+/**
+ * Creates the `core/block` that references a synced pattern: by `ref` for a
+ * user pattern, by `slug` for a registered one.
+ *
+ * @param {Object} pattern Pattern object.
+ * @return {Object} Block object.
+ */
+export function createSyncedPatternBlock( pattern ) {
+	return createBlock(
+		'core/block',
+		pattern.type === INSERTER_PATTERN_TYPES.user
+			? { ref: pattern.id }
+			: { slug: pattern.name }
+	);
+}
 
 export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 	const isUserPattern = pattern.name.startsWith( 'core/block' );
@@ -61,15 +93,14 @@ export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {
 	// Filter by sync status.
 	if (
 		syncFilter === INSERTER_SYNC_TYPES.full &&
-		pattern.syncStatus !== ''
+		! isPatternSynced( pattern )
 	) {
 		return true;
 	}
 
 	if (
 		syncFilter === INSERTER_SYNC_TYPES.unsynced &&
-		pattern.syncStatus !== 'unsynced' &&
-		isUserPattern
+		isPatternSynced( pattern )
 	) {
 		return true;
 	}

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from '@wordpress/element';
-import { cloneBlock, createBlock } from '@wordpress/blocks';
+import { cloneBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -9,7 +9,10 @@ import {
 	isNavigationOverlayContextKey,
 	userPatternCategoriesSelectKey,
 } from '../../../store/private-keys';
-import { INSERTER_PATTERN_TYPES } from '../block-patterns-tab/utils';
+import {
+	isPatternSynced,
+	createSyncedPatternBlock,
+} from '../block-patterns-tab/utils';
 import { isFiltered } from '../../../store/utils';
 
 /**
@@ -109,11 +112,9 @@ const usePatternsState = (
 			if ( destinationRootClientId === null ) {
 				return;
 			}
-			const patternBlocks =
-				pattern.type === INSERTER_PATTERN_TYPES.user &&
-				pattern.syncStatus !== 'unsynced'
-					? [ createBlock( 'core/block', { ref: pattern.id } ) ]
-					: blocks;
+			const patternBlocks = isPatternSynced( pattern )
+				? [ createSyncedPatternBlock( pattern ) ]
+				: blocks;
 			onInsert(
 				( patternBlocks ?? [] ).map( ( block ) => {
 					const clonedBlock = cloneBlock( block );

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Pattern: Add a `slug` attribute so a `core/block` can reference a registered pattern (theme, plugin or core) by name, with pattern overrides working the same way as for user patterns ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+
 ### Enhancements
 
 -   Math: Declare `interactivity.clientNavigation` support. The block's front end output is static markup, and without the declaration a Math block inside a Query block forced full page reloads on pagination ([#82248](https://github.com/WordPress/gutenberg/pull/82248)).

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
--   Pattern: Add a `slug` attribute so a `core/block` can reference a registered pattern (theme, plugin or core) by name, with pattern overrides working the same way as for user patterns ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   Pattern: Add a `slug` attribute so a `core/block` can reference a registered pattern (theme, plugin or core) by name, with pattern overrides working the same way as for user patterns ([#82544](https://github.com/WordPress/gutenberg/pull/82544)).
 
 ### Enhancements
 

--- a/packages/block-library/src/block/README.md
+++ b/packages/block-library/src/block/README.md
@@ -16,6 +16,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | Attribute | [Type](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation) | [Default](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#default-value) | Description |
 |-----------|------|---------|-------------|
 | `ref` | `number` | — | — |
+| `slug` | `string` | — | — |
 | `content` | `object` | `{}` | — |
 
 ## Supports

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -11,6 +11,9 @@
 		"ref": {
 			"type": "number"
 		},
+		"slug": {
+			"type": "string"
+		},
 		"content": {
 			"type": "object",
 			"default": {}

--- a/packages/block-library/src/block/edit.jsx
+++ b/packages/block-library/src/block/edit.jsx
@@ -25,10 +25,11 @@ import {
 	InnerBlocks,
 } from '@wordpress/block-editor';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
-import { getBlockBindingsSource } from '@wordpress/blocks';
+import { getBlockBindingsSource, parse } from '@wordpress/blocks';
 import { unlock } from '../lock-unlock';
 
 const { useLayoutClasses } = unlock( blockEditorPrivateApis );
+const EMPTY_ARRAY = [];
 const { isOverridableBlock } = unlock( patternsPrivateApis );
 
 const fullAlignments = [ 'full', 'wide', 'left', 'right' ];
@@ -79,37 +80,117 @@ const NOOP = () => {};
 // that allows short-circuiting rendering as early as possible, before any
 // of the other effects in the block edit have run.
 export default function ReusableBlockEditRecursionWrapper( props ) {
-	const { ref } = props.attributes;
-	const hasAlreadyRendered = useHasRecursion( ref );
+	const { ref, slug } = props.attributes;
+	// `ref` points at a user pattern (a `wp_block` post), `slug` at a
+	// registered pattern. `ref` wins when both are set.
+	const uniqueId = ref || slug;
+	const hasAlreadyRendered = useHasRecursion( uniqueId );
 
 	if ( hasAlreadyRendered ) {
 		return <RecursionWarning />;
 	}
 
 	return (
-		<RecursionProvider uniqueId={ ref }>
-			<ReusableBlockEdit { ...props } />
+		<RecursionProvider uniqueId={ uniqueId }>
+			{ ref ? (
+				<UserPatternEdit { ...props } />
+			) : (
+				<RegisteredPatternEdit { ...props } />
+			) }
 		</RecursionProvider>
 	);
 }
 
-function ReusableBlockControl( {
-	recordId,
-	canOverrideBlocks,
-	hasContent,
-	handleEditOriginal,
-	resetContent,
-} ) {
+/**
+ * Loads a user pattern (a `wp_block` post) referenced by `ref`.
+ *
+ * @param {Object} props Block edit props.
+ */
+function UserPatternEdit( props ) {
+	const { ref } = props.attributes;
+	const { record, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_block',
+		ref
+	);
+	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_block', {
+		id: ref,
+	} );
 	const canUserEdit = useSelect(
 		( select ) =>
 			!! select( coreStore ).canUser( 'update', {
 				kind: 'postType',
 				name: 'wp_block',
-				id: recordId,
+				id: ref,
 			} ),
-		[ recordId ]
+		[ ref ]
 	);
 
+	return (
+		<ReusableBlockEdit
+			{ ...props }
+			blocks={ blocks }
+			hasResolved={ hasResolved }
+			isMissing={ hasResolved && ! record }
+			canUserEdit={ canUserEdit }
+		/>
+	);
+}
+
+/**
+ * Loads a registered pattern (theme, plugin or core) referenced by `slug`.
+ *
+ * @param {Object} props Block edit props.
+ */
+function RegisteredPatternEdit( props ) {
+	const { slug } = props.attributes;
+	const { pattern, hasResolved } = useSelect(
+		( select ) => {
+			const _pattern = unlock(
+				select( blockEditorStore )
+			).getPatternBySlug( slug );
+			return {
+				pattern: _pattern,
+				hasResolved:
+					!! _pattern ||
+					select( coreStore ).hasFinishedResolution(
+						'getBlockPatterns'
+					),
+			};
+		},
+		[ slug ]
+	);
+	const content = pattern?.content;
+	// Parse the raw content rather than using the shared parsed pattern, so
+	// the root block isn't stamped with `metadata.patternName` and treated as
+	// an unsynced pattern instance.
+	const blocks = useMemo(
+		() =>
+			content
+				? parse( content, { __unstableSkipMigrationLogs: true } )
+				: EMPTY_ARRAY,
+		[ content ]
+	);
+
+	return (
+		<ReusableBlockEdit
+			{ ...props }
+			blocks={ blocks }
+			hasResolved={ hasResolved }
+			isMissing={ hasResolved && ! pattern }
+			// Editing a registered pattern in place is not supported yet.
+			canUserEdit={ false }
+		/>
+	);
+}
+
+function ReusableBlockControl( {
+	canUserEdit,
+	canOverrideBlocks,
+	hasContent,
+	handleEditOriginal,
+	resetContent,
+} ) {
 	return (
 		<>
 			{ canUserEdit && !! handleEditOriginal && (
@@ -145,17 +226,11 @@ function ReusableBlockEdit( {
 	attributes: { ref, content },
 	__unstableParentLayout: parentLayout,
 	setAttributes,
+	blocks,
+	hasResolved,
+	isMissing,
+	canUserEdit,
 } ) {
-	const { record, hasResolved } = useEntityRecord(
-		'postType',
-		'wp_block',
-		ref
-	);
-	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_block', {
-		id: ref,
-	} );
-	const isMissing = hasResolved && ! record;
-
 	const { __unstableMarkLastChangeAsPersistent } =
 		useDispatch( blockEditorStore );
 
@@ -233,7 +308,11 @@ function ReusableBlockEdit( {
 	if ( isMissing ) {
 		children = (
 			<Warning>
-				{ __( 'Block has been deleted or is unavailable.' ) }
+				{ ref
+					? __( 'Block has been deleted or is unavailable.' )
+					: __(
+							'The pattern this block references is not registered by the active theme or plugins.'
+					  ) }
 			</Warning>
 		);
 	}
@@ -250,7 +329,7 @@ function ReusableBlockEdit( {
 		<>
 			{ hasResolved && ! isMissing && (
 				<ReusableBlockControl
-					recordId={ ref }
+					canUserEdit={ canUserEdit }
 					canOverrideBlocks={ canOverrideBlocks }
 					hasContent={ !! content }
 					handleEditOriginal={

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -1,8 +1,10 @@
 import { symbol as icon } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import initBlock from '../utils/init-block';
+import { unlock } from '../lock-unlock';
 import metadata from './block.json';
 import edit from './edit';
 import deprecated from './deprecated';
@@ -15,21 +17,22 @@ export const settings = {
 	deprecated,
 	edit,
 	icon,
-	__experimentalLabel: ( { ref } ) => {
-		if ( ! ref ) {
-			return;
+	__experimentalLabel: ( { ref, slug } ) => {
+		if ( ref ) {
+			const entity = select( coreStore ).getEditedEntityRecord(
+				'postType',
+				'wp_block',
+				ref
+			);
+			return entity?.title ? decodeEntities( entity.title ) : undefined;
 		}
 
-		const entity = select( coreStore ).getEditedEntityRecord(
-			'postType',
-			'wp_block',
-			ref
-		);
-		if ( ! entity?.title ) {
-			return;
+		if ( slug ) {
+			const pattern = unlock(
+				select( blockEditorStore )
+			).getPatternBySlug( slug );
+			return pattern?.title ? decodeEntities( pattern.title ) : undefined;
 		}
-
-		return decodeEntities( entity.title );
 	},
 };
 

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -12,23 +12,51 @@
  *
  * @global WP_Embed $wp_embed
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes     The block attributes. Either `ref`, the ID of a
+ *                                 `wp_block` post, or `slug`, the name of a
+ *                                 registered pattern.
+ * @param string   $content        The block content.
+ * @param WP_Block $block_instance The block instance.
  *
  * @return string Rendered HTML of the referenced block.
  */
 function render_block_core_block( $attributes, $content, $block_instance ) {
 	static $seen_refs = array();
 
-	if ( empty( $attributes['ref'] ) ) {
+	$ref  = ! empty( $attributes['ref'] ) ? (int) $attributes['ref'] : 0;
+	$slug = ! empty( $attributes['slug'] ) ? (string) $attributes['slug'] : '';
+
+	if ( ! $ref && ! $slug ) {
 		return '';
 	}
 
-	$reusable_block = get_post( $attributes['ref'] );
-	if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
-		return '';
+	$reusable_block = null;
+
+	if ( $ref ) {
+		// A user pattern: a `wp_block` post.
+		$reusable_block = get_post( $ref );
+		if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
+			return '';
+		}
+
+		if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
+			return '';
+		}
+
+		$seen_key = 'ref:' . $ref;
+		$content  = $reusable_block->post_content;
+	} else {
+		// A registered pattern, referenced by its name.
+		$pattern = WP_Block_Patterns_Registry::get_instance()->get_registered( $slug );
+		if ( ! $pattern ) {
+			return '';
+		}
+
+		$seen_key = 'slug:' . $slug;
+		$content  = $pattern['content'];
 	}
 
-	if ( isset( $seen_refs[ $attributes['ref'] ] ) ) {
+	if ( isset( $seen_refs[ $seen_key ] ) ) {
 		// WP_DEBUG_DISPLAY must only be honored when WP_DEBUG. This precedent
 		// is set in `wp_debug_mode()`.
 		$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
@@ -39,15 +67,11 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 			'';
 	}
 
-	if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
-		return '';
-	}
-
-	$seen_refs[ $attributes['ref'] ] = true;
+	$seen_refs[ $seen_key ] = true;
 
 	// Handle embeds for reusable blocks.
 	global $wp_embed;
-	$content = $wp_embed->run_shortcode( $reusable_block->post_content );
+	$content = $wp_embed->run_shortcode( $content );
 	$content = $wp_embed->autoembed( $content );
 
 	// Back compat.
@@ -73,8 +97,10 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		$attributes['content'] = $attributes['overrides'];
 	}
 
-	// Apply Block Hooks.
-	$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
+	// Apply Block Hooks. Registered patterns already have them applied by the registry.
+	if ( $reusable_block ) {
+		$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
+	}
 
 	/**
 	 * We attach the blocks from $content as inner blocks to the Synced Pattern block instance.
@@ -86,7 +112,7 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 	$block_instance->refresh_context_dependents();
 
 	$content = $block_instance->render( array( 'dynamic' => false ) );
-	unset( $seen_refs[ $attributes['ref'] ] );
+	unset( $seen_refs[ $seen_key ] );
 
 	return $content;
 }

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -136,13 +136,20 @@ const selectPatterns = createSelector(
 		];
 
 		if ( syncStatus ) {
-			// User patterns can have their sync statuses checked directly
-			// Non-user patterns are all unsynced for the time being.
+			// User patterns carry `wp_pattern_sync_status`; registered
+			// patterns carry a `synced` flag.
 			patterns = patterns.filter( ( pattern ) => {
-				return pattern.type === PATTERN_TYPES.user
-					? ( pattern.wp_pattern_sync_status ||
+				if ( pattern.type === PATTERN_TYPES.user ) {
+					return (
+						( pattern.wp_pattern_sync_status ||
 							PATTERN_SYNC_TYPES.full ) === syncStatus
-					: syncStatus === PATTERN_SYNC_TYPES.unsynced;
+					);
+				}
+				return (
+					( pattern.synced
+						? PATTERN_SYNC_TYPES.full
+						: PATTERN_SYNC_TYPES.unsynced ) === syncStatus
+				);
 			} );
 		}
 

--- a/packages/editor/src/components/document-bar/useEditedSectionDetails.js
+++ b/packages/editor/src/components/document-bar/useEditedSectionDetails.js
@@ -18,7 +18,7 @@ export default function useEditedSectionDetails() {
 			__experimentalGetParsedPattern,
 		} = select( blockEditorStore );
 		const { getEditedEntityRecord, getCurrentTheme } = select( coreStore );
-		const { getEditedContentOnlySection } = unlock(
+		const { getEditedContentOnlySection, getPatternBySlug } = unlock(
 			select( blockEditorStore )
 		);
 
@@ -59,6 +59,18 @@ export default function useEditedSectionDetails() {
 				return {
 					patternName: attributes.ref,
 					patternTitle: decodeEntities( entity.title ),
+					type: 'synced-pattern',
+				};
+			}
+		}
+
+		// Handle registered patterns referenced by slug (core/block)
+		if ( blockName === 'core/block' && !! attributes?.slug ) {
+			const pattern = getPatternBySlug( attributes.slug );
+			if ( pattern?.title ) {
+				return {
+					patternName: attributes.slug,
+					patternTitle: decodeEntities( pattern.title ),
 					type: 'synced-pattern',
 				};
 			}

--- a/packages/fields/src/fields/pattern-sync-status/index.tsx
+++ b/packages/fields/src/fields/pattern-sync-status/index.tsx
@@ -24,7 +24,9 @@ const SYNC_STATUS_FILTERS = [
 
 function getPatternSyncStatus( item: Pattern ) {
 	if ( item.type && item.type !== PATTERN_TYPES.user ) {
-		return PATTERN_SYNC_TYPES.unsynced;
+		return item.synced
+			? PATTERN_SYNC_TYPES.full
+			: PATTERN_SYNC_TYPES.unsynced;
 	}
 	// When a pattern is first created directly from the post editor
 	// (`post-new.php?post_type=wp_block`), the top-level sync status is not

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -119,6 +119,8 @@ export interface Pattern extends CommonPost {
 	excerpt?: string | { raw: string; rendered: string };
 	meta?: Record< string, any >;
 	wp_pattern_sync_status?: string;
+	// Registered (theme, plugin, core) patterns only.
+	synced?: boolean;
 }
 
 export interface SiteSettings {

--- a/packages/patterns/src/components/patterns-manage-button.jsx
+++ b/packages/patterns/src/components/patterns-manage-button.jsx
@@ -33,14 +33,18 @@ function PatternsManageButton( { clientId, onClose } ) {
 			const _isUnsyncedPattern =
 				!! block?.attributes?.metadata?.patternName;
 
+			// A registered pattern (referenced by `slug`) has no post to
+			// check permissions against; detaching it only touches the
+			// current post.
 			const _isSyncedPattern =
 				!! block &&
 				isReusableBlock( block ) &&
-				!! canUser( 'update', {
-					kind: 'postType',
-					name: 'wp_block',
-					id: block.attributes.ref,
-				} );
+				( !! block.attributes.slug ||
+					!! canUser( 'update', {
+						kind: 'postType',
+						name: 'wp_block',
+						id: block.attributes.ref,
+					} ) );
 
 			return {
 				attributes: block.attributes,

--- a/phpunit/blocks/renderReusable.php
+++ b/phpunit/blocks/renderReusable.php
@@ -46,6 +46,111 @@ class Test_Blocks_RenderReusable extends WP_UnitTestCase {
 		unregister_block_bindings_source( 'test/block-binding' );
 	}
 
+	public function set_up() {
+		parent::set_up();
+		register_block_pattern(
+			'test/greeting',
+			array(
+				'title'   => 'Greeting',
+				'content' => '<!-- wp:paragraph {"metadata":{"name":"Greeting","bindings":{"__default":{"source":"core/pattern-overrides"}}}} --><p>Hello from a registered pattern!</p><!-- /wp:paragraph -->',
+			)
+		);
+		register_block_pattern(
+			'test/nested',
+			array(
+				'title'   => 'Nested',
+				'content' => '<!-- wp:block {"slug":"test/greeting"} /-->',
+			)
+		);
+	}
+
+	public function tear_down() {
+		unregister_block_pattern( 'test/greeting' );
+		unregister_block_pattern( 'test/nested' );
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_block
+	 */
+	public function test_render_registered_pattern_by_slug() {
+		$output = do_blocks( '<!-- wp:block {"slug":"test/greeting"} /-->' );
+		$this->assertSame( '<p class="wp-block-paragraph">Hello from a registered pattern!</p>', $output );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_block
+	 */
+	public function test_render_registered_pattern_by_slug_applies_overrides() {
+		$output = do_blocks( '<!-- wp:block {"slug":"test/greeting","content":{"Greeting":{"content":"Overridden on this instance"}}} /-->' );
+		$this->assertSame( '<p class="wp-block-paragraph">Overridden on this instance</p>', $output );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_block
+	 */
+	public function test_render_registered_pattern_nested_in_registered_pattern() {
+		$output = do_blocks( '<!-- wp:block {"slug":"test/nested"} /-->' );
+		$this->assertSame( '<p class="wp-block-paragraph">Hello from a registered pattern!</p>', $output );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_block
+	 */
+	public function test_render_unregistered_slug_renders_nothing() {
+		$this->assertSame( '', do_blocks( '<!-- wp:block {"slug":"test/does-not-exist"} /-->' ) );
+	}
+
+	/**
+	 * @covers ::gutenberg_render_block_core_block
+	 */
+	public function test_render_ref_wins_over_slug() {
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/block',
+				'attrs'     => array(
+					'ref'  => self::$block_id,
+					'slug' => 'test/greeting',
+				),
+			),
+			array(
+				'my-custom/context' => 'From the post',
+			)
+		);
+		$this->assertSame( '<p class="wp-block-paragraph">From the post</p>', $block->render() );
+	}
+
+	/**
+	 * @covers ::gutenberg_is_block_pattern_synced
+	 */
+	public function test_registered_patterns_are_unsynced_by_default() {
+		$this->assertFalse( gutenberg_is_block_pattern_synced( array( 'name' => 'test/greeting' ) ) );
+		$this->assertFalse(
+			gutenberg_is_block_pattern_synced(
+				array(
+					'name'   => 'test/greeting',
+					'source' => 'theme',
+				)
+			)
+		);
+		$this->assertFalse(
+			gutenberg_is_block_pattern_synced(
+				array(
+					'name'   => 'test/greeting',
+					'synced' => false,
+				)
+			)
+		);
+		$this->assertTrue(
+			gutenberg_is_block_pattern_synced(
+				array(
+					'name'   => 'test/greeting',
+					'synced' => true,
+				)
+			)
+		);
+	}
+
 	/**
 	 * @see https://github.com/WordPress/gutenberg/issues/70391
 	 */

--- a/routes/pattern-list/use-patterns.ts
+++ b/routes/pattern-list/use-patterns.ts
@@ -28,6 +28,7 @@ const { extractWords, getNormalizedSearchTerms, normalizeString } = unlock(
  */
 interface ThemePattern {
 	name: string;
+	synced?: boolean;
 	title: string;
 	content: string;
 	description: string;
@@ -99,8 +100,9 @@ function normalizeThemePattern( pattern: ThemePattern ): NormalizedPattern {
 		type: PATTERN_TYPES.theme,
 		// Normalize categories to always be an array of slugs
 		categories: pattern.categories || [],
-		// Theme patterns are always unsynced
-		syncStatus: PATTERN_SYNC_TYPES.unsynced,
+		syncStatus: pattern.synced
+			? PATTERN_SYNC_TYPES.full
+			: PATTERN_SYNC_TYPES.unsynced,
 		description: pattern.description || '',
 	};
 }


### PR DESCRIPTION
## What?

Part 1 of an exploration to unify template parts, "components" and patterns into a single concept: **registered patterns**, referenced by `core/block`.

- `core/block` gets a `slug` attribute. With `slug`, the block resolves a registered pattern (theme, plugin or core) by name, in the editor and in PHP. `ref` keeps pointing at a `wp_block` post and wins when both are set. Pattern overrides (`content` attribute + `pattern/overrides` context) work the same for both.
- Registered patterns can opt into being **synced** with `'synced' => true` at registration, or a `Synced: yes` header in a theme `patterns/` file. The block patterns REST endpoint exposes a `synced` boolean.
- Inserting a synced registered pattern (inserter click, drag and drop) inserts `<!-- wp:block {"slug":"theme/name"} /-->` instead of a copy. Unsynced patterns (the default, and every existing pattern) keep copying their blocks.
- The synced badge, the inserter sync filters, "Change design" and the Patterns page (edit-site and the extensible site editor route) treat registered patterns as synced or not based on the flag.
- Detach works on slug-based instances. "Edit original" is hidden for them for now: editing a registered pattern (creating a linked `wp_block` override) is the next PR.

## Why?

See the discussion around introducing "components" to block themes. Rather than adding a concept, the idea is to remove some: template parts and theme patterns become the same thing (registered patterns), `core/block` becomes the one way to reference one, and template parts disappear from the UI. The planned follow-ups, stacked on this PR:

1. Auto-register `parts/*.html` as synced patterns under `<theme>/part/<slug>`, and make `core/template-part` a thin alias delegating to the pattern implementation (no markup migration, `core/block` gains an optional `tagName` so headers/footers keep their landmark).
2. Editing registered patterns: a `wp_block` post linked to the registered name by post meta, resolved slug → override → registry, with "Edit" on the Patterns page.
3. Remove template part surfaces from the UI.

## How?

- `packages/block-library/src/block/`: `edit.jsx` splits into a `ref` loader (entity record, unchanged) and a `slug` loader (`getPatternBySlug` + `parse`), feeding the same controlled inner blocks component. `index.php` resolves `slug` through `WP_Block_Patterns_Registry`.
- `lib/compat/wordpress-7.2/block-patterns.php`: `gutenberg_is_block_pattern_synced()` and the `Synced: yes` header support (core's `WP_Theme::get_block_patterns()` reads a fixed header list, so opted-in theme files are re-registered on `init` at priority 11; in core this would be one more header).
- `lib/compat/wordpress-7.2/class-gutenberg-rest-block-patterns-controller-7-2.php`: adds the `synced` field.
- `packages/block-editor`: `isPatternSynced()` / `createSyncedPatternBlock()` in the inserter utils, used by the click and drag paths, the patterns list badge, the sync filters and "Change design".

## Testing Instructions

Register a synced pattern with overrides, for example in a small plugin:

```php
register_block_pattern(
	'demo/card',
	array(
		'title'   => 'Demo: Card',
		'synced'  => true,
		'content' => '<!-- wp:heading {"metadata":{"name":"Card title","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
<h2 class="wp-block-heading">Card title</h2>
<!-- /wp:heading -->
<!-- wp:paragraph -->
<p>Locked in every instance.</p>
<!-- /wp:paragraph -->',
	)
);
```

Or add `Synced: yes` to the header of a theme `patterns/*.php` file.

1. In the post editor, insert the pattern from the inserter. Expect a Pattern block (synced icon, pattern title in the toolbar) whose markup is `<!-- wp:block {"slug":"demo/card"} /-->`. Bound blocks are content-only, the unbound paragraph is disabled.
2. Edit the heading, save, view the front end: the override renders. "Reset" in the toolbar clears it.
3. Insert the same pattern twice and change the heading in one: the other keeps the registered text.
4. "Detach" in the block menu turns the instance into regular blocks, keeping the override values.
5. Insert any pattern without the flag: still a copy, as before.
6. Deactivate the plugin or remove the pattern: the block shows "The pattern this block references is not registered by the active theme or plugins" in the editor and renders nothing on the front end.

PHP: `npm run test:unit:php:base -- --filter Test_Blocks_RenderReusable`.

## Notes

- **Unsynced copies still act like patterns.** Inserting an unsynced pattern stamps `metadata.patternName` on the copy, which makes it a content-only section with an "Edit pattern" / "Exit pattern" button that only unlocks the local copy (from #71512, cc @talldan). That is pre-existing and untouched here, but with a real synced/copied distinction the label reads as if a shared pattern were being edited. Worth deciding separately whether copies should keep the locking, or just keep `metadata.patternName` for "Change design".
- "Edit original" and the block inspector's isolated edit button are hidden for slug-based instances until the override PR lands.
- `gutenberg_register_synced_theme_block_patterns()` reads one extra header per theme pattern file on `init`; it would be replaced by a header in `WP_Theme::get_block_patterns()` in core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
