### PR TITLE
Theme: Reduce repeated color ramp search work

### DIFF
--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   Update type-checking for script files to enforce NodeNext module resolution ([#82622](https://github.com/WordPress/gutenberg/pull/82622)).
 -   Remove `esbuild-esm-loader` dependency in favor of Node.js TypeScript native type-stripping ([#82680](https://github.com/WordPress/gutenberg/pull/82680)).
 -   Migrate design token modes to the DTCG resolver and Terrazzo CSS permutations. ([#82537](https://github.com/WordPress/gutenberg/pull/82537))
+-   Reuse seed-dependent calculations during color-ramp constraint searches. ([#82545](https://github.com/WordPress/gutenberg/pull/82545))
 -   Generate the default ramps before derived token artifacts so one build uses the current ramp algorithm throughout. ([#82525](https://github.com/WordPress/gutenberg/pull/82525))
 -   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))
 -   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -9,6 +9,7 @@ import {
 	getLuminance,
 	sRGB,
 	OKLCH,
+	type ColorObject,
 	type PlainColorObject,
 } from 'colorjs.io/fn';
 
@@ -87,16 +88,17 @@ function getContrastFromLuminances( first: number, second: number ): number {
 }
 
 /**
- * Assert that a seed-color string is sRGB-parseable and fully opaque (hex,
+ * Parse a seed-color string and assert that it is sRGB-parseable and fully opaque (hex,
  * `rgb()`/`rgba()`, or a CSS named color), throwing otherwise.
  *
  * Rejection is deterministic regardless of which `ColorSpace`s are globally
  * registered.
  *
  * @param seed The seed-color string to validate.
+ * @return The parsed seed color.
  * @throws If `seed` is not an sRGB-parseable, fully opaque string.
  */
-export function assertValidSeedColor( seed: string ): void {
+export function parseSeedColor( seed: string ): ReturnType< typeof parse > {
 	ALLOWED_SEED_COLOR_SPACES.forEach( ( space ) =>
 		ColorSpace.register( space )
 	);
@@ -125,15 +127,14 @@ export function assertValidSeedColor( seed: string ): void {
 			`Unsupported seed color "${ seed }": expected a fully opaque color.`
 		);
 	}
+
+	return parsedColor;
 }
 
 /**
  * Make sure that a color is valid in the sRGB gamut and convert it to OKLCH.
- * @param c A `PlainColorObject`, or an sRGB-parseable string.
+ * @param c A color object.
  */
-export function clampToGamut( c: string | PlainColorObject ) {
-	if ( typeof c === 'string' ) {
-		ColorSpace.register( sRGB );
-	}
+export function clampToGamut( c: ColorObject ) {
 	return to( toGamut( c, { space: sRGB, method: 'css' } ), OKLCH );
 }

--- a/packages/theme/src/color-ramps/lib/color-utils.ts
+++ b/packages/theme/src/color-ramps/lib/color-utils.ts
@@ -132,6 +132,8 @@ export function assertValidSeedColor( seed: string ): void {
  * @param c A `PlainColorObject`, or an sRGB-parseable string.
  */
 export function clampToGamut( c: string | PlainColorObject ) {
-	ColorSpace.register( sRGB );
+	if ( typeof c === 'string' ) {
+		ColorSpace.register( sRGB );
+	}
 	return to( toGamut( c, { space: sRGB, method: 'css' } ), OKLCH );
 }

--- a/packages/theme/src/color-ramps/lib/find-color-with-constraints.ts
+++ b/packages/theme/src/color-ramps/lib/find-color-with-constraints.ts
@@ -2,7 +2,7 @@ import { get, OKLCH, type PlainColorObject } from 'colorjs.io/fn';
 import { solveWithBisect } from './utils.ts';
 import { WHITE, BLACK, CONTRAST_EPSILON } from './constants.ts';
 import { clampToGamut, getContrast } from './color-utils.ts';
-import { type TaperChromaOptions, taperChroma } from './taper-chroma.ts';
+import { createChromaTaper, type TaperChromaOptions } from './taper-chroma.ts';
 
 /**
  * Difference of contrast values that grows linearly with the Y luminance.
@@ -60,13 +60,18 @@ export function findColorMeetingRequirements(
 			achieved: 1,
 		};
 	}
+	const seedChroma = get( seed, [ OKLCH, 'c' ] );
+	const seedHue = get( seed, [ OKLCH, 'h' ] );
+	const taperChromaAtLightness = taperChromaOptions
+		? createChromaTaper( seed, taperChromaOptions )
+		: undefined;
 
 	function getColorForL( l: number ): PlainColorObject {
 		let newL = l;
-		let newC = get( seed, [ OKLCH, 'c' ] );
+		let newC = seedChroma;
 
-		if ( taperChromaOptions ) {
-			const tapered = taperChroma( seed, newL, taperChromaOptions );
+		if ( taperChromaAtLightness ) {
+			const tapered = taperChromaAtLightness( newL );
 			// taperChroma returns either { l, c } or a ColorObject
 			if ( 'l' in tapered && 'c' in tapered ) {
 				newL = tapered.l;
@@ -79,7 +84,7 @@ export function findColorMeetingRequirements(
 
 		return clampToGamut( {
 			space: OKLCH,
-			coords: [ newL, newC, get( seed, [ OKLCH, 'h' ] ) ],
+			coords: [ newL, newC, seedHue ],
 			alpha: seed.alpha,
 		} );
 	}

--- a/packages/theme/src/color-ramps/lib/index.ts
+++ b/packages/theme/src/color-ramps/lib/index.ts
@@ -1,9 +1,9 @@
 import { clone, get, OKLCH, set, type PlainColorObject } from 'colorjs.io/fn';
 import {
-	assertValidSeedColor,
 	clampToGamut,
 	getContrast,
 	getColorString,
+	parseSeedColor,
 } from './color-utils.ts';
 import { findColorMeetingRequirements } from './find-color-with-constraints.ts';
 import {
@@ -222,13 +222,12 @@ export function buildRamp(
 		rescaleToFitContrastTargets?: boolean;
 	} = {}
 ): RampResult {
-	// Validate here: the single point where user-supplied color strings enter.
-	// Internal recursive callers pass color objects to `clampToGamut` instead.
-	assertValidSeedColor( seedArg );
+	// Parse and validate here: the single point where user-supplied color strings enter.
+	const parsedSeed = parseSeedColor( seedArg );
 
 	let seed: PlainColorObject;
 	try {
-		seed = clampToGamut( seedArg );
+		seed = clampToGamut( parsedSeed );
 	} catch ( error ) {
 		throw new Error(
 			`Invalid seed color "${ seedArg }": ${

--- a/packages/theme/src/color-ramps/lib/taper-chroma.ts
+++ b/packages/theme/src/color-ramps/lib/taper-chroma.ts
@@ -86,11 +86,7 @@ export function createChromaTaper(
 	const seedCarry = Math.pow( seedRelative, clamp01( carry ) );
 
 	return ( lTarget ) => {
-		const cmaxTarget = getMaxChromaAtLH(
-			clamp01( lTarget ),
-			hSeed,
-			gamut
-		);
+		const cmaxTarget = getMaxChromaAtLH( clamp01( lTarget ), hSeed, gamut );
 
 		// Intended chroma from local capacity, tempered by seed vividness
 		const cIntendedBase = alpha * cmaxTarget;

--- a/packages/theme/src/color-ramps/lib/taper-chroma.ts
+++ b/packages/theme/src/color-ramps/lib/taper-chroma.ts
@@ -35,6 +35,19 @@ export function taperChroma(
 	lTarget: number, // [0..1]
 	options: TaperChromaOptions = {}
 ): { l: number; c: number } | PlainColorObject {
+	return createChromaTaper( seed, options )( lTarget );
+}
+
+/**
+ * Prepare a chroma taper for repeated target-lightness calculations.
+ *
+ * @param seed    Seed color in OKLCH.
+ * @param options Chroma taper options.
+ */
+export function createChromaTaper(
+	seed: PlainColorObject,
+	options: TaperChromaOptions = {}
+): ( lTarget: number ) => { l: number; c: number } | PlainColorObject {
 	const gamut = options.gamut ?? sRGB;
 	const alpha = options.alpha ?? 0.65; // 0.7-0.8 works well for accent surface
 	const carry = options.carry ?? 0.5;
@@ -55,42 +68,48 @@ export function taperChroma(
 			hSeed = normalizeHue( options.hueFallback );
 		} else {
 			// Respect achromatic intent: grayscale at target L
-			return {
+			return ( lTarget ) => ( {
 				space: OKLCH,
 				coords: [ clamp01( lTarget ), 0, 0 ],
 				alpha: 1,
-			};
+			} );
 		}
 	}
 
-	// Capacity at seed and target
+	// Capacity at seed
 	const lSeed = clamp01( get( seed, [ OKLCH, 'l' ] ) );
 	const cmaxSeed = getMaxChromaAtLH( lSeed, hSeed, gamut );
-	const cmaxTarget = getMaxChromaAtLH( clamp01( lTarget ), hSeed, gamut );
 
 	// Seed vividness ratio (hue-fair normalization)
-	let seedRelative = 0;
 	const denom = cmaxSeed > 0 ? cmaxSeed : 1e-6;
-	seedRelative = clamp01( cSeed / denom );
+	const seedRelative = clamp01( cSeed / denom );
+	const seedCarry = Math.pow( seedRelative, clamp01( carry ) );
 
-	// Intended chroma from local capacity, tempered by seed vividness
-	const cIntendedBase = alpha * cmaxTarget;
-	const cWithCarry =
-		cIntendedBase * Math.pow( seedRelative, clamp01( carry ) );
+	return ( lTarget ) => {
+		const cmaxTarget = getMaxChromaAtLH(
+			clamp01( lTarget ),
+			hSeed,
+			gamut
+		);
 
-	// Gentle, symmetric desaturation vs distance in L
-	const t = continuousTaper( lSeed, lTarget, {
-		radiusLight,
-		radiusDark,
-		kLight,
-		kDark,
-	} );
-	const cPlanned = cWithCarry * t;
+		// Intended chroma from local capacity, tempered by seed vividness
+		const cIntendedBase = alpha * cmaxTarget;
+		const cWithCarry = cIntendedBase * seedCarry;
 
-	// Downward-only clamp (preserve L & H)
-	const lOut = clamp01( lTarget );
+		// Gentle, symmetric desaturation vs distance in L
+		const t = continuousTaper( lSeed, lTarget, {
+			radiusLight,
+			radiusDark,
+			kLight,
+			kDark,
+		} );
+		const cPlanned = cWithCarry * t;
 
-	return { l: lOut, c: cPlanned };
+		// Downward-only clamp (preserve L & H)
+		const lOut = clamp01( lTarget );
+
+		return { l: lOut, c: cPlanned };
+	};
 }
 
 /* ---------------- helpers & caches ---------------- */

--- a/packages/theme/src/color-ramps/test/index.test.ts
+++ b/packages/theme/src/color-ramps/test/index.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { getLuminance, serialize, to, HSL, sRGB } from 'colorjs.io/fn';
 import { buildAccentRamp, buildBgRamp } from '..';
 import { buildRamp } from '../lib';
-import { clampToGamut, getColorString, getContrast } from '../lib/color-utils';
+import {
+	clampToGamut,
+	getColorString,
+	getContrast,
+	parseSeedColor,
+} from '../lib/color-utils';
 import { BG_RAMP_CONFIG, ACCENT_RAMP_CONFIG } from '../lib/ramp-configs';
 import { DEFAULT_SEED_COLORS } from '../lib/constants';
 import {
@@ -252,8 +257,8 @@ describe( 'buildRamps', () => {
 		);
 		expect(
 			computeBetterFgColorDirection( [
-				clampToGamut( '#333' ),
-				clampToGamut( '#eee' ),
+				clampToGamut( parseSeedColor( '#333' ) ),
+				clampToGamut( parseSeedColor( '#eee' ) ),
 			] ).better
 		).toBe( 'darker' );
 	} );


### PR DESCRIPTION
Follow up to #82294.

## What?

Reduce repeated Color.js work in the internal theme color-ramp solver without changing generated ramps.

## Why?

Each bisection candidate reread the same seed coordinates and rebuilt the same chroma-taper inputs. Object-based gamut checks also repeated sRGB registration even though the object already identifies its color space.

## How?

Prepare the seed-dependent chroma taper once per constraint search, reuse the seed's chroma and hue, and register sRGB in `clampToGamut` only for string input. This adds no cache and does not overlap the luminance cache in #82445, the deterministic chroma-capacity cache in #82505, or the benchmark and output profiles in #82528.

## Performance

Against current trunk, six alternating process pairs reduced median calculation time by 35% to 43%.

| Case | Median reduction | p95 reduction |
| --- | ---: | ---: |
| Background ramp | 35.3% | 30.4% |
| Accent ramp | 41.1% | 45.2% |
| Full theme, uncached | 43.1% | 49.3% |

> [!Note]
> **Upcoming solver work will reduce this PR's incremental gain**. In particular, #82294 adds a new foreground path that does not yet reuse the prepared taper and adds APCA, WCAG, and serialization work. The existing constraint searches still benefit, but they become a smaller share of total theme-generation time.

## Testing Instructions

1. Run `npm run test:unit:vitest -- packages/theme/src/color-ramps/test`.
2. Run `npm run build --workspace @wordpress/theme`.
3. Confirm the build creates no generated diff.

<details>
<summary>Benchmark results</summary>

Apple M2 Pro MacBook Pro, 12 cores, 32 GB RAM, macOS 26.6.2, Node v24.20.0. The temporary uncommitted harness ran each revision in a separate Node process. Results aggregate six alternating-order process pairs. Each process measured 40 samples after 8 warmups, with 100 operations per sample for individual ramps and 10 for a full theme.

Fixtures covered default light (`#fcfcfc` / `#3858e9`), default dark (`#1e1e1e` / `#3858e9`), middle gray (`#808080` / `#808080`), and saturated (`#00ffff` / `#ff00ff`) inputs. A full theme builds the background ramp plus the primary, info, success, caution, warning, and error accent ramps without whole-theme memoization.

| Case | Trunk median | PR median | Change | Trunk p95 | PR p95 | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Background ramp | 0.485 ms | 0.314 ms | -35.3% | 0.514 ms | 0.358 ms | -30.4% |
| Accent ramp | 0.727 ms | 0.429 ms | -41.1% | 0.823 ms | 0.451 ms | -45.2% |
| Full theme, uncached | 5.579 ms | 3.174 ms | -43.1% | 6.666 ms | 3.377 ms | -49.3% |

A direct comparison across the existing 360-background and 99-accent snapshot grids plus the four full-theme fixtures produced identical 258,087-byte output, including ramp values, warnings, and directions.

</details>

### Testing Instructions for Keyboard

Not applicable. This change has no user interface.

## Screenshots or screencast

Not applicable. Generated colors are unchanged.

## Use of AI Tools

OpenAI Codex helped inspect related pull requests, build the temporary benchmark and output comparator, implement the optimization, run verification, and draft this description. The author reviewed the resulting code and measurements.
