### PR TITLE
Pattern Editing: Nest content groups and make them selectable to reorder

### DIFF
--- a/packages/block-editor/src/components/block-quick-navigation/index.jsx
+++ b/packages/block-editor/src/components/block-quick-navigation/index.jsx
@@ -1,5 +1,6 @@
 import { getBlockType } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
 import {
 	Button,
 	__experimentalVStack as VStack,
@@ -13,6 +14,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import ContentGroupHeading from '../content-group-heading';
 import { unlock } from '../../lock-unlock';
 
 export default function BlockQuickNavigation( {
@@ -28,54 +30,19 @@ export default function BlockQuickNavigation( {
 	return (
 		<VStack spacing={ 1 }>
 			{ clientIds.map( ( clientId ) => (
-				<BlockQuickNavigationGroup
-					key={ clientId }
-					clientId={ clientId }
-					showGroupHeadings={ showGroupHeadings }
-				>
+				<Fragment key={ clientId }>
+					{ showGroupHeadings && (
+						<ContentGroupHeading clientId={ clientId } />
+					) }
 					<BlockQuickNavigationItem
 						onSelect={ onSelect }
 						onSwitchToListView={ onSwitchToListView }
 						hasListViewTab={ hasListViewTab }
 						clientId={ clientId }
 					/>
-				</BlockQuickNavigationGroup>
+				</Fragment>
 			) ) }
 		</VStack>
-	);
-}
-
-function BlockQuickNavigationGroup( {
-	children,
-	clientId,
-	showGroupHeadings,
-} ) {
-	const groupHeaderClientId = useSelect(
-		( select ) => {
-			if ( ! showGroupHeadings ) {
-				return null;
-			}
-
-			return unlock(
-				select( blockEditorStore )
-			).getContentGroupHeaderClientId( clientId );
-		},
-		[ clientId, showGroupHeadings ]
-	);
-	const groupHeaderTitle = useBlockDisplayTitle( {
-		clientId: groupHeaderClientId,
-		context: 'list-view',
-	} );
-
-	return (
-		<>
-			{ groupHeaderTitle && (
-				<h2 className="block-editor-block-quick-navigation__group-heading">
-					{ groupHeaderTitle }
-				</h2>
-			) }
-			{ children }
-		</>
 	);
 }
 

--- a/packages/block-editor/src/components/block-quick-navigation/style.scss
+++ b/packages/block-editor/src/components/block-quick-navigation/style.scss
@@ -1,12 +1,3 @@
-@use "@wordpress/base-styles/variables";
-
-.block-editor-block-quick-navigation__group-heading {
-	padding: variables.$grid-unit-30 0 variables.$grid-unit-05;
-	margin: 0 !important;
-	font-size: 13px;
-	font-weight: 500;
-}
-
 .block-editor-block-quick-navigation__item {
 	font-weight: var(--wpds-typography-font-weight-default);
 }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.jsx
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.jsx
@@ -99,6 +99,7 @@ export function BlockSettingsDropdown( {
 				canMoveBlocks,
 				getBlockIndex,
 				getBlockCount,
+				isContentGroupBlock,
 			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -120,8 +121,15 @@ export function BlockSettingsDropdown( {
 				previousBlockClientId:
 					getPreviousBlockClientId( firstBlockClientId ),
 				selectedBlockClientIds: getSelectedBlockClientIds(),
+				// A named container inside a pattern is disabled rather than
+				// content-only, but it is restricted for the same reason: its
+				// design belongs to the pattern. It takes the same menu, so
+				// that reordering does not come with a way to restyle,
+				// unlock or hide the container.
 				isContentOnly:
-					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
+					getBlockEditingMode( firstBlockClientId ) ===
+						'contentOnly' ||
+					isContentGroupBlock( firstBlockClientId ),
 				isZoomOut: _isZoomOut(),
 				canEdit: canEditBlock( firstBlockClientId ),
 				canMove: canMoveBlocks( clientIds ),

--- a/packages/block-editor/src/components/block-toolbar/index.jsx
+++ b/packages/block-editor/src/components/block-toolbar/index.jsx
@@ -60,6 +60,7 @@ export function PrivateBlockToolbar( {
 		showParentSelector,
 		isUsingBindings,
 		isSectionContainer,
+		isContentGroup,
 		hasContentOnlyLocking,
 		showShuffleButton,
 		showSlots,
@@ -85,6 +86,7 @@ export function PrivateBlockToolbar( {
 			getParentSectionBlock,
 			isZoomOut,
 			isSectionBlock,
+			isContentGroupBlock,
 			isBlockHiddenAtViewport,
 			getSelectedBlockStyleState,
 			isResponsiveEditing,
@@ -154,6 +156,11 @@ export function PrivateBlockToolbar( {
 				selectedBlockClientIds.length === 1,
 			isUsingBindings: _isUsingBindings,
 			isSectionContainer: _isSectionBlock,
+			// Dragging a grouping row has nowhere to land: the container it
+			// sits in is disabled, so it exposes no drop zone. Until that is
+			// supported, the movers are the only way to reorder a group and a
+			// drag handle would be an affordance that does nothing.
+			isContentGroup: isContentGroupBlock( selectedBlockClientId ),
 			hasContentOnlyLocking: _hasTemplateLock,
 			showShuffleButton: _isZoomOut,
 			showSlots: ! _isZoomOut && ! _isEditingResponsiveStyleState,
@@ -239,7 +246,9 @@ export function PrivateBlockToolbar( {
 								) }
 							<BlockMover
 								clientIds={ blockClientIds }
-								hideDragHandle={ hideDragHandle }
+								hideDragHandle={
+									hideDragHandle || isContentGroup
+								}
 							/>
 						</ToolbarGroup>
 					</div>

--- a/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
+++ b/packages/block-editor/src/components/block-toolbar/use-has-block-toolbar.js
@@ -1,6 +1,7 @@
 import { useSelect } from '@wordpress/data';
 import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Returns true if the block toolbar should be shown.
@@ -9,8 +10,12 @@ import { store as blockEditorStore } from '../../store';
  */
 export function useHasBlockToolbar() {
 	const enabled = useSelect( ( select ) => {
-		const { getBlockEditingMode, getBlockName, getBlockSelectionStart } =
-			select( blockEditorStore );
+		const {
+			getBlockEditingMode,
+			getBlockName,
+			getBlockSelectionStart,
+			isContentGroupBlock,
+		} = unlock( select( blockEditorStore ) );
 
 		// we only care about the 1st selected block
 		// for the toolbar, so we use getBlockSelectionStart
@@ -21,10 +26,16 @@ export function useHasBlockToolbar() {
 			selectedBlockClientId &&
 			getBlockType( getBlockName( selectedBlockClientId ) );
 
+		// A named container inside a pattern is disabled so that its design
+		// stays locked, but it is selectable in List View and its toolbar is
+		// how the group is reordered among its siblings. The toolbar carries
+		// no design controls in a non-default editing mode, so it amounts to
+		// the block icon plus the mover.
 		return (
 			blockType &&
 			hasBlockSupport( blockType, '__experimentalToolbar', true ) &&
-			getBlockEditingMode( selectedBlockClientId ) !== 'disabled'
+			( getBlockEditingMode( selectedBlockClientId ) !== 'disabled' ||
+				isContentGroupBlock( selectedBlockClientId ) )
 		);
 	}, [] );
 

--- a/packages/block-editor/src/components/content-group-heading/index.jsx
+++ b/packages/block-editor/src/components/content-group-heading/index.jsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx';
+import { Fragment } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '../../store';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { unlock } from '../../lock-unlock';
+
+function ContentGroupName( { clientId } ) {
+	return useBlockDisplayTitle( { clientId, context: 'list-view' } );
+}
+
+/**
+ * Renders the heading that introduces the content rows of a named group inside
+ * a content-only pattern, or nothing when the row it precedes is not the first
+ * of its group.
+ *
+ * Groups nest, so the heading reads as a path from the outermost named
+ * container inwards. That is what tells two identically named cards apart when
+ * they sit under different parents.
+ *
+ * @param {Object}  props           Component props.
+ * @param {string}  props.clientId  Client ID of the content block the heading precedes.
+ * @param {?string} props.className Additional class name, e.g. to match the inset of the list it heads.
+ */
+export default function ContentGroupHeading( { clientId, className } ) {
+	const groupClientIds = useSelect(
+		( select ) =>
+			unlock(
+				select( blockEditorStore )
+			).getContentGroupHeadingClientIds( clientId ),
+		[ clientId ]
+	);
+
+	if ( ! groupClientIds.length ) {
+		return null;
+	}
+
+	return (
+		<h2
+			className={ clsx(
+				'block-editor-content-group-heading',
+				className
+			) }
+		>
+			{ groupClientIds.map( ( groupClientId, index ) => (
+				<Fragment key={ groupClientId }>
+					{ index > 0 && (
+						<span
+							className="block-editor-content-group-heading__separator"
+							aria-hidden="true"
+						>
+							/
+						</span>
+					) }
+					<ContentGroupName clientId={ groupClientId } />
+				</Fragment>
+			) ) }
+		</h2>
+	);
+}

--- a/packages/block-editor/src/components/content-group-heading/style.scss
+++ b/packages/block-editor/src/components/content-group-heading/style.scss
@@ -1,0 +1,15 @@
+@use "@wordpress/base-styles/variables";
+
+.block-editor-content-group-heading {
+	display: flex;
+	flex-wrap: wrap;
+	gap: variables.$grid-unit-05;
+	padding: variables.$grid-unit-30 0 variables.$grid-unit-05;
+	margin: 0 !important;
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: var(--wpds-typography-font-weight-emphasis);
+}
+
+.block-editor-content-group-heading__separator {
+	opacity: 0.6;
+}

--- a/packages/block-editor/src/components/list-view/block.jsx
+++ b/packages/block-editor/src/components/list-view/block.jsx
@@ -119,6 +119,7 @@ function ListViewBlock( {
 		positionLabel,
 		isSynced,
 		isLocked,
+		isContentGroup,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -129,6 +130,7 @@ function ListViewBlock( {
 				getEditedContentOnlySection,
 				isSyncedBlock,
 				isLockedBlock,
+				isContentGroupBlock,
 			} = unlock( select( blockEditorStore ) );
 			const settings = getSettings();
 			const attributes = getBlockAttributes( clientId );
@@ -146,12 +148,20 @@ function ListViewBlock( {
 				positionLabel: getPositionTypeLabel( attributes ),
 				isSynced: isSyncedBlock( clientId ),
 				isLocked: isLockedBlock( clientId ),
+				isContentGroup: isContentGroupBlock( clientId ),
 			};
 		},
 		[ clientId ]
 	);
 
 	const isDisabled = blockEditingMode === 'disabled';
+	// Both kinds of row are disabled, but only one of them is inert. A faded
+	// context row is outside the pattern being edited and cannot be acted on.
+	// A grouping row is inside it, and is selectable so that the block
+	// toolbar's mover can reorder the group among its siblings. Selecting it
+	// exposes no design controls: those are gated on the default editing mode,
+	// which a grouping row does not have.
+	const isFadedContext = isDisabled && ! isContentGroup;
 	const canRename =
 		!! blockName && hasBlockSupport( blockName, 'renaming', true );
 
@@ -428,6 +438,22 @@ function ListViewBlock( {
 		debouncedToggleBlockHighlight( clientId, false );
 	}, [ clientId, setIsHovered, debouncedToggleBlockHighlight ] );
 
+	const toggleExpanded = useCallback(
+		( event ) => {
+			// Prevent shift+click from opening link in a new window when toggling.
+			event.preventDefault();
+			event.stopPropagation();
+			if ( isExpanded === undefined ) {
+				return;
+			}
+			updateExpansion( {
+				type: isExpanded ? 'collapse' : 'expand',
+				clientIds: [ clientId ],
+			} );
+		},
+		[ clientId, updateExpansion, isExpanded ]
+	);
+
 	const selectEditorBlock = useCallback(
 		( event ) => {
 			// For keyboard activation (Enter/Space on a link), transfer focus
@@ -451,22 +477,6 @@ function ListViewBlock( {
 			focusListItem( focusClientId, treeGridElementRef?.current );
 		},
 		[ selectBlock, treeGridElementRef ]
-	);
-
-	const toggleExpanded = useCallback(
-		( event ) => {
-			// Prevent shift+click from opening link in a new window when toggling.
-			event.preventDefault();
-			event.stopPropagation();
-			if ( isExpanded === undefined ) {
-				return;
-			}
-			updateExpansion( {
-				type: isExpanded ? 'collapse' : 'expand',
-				clientIds: [ clientId ],
-			} );
-		},
-		[ clientId, updateExpansion, isExpanded ]
 	);
 
 	// Allow right-clicking an item in the List View to open up the block settings dropdown.
@@ -559,7 +569,8 @@ function ListViewBlock( {
 
 	const hasSiblings = siblingBlockCount > 0;
 	const canShowBlockActions = showBlockActions && ! isDisabled;
-	const hasRenderedMovers = showBlockMovers && hasSiblings && ! isDisabled;
+	const hasRenderedMovers =
+		showBlockMovers && hasSiblings && ! isFadedContext;
 	const moverCellClassName = clsx(
 		'block-editor-list-view-block__mover-cell',
 		{ 'is-visible': isHovered || isSelected }
@@ -586,13 +597,14 @@ function ListViewBlock( {
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
 		'is-synced': isSynced,
-		'is-draggable': canMoveBlock && ! isDisabled,
+		'is-draggable': canMoveBlock && ! isFadedContext,
 		'is-displacement-normal': displacement === 'normal',
 		'is-displacement-up': displacement === 'up',
 		'is-displacement-down': displacement === 'down',
 		'is-after-dragged-blocks': isAfterDraggedBlocks,
 		'is-nesting': isNesting,
-		'is-disabled': isDisabled,
+		'is-disabled': isFadedContext,
+		'is-content-group': isContentGroup,
 	} );
 
 	// Only include all selected blocks if the currently clicked on block
@@ -604,7 +616,7 @@ function ListViewBlock( {
 		: [ clientId ];
 
 	const getListViewBlockTabIndex = ( rovingTabIndex ) => {
-		if ( isDisabled ) {
+		if ( isFadedContext ) {
 			return -1;
 		}
 
@@ -621,10 +633,10 @@ function ListViewBlock( {
 			className={ classes }
 			isDragged={ isDragged }
 			onKeyDown={ onKeyDown }
-			onMouseEnter={ isDisabled ? undefined : onMouseEnter }
-			onMouseLeave={ isDisabled ? undefined : onMouseLeave }
-			onFocus={ isDisabled ? undefined : onMouseEnter }
-			onBlur={ isDisabled ? undefined : onMouseLeave }
+			onMouseEnter={ isFadedContext ? undefined : onMouseEnter }
+			onMouseLeave={ isFadedContext ? undefined : onMouseLeave }
+			onFocus={ isFadedContext ? undefined : onMouseEnter }
+			onBlur={ isFadedContext ? undefined : onMouseLeave }
 			level={ level }
 			position={ position }
 			rowCount={ rowCount }
@@ -650,7 +662,7 @@ function ListViewBlock( {
 							}
 							onMouseDown={ onMouseDown }
 							onToggleExpanded={
-								isDisabled ? undefined : toggleExpanded
+								isFadedContext ? undefined : toggleExpanded
 							}
 							ref={ ref }
 							tabIndex={ getListViewBlockTabIndex( tabIndex ) }
@@ -660,7 +672,7 @@ function ListViewBlock( {
 							selectedClientIds={ selectedClientIds }
 							ariaDescribedBy={ descriptionId }
 							visibilityLabel={ blockVisibilityDescription }
-							isDisabled={ isDisabled }
+							isDisabled={ isFadedContext }
 						/>
 						<AriaReferencedText id={ descriptionId }>
 							{ [

--- a/packages/block-editor/src/hooks/block-fields/index.jsx
+++ b/packages/block-editor/src/hooks/block-fields/index.jsx
@@ -18,6 +18,7 @@ import { replacePatternOverridesDefaultBinding } from '../../utils/block-binding
 import BlockContext from '../../components/block-context';
 import BlockIcon from '../../components/block-icon';
 import useBlockDisplayTitle from '../../components/block-title/use-block-display-title';
+import ContentGroupHeading from '../../components/content-group-heading';
 import useBlockDisplayInformation from '../../components/use-block-display-information';
 const { fieldsKey, formKey } = unlock( blocksPrivateApis );
 import FieldsDropdownMenu from './fields-dropdown-menu';
@@ -64,22 +65,6 @@ function BlockFields( {
 } ) {
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
-		context: 'list-view',
-	} );
-	const groupHeaderClientId = useSelect(
-		( select ) => {
-			if ( ! isMultiBlock ) {
-				return null;
-			}
-
-			return unlock(
-				select( blockEditorStore )
-			).getContentGroupHeaderClientId( clientId );
-		},
-		[ clientId, isMultiBlock ]
-	);
-	const groupHeaderTitle = useBlockDisplayTitle( {
-		clientId: groupHeaderClientId,
 		context: 'list-view',
 	} );
 	const blockInformation = useBlockDisplayInformation( clientId );
@@ -226,10 +211,11 @@ function BlockFields( {
 
 	return (
 		<>
-			{ groupHeaderTitle && (
-				<h2 className="block-editor-block-fields__group-heading">
-					{ groupHeaderTitle }
-				</h2>
+			{ isMultiBlock && (
+				<ContentGroupHeading
+					clientId={ clientId }
+					className="block-editor-block-fields__group-heading"
+				/>
 			) }
 			<div
 				className="block-editor-block-fields__container"

--- a/packages/block-editor/src/hooks/block-fields/styles.scss
+++ b/packages/block-editor/src/hooks/block-fields/styles.scss
@@ -32,9 +32,7 @@
 	margin: 0 !important;
 }
 
+/* The block fields list is inset, so its group headings line up with it. */
 .block-editor-block-fields__group-heading {
-	padding: $grid-unit-30 $grid-unit-20 $grid-unit-05;
-	margin: 0 !important;
-	font-size: 13px;
-	font-weight: 500;
+	padding-inline: $grid-unit-20;
 }

--- a/packages/block-editor/src/hooks/list-view.jsx
+++ b/packages/block-editor/src/hooks/list-view.jsx
@@ -77,9 +77,9 @@ export function ListViewPanel( { clientId, name } ) {
 				return null;
 			}
 
-			return unlock(
-				select( blockEditorStore )
-			).getTopMostNamedContentGroupForBlock( clientId );
+			return unlock( select( blockEditorStore ) ).getContentGroupForBlock(
+				clientId
+			);
 		},
 		[ clientId, isSelectionWithinCurrentSection ]
 	);

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -41,6 +41,8 @@ import { BLOCK_VISIBILITY_VIEWPORTS } from '../components/block-visibility/const
 const { isContentBlock, editableRootKey } = unlock( blocksPrivateApis );
 const { getViewportBreakpoints } = unlock( globalStylesEnginePrivateApis );
 
+const EMPTY_ARRAY = [];
+
 export { getBlockSettings } from './get-block-settings';
 
 function isViewportAvailable( state, viewport ) {
@@ -159,48 +161,25 @@ function hasContentOnlyDescendant( state, clientId ) {
 }
 
 /**
- * Returns whether any ancestor of the block is already surfaced as a grouping
- * row, so that only the top-most named container in a pattern becomes a group
- * and the inspector does not nest groups within groups.
- *
- * @param {Object} state    Global application state.
- * @param {string} clientId Client ID of the block.
- *
- * @return {boolean} Whether an ancestor already groups content.
- */
-function hasContentGroupAncestor( state, clientId ) {
-	let parent = state.blocks.parents.get( clientId );
-
-	while ( parent !== undefined ) {
-		if (
-			getBlockEditingMode( state, parent ) === 'disabled' &&
-			!! getBlockAttributes( state, parent )?.metadata?.name
-		) {
-			return true;
-		}
-
-		parent = state.blocks.parents.get( parent );
-	}
-
-	return false;
-}
-
-/**
  * Returns whether a disabled block should be surfaced in List View as a row
  * that groups the content blocks beneath it. A pattern author opts a container
  * in by naming it (the block rename feature), and the name is only meaningful
- * as a group when there is editable content under it to group. Only the
- * top-most named container becomes a group, to keep the flattened list flat.
+ * as a group when there is editable content under it to group.
+ *
+ * Groups nest to any depth, so a named card inside a named grid keeps both
+ * rows. Nesting mirrors the markup the author wrote: a container only becomes
+ * a row by being named, so the depth of the result is the depth the author
+ * asked for rather than the depth of the block tree.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the block.
  *
  * @return {boolean} Whether the block groups content in List View.
  */
-function isContentGroupBlock( state, clientId ) {
+export function isContentGroupBlock( state, clientId ) {
 	return (
+		getBlockEditingMode( state, clientId ) === 'disabled' &&
 		!! getBlockAttributes( state, clientId )?.metadata?.name &&
-		! hasContentGroupAncestor( state, clientId ) &&
 		hasContentOnlyDescendant( state, clientId )
 	);
 }
@@ -464,6 +443,10 @@ export const getListViewClientIdsTree = createSelector(
 		state.blocks.blockEditingModes,
 		state.blocks.parents,
 		state.editedContentOnlySection,
+		// Bumped only when a block's `metadata` changes, so that reading
+		// `metadata.name` to decide whether a container groups content does
+		// not rebuild the tree on every keystroke.
+		state.blockMetadataRevision,
 		// The state below is only read to resolve a block's parent section,
 		// which the tree does only while a content-only section is being
 		// edited. Depending on it otherwise rebuilds the tree on every
@@ -479,28 +462,29 @@ export const getListViewClientIdsTree = createSelector(
 	]
 );
 
-function getTopMostNamedContentGroupForBlockUnmemoized( state, clientId ) {
+function getContentGroupsForBlockUnmemoized( state, clientId ) {
 	const sectionClientId = getParentSectionBlock( state, clientId );
 	if ( ! sectionClientId ) {
-		return null;
+		return EMPTY_ARRAY;
 	}
 
 	const parents = getBlockParents( state, clientId );
 	const sectionIndex = parents.indexOf( sectionClientId );
 	if ( sectionIndex === -1 ) {
-		return null;
+		return EMPTY_ARRAY;
 	}
 
-	for ( const parent of parents.slice( sectionIndex + 1 ) ) {
-		const isNamedDisabledParent =
-			getBlockEditingMode( state, parent ) === 'disabled' &&
-			!! getBlockAttributes( state, parent )?.metadata?.name;
-		if ( isNamedDisabledParent ) {
-			return parent;
-		}
-	}
+	// `getBlockParents` returns ancestors outermost first, so slicing past the
+	// section keeps the path within the pattern, in the order it reads.
+	const groups = parents
+		.slice( sectionIndex + 1 )
+		.filter(
+			( parent ) =>
+				getBlockEditingMode( state, parent ) === 'disabled' &&
+				!! getBlockAttributes( state, parent )?.metadata?.name
+		);
 
-	return null;
+	return groups.length ? groups : EMPTY_ARRAY;
 }
 
 /**
@@ -540,7 +524,6 @@ export const getContentClientIdsForSection = createSelector(
 	( state ) => [
 		state.blocks.order,
 		state.blocks.byClientId,
-		state.blocks.attributes,
 		state.derivedBlockEditingModes,
 		state.blocks.blockEditingModes,
 		state.blockListSettings,
@@ -548,61 +531,79 @@ export const getContentClientIdsForSection = createSelector(
 );
 
 /**
- * Returns the top-most named disabled grouping block for a content block.
+ * Returns the named containers that group a content block, outermost first.
+ *
+ * Groups nest, so a heading built from this reads as a path — "Pricing table
+ * / Premium" — which is what distinguishes two identically named cards under
+ * different parents.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the content block.
  *
- * @return {?string} Client ID of the grouping block, or null.
+ * @return {string[]} Client IDs of the grouping blocks, outermost first.
  */
-export const getTopMostNamedContentGroupForBlock = createSelector(
-	getTopMostNamedContentGroupForBlockUnmemoized,
+export const getContentGroupsForBlock = createSelector(
+	getContentGroupsForBlockUnmemoized,
 	( state ) => [
 		state.blocks.parents,
 		state.blocks.byClientId,
-		state.blocks.attributes,
 		state.derivedBlockEditingModes,
 		state.blocks.blockEditingModes,
 		state.blockListSettings,
 		state.editedContentOnlySection,
 		state.settings,
+		state.blockMetadataRevision,
 	]
 );
 
 /**
- * Returns a group heading client ID for the first content row in a named group.
- * Later content rows in the same group return null.
+ * Returns the innermost named container that groups a content block.
  *
  * @param {Object} state    Global application state.
  * @param {string} clientId Client ID of the content block.
  *
  * @return {?string} Client ID of the grouping block, or null.
  */
-export const getContentGroupHeaderClientId = createSelector(
+export function getContentGroupForBlock( state, clientId ) {
+	const groups = getContentGroupsForBlock( state, clientId );
+	return groups.length ? groups[ groups.length - 1 ] : null;
+}
+
+/**
+ * Returns the group path to render as a heading above a content row, or an
+ * empty array when the row is not the first of its group and so sits under a
+ * heading that has already been rendered.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId Client ID of the content block.
+ *
+ * @return {string[]} Client IDs of the grouping blocks, outermost first.
+ */
+export const getContentGroupHeadingClientIds = createSelector(
 	( state, clientId ) => {
-		const groupClientId = getTopMostNamedContentGroupForBlock(
-			state,
-			clientId
-		);
+		const groupClientId = getContentGroupForBlock( state, clientId );
 		if ( ! groupClientId ) {
-			return null;
+			return EMPTY_ARRAY;
 		}
 
 		const sectionClientId = getParentSectionBlock( state, clientId );
 		if ( ! sectionClientId ) {
-			return null;
+			return EMPTY_ARRAY;
 		}
 
+		// A group's content rows are consecutive in document order, so the
+		// first row carrying this group is the one the heading belongs above.
 		const firstClientIdInGroup = getContentClientIdsForSection(
 			state,
 			sectionClientId
 		).find(
 			( current ) =>
-				getTopMostNamedContentGroupForBlock( state, current ) ===
-				groupClientId
+				getContentGroupForBlock( state, current ) === groupClientId
 		);
 
-		return firstClientIdInGroup === clientId ? groupClientId : null;
+		return firstClientIdInGroup === clientId
+			? getContentGroupsForBlock( state, clientId )
+			: EMPTY_ARRAY;
 	},
 	( state ) => [
 		state.blocks.order,
@@ -614,6 +615,7 @@ export const getContentGroupHeaderClientId = createSelector(
 		state.blockListSettings,
 		state.editedContentOnlySection,
 		state.settings,
+		state.blockMetadataRevision,
 	]
 );
 
@@ -875,8 +877,6 @@ export const getAllPatterns = createRegistrySelector( ( select ) =>
 		);
 	}, getAllPatternsDependants( select ) )
 );
-
-const EMPTY_ARRAY = [];
 
 export const getReusableBlocks = createRegistrySelector(
 	( select ) => ( state ) => {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1906,6 +1906,54 @@ export function lastBlockAttributesChange( state = null, action ) {
 }
 
 /**
+ * Returns whether an attribute update touches a block's `metadata` attribute.
+ *
+ * @param {Object} action Dispatched action.
+ *
+ * @return {boolean} Whether `metadata` is part of the update.
+ */
+function hasMetadataUpdate( action ) {
+	if ( action.type === 'UPDATE_BLOCK' ) {
+		return (
+			!! action.updates?.attributes &&
+			'metadata' in action.updates.attributes
+		);
+	}
+
+	return action.clientIds.some( ( clientId ) => {
+		const attributes = action.options?.uniqueByBlock
+			? action.attributes[ clientId ]
+			: action.attributes;
+		return !! attributes && 'metadata' in attributes;
+	} );
+}
+
+/**
+ * Reducer returning a revision that changes whenever a block's `metadata`
+ * attribute may have changed without the block tree itself changing shape.
+ *
+ * Selectors that read `metadata` depend on this instead of on
+ * `state.blocks.attributes`, which is replaced on every attribute change and
+ * so would invalidate them on every keystroke. Structural changes are already
+ * covered by `state.blocks.order`, so only in-place attribute updates need to
+ * be counted here.
+ *
+ * @param {number} state  Current revision.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {number} Updated revision.
+ */
+export function blockMetadataRevision( state = 0, action ) {
+	switch ( action.type ) {
+		case 'UPDATE_BLOCK':
+		case 'UPDATE_BLOCK_ATTRIBUTES':
+			return hasMetadataUpdate( action ) ? state + 1 : state;
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning current highlighted block.
  *
  * @param {boolean} state  Current highlighted block.
@@ -2437,6 +2485,7 @@ const combinedReducers = combineReducers( {
 	settings,
 	preferences,
 	lastBlockAttributesChange,
+	blockMetadataRevision,
 	lastFocus,
 	expandedBlock,
 	highlightedBlock,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -33,6 +33,7 @@ import {
 	getSectionRootClientId,
 	isSectionBlock,
 	getParentSectionBlock,
+	isContentGroupBlock,
 	isZoomOut,
 	isContainerInsertableToInContentOnlyMode,
 	getClientIdWithClientIdsTree,
@@ -2141,6 +2142,23 @@ export function canMoveBlock( state, clientId ) {
 	}
 
 	const isBlockWithinSection = !! getParentSectionBlock( state, clientId );
+
+	// A named container inside a pattern is surfaced in List View as a row
+	// that groups the content beneath it, and reordering those rows among
+	// their siblings is the point of naming them. The rules below otherwise
+	// refuse it twice over: a container is not a content block, and its parent
+	// is disabled.
+	//
+	// This permits a reorder and nothing more. Every lock that could forbid
+	// the move — preview mode, static inner content, `lock.move`, a
+	// `templateLock` of 'all' — has already been applied above, and
+	// `moveBlocksToPosition` only skips its remove and insert checks when the
+	// move stays inside the same parent, so a group still cannot be lifted
+	// out of the pattern.
+	if ( isBlockWithinSection && isContentGroupBlock( state, clientId ) ) {
+		return true;
+	}
+
 	const isContentRoleBlock = isContentBlock(
 		getBlockName( state, clientId )
 	);

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -19,6 +19,8 @@ import {
 	isBlockSubtreeDisabled,
 	getEnabledClientIdsTree,
 	getListViewClientIdsTree,
+	getContentGroupsForBlock,
+	getContentGroupHeadingClientIds,
 	getEnabledBlockParents,
 	getExpandedBlock,
 	isDragging,
@@ -1273,6 +1275,140 @@ describe( 'private selectors', () => {
 
 		// The memoization above is only reachable if the reducer preserves
 		// these references through a keystroke.
+
+		// A pattern whose grid contains two named cards, each holding one
+		// editable heading. Nothing is being edited, so the pattern is
+		// flattened and only the named containers hold the list together.
+		const createGroupedState = () => ( {
+			settings: {},
+			blocks: {
+				byClientId: new Map( [
+					[ 'pattern', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'grid', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'card-a', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'card-b', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'heading-a', { name: TEST_CONTENT_BLOCK } ],
+					[ 'heading-b', { name: TEST_CONTENT_BLOCK } ],
+				] ),
+				attributes: new Map( [
+					[
+						'pattern',
+						{ metadata: { patternName: 'test/pattern' } },
+					],
+					[ 'grid', { metadata: { name: 'Pricing table' } } ],
+					[ 'card-a', { metadata: { name: 'Lite' } } ],
+					[ 'card-b', { metadata: { name: 'Premium' } } ],
+				] ),
+				order: new Map( [
+					[ '', [ 'pattern' ] ],
+					[ 'pattern', [ 'grid' ] ],
+					[ 'grid', [ 'card-a', 'card-b' ] ],
+					[ 'card-a', [ 'heading-a' ] ],
+					[ 'card-b', [ 'heading-b' ] ],
+					[ 'heading-a', [] ],
+					[ 'heading-b', [] ],
+				] ),
+				parents: new Map( [
+					[ 'pattern', '' ],
+					[ 'grid', 'pattern' ],
+					[ 'card-a', 'grid' ],
+					[ 'card-b', 'grid' ],
+					[ 'heading-a', 'card-a' ],
+					[ 'heading-b', 'card-b' ],
+				] ),
+				blockEditingModes: new Map(),
+			},
+			blockListSettings: new Map(),
+			editedContentOnlySection: null,
+			blockMetadataRevision: 0,
+			derivedBlockEditingModes: new Map( [
+				[ 'pattern', 'disabled' ],
+				[ 'grid', 'disabled' ],
+				[ 'card-a', 'disabled' ],
+				[ 'card-b', 'disabled' ],
+				[ 'heading-a', 'contentOnly' ],
+				[ 'heading-b', 'contentOnly' ],
+			] ),
+		} );
+
+		it( 'surfaces named containers as grouping rows, nested to any depth', () => {
+			expect( getListViewClientIdsTree( createGroupedState() ) ).toEqual(
+				[
+					{
+						clientId: 'grid',
+						innerBlocks: [
+							{
+								clientId: 'card-a',
+								innerBlocks: [
+									{ clientId: 'heading-a', innerBlocks: [] },
+								],
+							},
+							{
+								clientId: 'card-b',
+								innerBlocks: [
+									{ clientId: 'heading-b', innerBlocks: [] },
+								],
+							},
+						],
+					},
+				]
+			);
+		} );
+
+		it( 'omits a named container that groups no editable content', () => {
+			const state = createGroupedState();
+			state.derivedBlockEditingModes.set( 'heading-a', 'disabled' );
+			state.derivedBlockEditingModes.set( 'heading-b', 'disabled' );
+
+			expect( getListViewClientIdsTree( state ) ).toEqual( [] );
+		} );
+
+		it( 'omits an unnamed container while keeping the named ones', () => {
+			const state = createGroupedState();
+			state.blocks.attributes.delete( 'grid' );
+
+			expect( getListViewClientIdsTree( state ) ).toEqual( [
+				{
+					clientId: 'card-a',
+					innerBlocks: [ { clientId: 'heading-a', innerBlocks: [] } ],
+				},
+				{
+					clientId: 'card-b',
+					innerBlocks: [ { clientId: 'heading-b', innerBlocks: [] } ],
+				},
+			] );
+		} );
+
+		it( 'rebuilds when a block is renamed', () => {
+			const state = createGroupedState();
+			const before = getListViewClientIdsTree( state );
+
+			const renamed = {
+				...state,
+				blocks: {
+					...state.blocks,
+					attributes: new Map( state.blocks.attributes ),
+				},
+				blockMetadataRevision: 1,
+			};
+			renamed.blocks.attributes.delete( 'card-a' );
+
+			expect( getListViewClientIdsTree( renamed ) ).not.toBe( before );
+			expect( getListViewClientIdsTree( renamed ) ).toEqual( [
+				{
+					clientId: 'grid',
+					innerBlocks: [
+						{ clientId: 'heading-a', innerBlocks: [] },
+						{
+							clientId: 'card-b',
+							innerBlocks: [
+								{ clientId: 'heading-b', innerBlocks: [] },
+							],
+						},
+					],
+				},
+			] );
+		} );
 		it( 'should keep its dependants referentially stable while typing', () => {
 			const block = ( clientId ) => ( {
 				clientId,
@@ -1299,6 +1435,98 @@ describe( 'private selectors', () => {
 			expect( getListViewClientIdsTree( next ) ).toBe(
 				getListViewClientIdsTree( state )
 			);
+		} );
+	} );
+
+	describe( 'content group paths', () => {
+		const TEST_CONTENT_BLOCK = 'core/test-group-path-content-block';
+		const TEST_STRUCTURE_BLOCK = 'core/test-group-path-structure-block';
+
+		const createState = () => ( {
+			settings: {},
+			blocks: {
+				byClientId: new Map( [
+					[ 'pattern', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'grid', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'card-a', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'card-b', { name: TEST_STRUCTURE_BLOCK } ],
+					[ 'heading-a', { name: TEST_CONTENT_BLOCK } ],
+					[ 'text-a', { name: TEST_CONTENT_BLOCK } ],
+					[ 'heading-b', { name: TEST_CONTENT_BLOCK } ],
+				] ),
+				attributes: new Map( [
+					[
+						'pattern',
+						{ metadata: { patternName: 'test/pattern' } },
+					],
+					[ 'grid', { metadata: { name: 'Pricing table' } } ],
+					[ 'card-a', { metadata: { name: 'Lite' } } ],
+					[ 'card-b', { metadata: { name: 'Premium' } } ],
+				] ),
+				order: new Map( [
+					[ '', [ 'pattern' ] ],
+					[ 'pattern', [ 'grid' ] ],
+					[ 'grid', [ 'card-a', 'card-b' ] ],
+					[ 'card-a', [ 'heading-a', 'text-a' ] ],
+					[ 'card-b', [ 'heading-b' ] ],
+					[ 'heading-a', [] ],
+					[ 'text-a', [] ],
+					[ 'heading-b', [] ],
+				] ),
+				parents: new Map( [
+					[ 'pattern', '' ],
+					[ 'grid', 'pattern' ],
+					[ 'card-a', 'grid' ],
+					[ 'card-b', 'grid' ],
+					[ 'heading-a', 'card-a' ],
+					[ 'text-a', 'card-a' ],
+					[ 'heading-b', 'card-b' ],
+				] ),
+				blockEditingModes: new Map(),
+			},
+			blockListSettings: new Map(),
+			editedContentOnlySection: null,
+			blockMetadataRevision: 0,
+			derivedBlockEditingModes: new Map( [
+				[ 'pattern', 'disabled' ],
+				[ 'grid', 'disabled' ],
+				[ 'card-a', 'disabled' ],
+				[ 'card-b', 'disabled' ],
+				[ 'heading-a', 'contentOnly' ],
+				[ 'text-a', 'contentOnly' ],
+				[ 'heading-b', 'contentOnly' ],
+			] ),
+		} );
+
+		it( 'returns the group path outermost first', () => {
+			expect(
+				getContentGroupsForBlock( createState(), 'heading-a' )
+			).toEqual( [ 'grid', 'card-a' ] );
+		} );
+
+		it( 'returns an empty path for a block outside any named group', () => {
+			const state = createState();
+			state.blocks.attributes.delete( 'grid' );
+			state.blocks.attributes.delete( 'card-a' );
+
+			expect( getContentGroupsForBlock( state, 'heading-a' ) ).toEqual(
+				[]
+			);
+		} );
+
+		it( 'heads only the first content row of each group', () => {
+			const state = createState();
+
+			expect(
+				getContentGroupHeadingClientIds( state, 'heading-a' )
+			).toEqual( [ 'grid', 'card-a' ] );
+			// Same group as heading-a, so it sits under a heading already rendered.
+			expect(
+				getContentGroupHeadingClientIds( state, 'text-a' )
+			).toEqual( [] );
+			expect(
+				getContentGroupHeadingClientIds( state, 'heading-b' )
+			).toEqual( [ 'grid', 'card-b' ] );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -34,6 +34,7 @@ import {
 	blockListSettings,
 	settings,
 	lastBlockAttributesChange,
+	blockMetadataRevision,
 	lastBlockInserted,
 	expandedBlock,
 	zoomLevel,
@@ -3717,6 +3718,76 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( new Map() );
+		} );
+	} );
+
+	describe( 'blockMetadataRevision', () => {
+		it( 'defaults to 0', () => {
+			expect( blockMetadataRevision( undefined, {} ) ).toBe( 0 );
+		} );
+
+		it( 'does not change while typing into a block', () => {
+			expect(
+				blockMetadataRevision( 3, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					clientIds: [ 'chicken' ],
+					attributes: { content: 'ribs' },
+				} )
+			).toBe( 3 );
+		} );
+
+		it( 'changes when an attribute update includes metadata', () => {
+			expect(
+				blockMetadataRevision( 3, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					clientIds: [ 'chicken' ],
+					attributes: { metadata: { name: 'Lite' } },
+				} )
+			).toBe( 4 );
+		} );
+
+		it( 'changes when metadata is cleared', () => {
+			expect(
+				blockMetadataRevision( 3, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					clientIds: [ 'chicken' ],
+					attributes: { metadata: undefined },
+				} )
+			).toBe( 4 );
+		} );
+
+		it( 'changes when any block in a per-block update includes metadata', () => {
+			expect(
+				blockMetadataRevision( 3, {
+					type: 'UPDATE_BLOCK_ATTRIBUTES',
+					clientIds: [ 'chicken', 'ribs' ],
+					attributes: {
+						chicken: { content: 'ribs' },
+						ribs: { metadata: { name: 'Premium' } },
+					},
+					options: { uniqueByBlock: true },
+				} )
+			).toBe( 4 );
+		} );
+
+		it( 'changes when a whole-block update includes metadata', () => {
+			expect(
+				blockMetadataRevision( 3, {
+					type: 'UPDATE_BLOCK',
+					clientId: 'chicken',
+					updates: { attributes: { metadata: { name: 'Lite' } } },
+				} )
+			).toBe( 4 );
+		} );
+
+		it( 'does not change when a whole-block update omits attributes', () => {
+			expect(
+				blockMetadataRevision( 3, {
+					type: 'UPDATE_BLOCK',
+					clientId: 'chicken',
+					updates: {},
+				} )
+			).toBe( 3 );
 		} );
 	} );
 

--- a/packages/block-editor/src/store/test/selectors.jsdom.test.jsx
+++ b/packages/block-editor/src/store/test/selectors.jsdom.test.jsx
@@ -5164,6 +5164,75 @@ describe( 'selectors', () => {
 			expect( canMoveBlock( state, 'child' ) ).toBe( false );
 		} );
 
+		it( 'allows moving a named container that groups content inside a section', () => {
+			// A named container inside a pattern is surfaced in List View as a
+			// grouping row, and reordering those rows is the point of naming
+			// them. It is not a content block and its parent is disabled, so
+			// both section rules would otherwise refuse the move.
+			const buildState = ( cardMetadata ) => ( {
+				blocks: {
+					byClientId: new Map(
+						Object.entries( {
+							section: { name: 'core/test-block-b' },
+							grid: { name: 'core/test-block-a' },
+							card: { name: 'core/test-block-a' },
+							heading: { name: 'core/test-content-block' },
+						} )
+					),
+					attributes: new Map(
+						Object.entries( {
+							section: {
+								// patternName makes this block a section.
+								metadata: { patternName: 'test-pattern' },
+							},
+							grid: { metadata: { name: 'Pricing table' } },
+							card: cardMetadata,
+							heading: {},
+						} )
+					),
+					parents: new Map(
+						Object.entries( {
+							section: '',
+							grid: 'section',
+							card: 'grid',
+							heading: 'card',
+						} )
+					),
+					order: new Map( [
+						[ '', [ 'section' ] ],
+						[ 'section', [ 'grid' ] ],
+						[ 'grid', [ 'card' ] ],
+						[ 'card', [ 'heading' ] ],
+					] ),
+					blockEditingModes: new Map(),
+				},
+				blockListSettings: new Map( [
+					[ 'section', {} ],
+					[ 'grid', {} ],
+					[ 'card', {} ],
+				] ),
+				settings: {
+					[ sectionRootClientIdKey ]: '',
+				},
+				derivedBlockEditingModes: new Map( [
+					[ 'grid', 'disabled' ],
+					[ 'card', 'disabled' ],
+					[ 'heading', 'contentOnly' ],
+				] ),
+			} );
+
+			expect(
+				canMoveBlock(
+					buildState( { metadata: { name: 'Lite' } } ),
+					'card'
+				)
+			).toBe( true );
+
+			// Without a name the container is not a grouping row, so the
+			// ordinary section rules still refuse the move.
+			expect( canMoveBlock( buildState( {} ), 'card' ) ).toBe( false );
+		} );
+
 		it( 'allows moving a content block within a content container inside a section', () => {
 			// When both the container and the child are content blocks,
 			// the contentOnly gating allows moving

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -21,6 +21,7 @@
 @use "./components/block-popover/style.scss" as *;
 @use "./components/block-preview/style.scss" as *;
 @use "./components/block-quick-navigation/style.scss" as *;
+@use "./components/content-group-heading/style.scss" as *;
 @use "./components/block-rename/style.scss" as *;
 @use "./components/block-styles/style.scss" as *;
 @use "./components/block-switcher/style.scss" as *;

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -175,11 +175,13 @@ test.describe( 'Unsynced pattern', () => {
 			} )
 		).not.toBeAttached();
 
+		// A named container is surfaced as a grouping row. It is actionable —
+		// it can be expanded and moved — so it is not announced as disabled.
 		const namedGroup = listView.getByRole( 'gridcell', {
 			name: 'Card',
 		} );
 		await expect( namedGroup ).toBeVisible();
-		await expect( namedGroup.locator( 'a' ) ).toHaveAttribute(
+		await expect( namedGroup.locator( 'a' ) ).not.toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -187,6 +189,12 @@ test.describe( 'Unsynced pattern', () => {
 			'href',
 			/#block-/
 		);
+
+		// The grouping row is a level of its own, so the content blocks it
+		// groups sit behind it and it has to be expanded to reach them.
+		await namedGroup
+			.getByTestId( 'list-view-expander' )
+			.click( { force: true } );
 
 		// Assert that content blocks are present in List View.
 		await expect(
@@ -236,6 +244,114 @@ test.describe( 'Unsynced pattern', () => {
 								},
 							},
 							{ name: 'core/image' },
+						],
+					},
+				],
+			},
+		] );
+	} );
+
+	test( 'nests and reorders named content groups in content only mode', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.setContent( `<!-- wp:group {"metadata":{"patternName":"core/block/123","name":"My pattern"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:group {"metadata":{"name":"Pricing table"},"layout":{"type":"flex"}} -->
+<div class="wp-block-group"><!-- wp:group {"metadata":{"name":"Lite"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading">Lite plan</h2>
+<!-- /wp:heading --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"metadata":{"name":"Premium"},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 class="wp-block-heading">Premium plan</h2>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'access+o' );
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		const expand = async ( name ) =>
+			listView
+				.getByRole( 'gridcell', { name } )
+				.getByTestId( 'list-view-expander' )
+				.click( { force: true } );
+
+		// A named container inside another named container is a group of its
+		// own, so both levels are kept and each can be expanded in turn.
+		await expand( 'My pattern' );
+		const pricingTable = listView.getByRole( 'gridcell', {
+			name: 'Pricing table',
+		} );
+		await expect( pricingTable ).toBeVisible();
+
+		await expand( 'Pricing table' );
+		await expect(
+			listView.getByRole( 'gridcell', { name: 'Lite', exact: true } )
+		).toBeVisible();
+		await expect(
+			listView.getByRole( 'gridcell', { name: 'Premium', exact: true } )
+		).toBeVisible();
+
+		// A grouping row is selectable, so the block toolbar is what reorders
+		// it. The card is a plain group inside a pattern, which the editing
+		// rules would otherwise refuse to move.
+		const liteRow = listView.getByRole( 'row' ).filter( {
+			has: page.getByRole( 'gridcell', { name: 'Lite', exact: true } ),
+		} );
+		await liteRow
+			.getByRole( 'link', { name: 'Lite', exact: true } )
+			.click();
+		await expect(
+			liteRow.getByRole( 'gridcell', { name: 'Lite', exact: true } )
+		).toHaveAttribute( 'aria-selected', 'true' );
+
+		await editor.showBlockToolbar();
+		const blockToolbar = page.getByRole( 'toolbar', {
+			name: 'Block tools',
+		} );
+
+		// The movers follow the parent's layout, which is flex here.
+		const moveRight = blockToolbar.getByRole( 'button', {
+			name: 'Move right',
+		} );
+		await expect( moveRight ).toBeEnabled();
+
+		// Selecting the group must not come with a way to restyle, unlock or
+		// hide it. Those all live behind the settings menu, which is empty for
+		// a grouping row and so does not render.
+		await expect(
+			blockToolbar.getByRole( 'button', { name: 'Options' } )
+		).not.toBeAttached();
+
+		await moveRight.click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				innerBlocks: [
+					{
+						name: 'core/group',
+						attributes: {
+							metadata: { name: 'Pricing table' },
+						},
+						innerBlocks: [
+							{
+								name: 'core/group',
+								attributes: {
+									metadata: { name: 'Premium' },
+								},
+							},
+							{
+								name: 'core/group',
+								attributes: { metadata: { name: 'Lite' } },
+							},
 						],
 					},
 				],

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -330,6 +330,13 @@ test.describe( 'Unsynced pattern', () => {
 			blockToolbar.getByRole( 'button', { name: 'Options' } )
 		).not.toBeAttached();
 
+		// No drag handle either: the container a grouping row sits in is
+		// disabled and so exposes no drop zone, which would leave the handle
+		// with nowhere to land. The movers are the way to reorder for now.
+		await expect(
+			blockToolbar.getByRole( 'button', { name: 'Drag' } )
+		).not.toBeAttached();
+
 		await moveRight.click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -913,6 +913,11 @@
 			"count": 1
 		}
 	},
+	"packages/block-editor/src/components/content-group-heading/index.jsx": {
+		"react/jsx-filename-extension": {
+			"count": 1
+		}
+	},
 	"packages/block-editor/src/components/contrast-checker/index.jsx": {
 		"react/jsx-filename-extension": {
 			"count": 1


### PR DESCRIPTION
> [!CAUTION]
> THIS IS AN EARLY DRAFT AND NOT READY FOR REVIEW YET

> [!IMPORTANT]
> Stacked PR. Base is `add/pattern-grouping-using-names-rebased` — @talldan's #79483 replayed onto trunk — so this diff is only the work on top.

## What?

Named containers inside a pattern now nest, and a grouping row can be selected and reordered. Refs #75463.

## Why?

Naming a nested container was a silent no-op, and a grouping row could be focused but not acted on.

## How?

- Grouping rows nest at any depth. Content panel headings show the path (`Pricing table / Premium`).
- A grouping row is selectable; the block toolbar's mover reorders it.
- `canMoveBlock`, `useHasBlockToolbar` and `BlockSettingsDropdown` each carve out grouping rows — the last so reordering cannot also restyle or unlock.
- `metadata.name` is read via a new `blockMetadataRevision` reducer, so List View is not rebuilt per keystroke.
- The drag handle is hidden: a disabled container exposes no drop zone, so a drag has nowhere to land.

## Testing Instructions

1. Paste the markup below into the code editor.
2. Open List View and expand the pattern. The named containers appear as nested rows.
3. Select a card row, then use Move left / Move right in the block toolbar.
4. Select a heading inside a card — the Content panel heading reads `Pricing table / Lite`.

<details><summary>Pattern markup</summary>

```html
<!-- wp:group {"metadata":{"patternName":"test/pricing","name":"Pricing, 3 columns"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"metadata":{"name":"Pricing table"},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:group {"metadata":{"name":"Lite"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Lite</h3>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>For getting started.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Premium"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Premium</h3>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>For teams.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Expert"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Expert</h3>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>For agencies.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

</details>

<details><summary>Edge cases — deeply nested</summary>

The block names say what each case is. `Design only` and `Empty` should **not** become rows; the rest should.

```html
<!-- wp:group {"metadata":{"patternName":"test/kitchen-sink","name":"Kitchen sink"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"metadata":{"name":"Level 1"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"metadata":{"name":"Level 3 under unnamed"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Deep heading</h4>
<!-- /wp:heading --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Level 1"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Duplicate name nested inside the same name.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Design only"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator --></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Twin"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Twin A</h4>
<!-- /wp:heading --></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Twin"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Twin B</h4>
<!-- /wp:heading --></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Empty"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:group {"metadata":{"name":"Holder"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"metadata":{"name":"Inner"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Only child is another named group.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:columns {"metadata":{"name":"Grid"}} -->
<div class="wp-block-columns"><!-- wp:column {"metadata":{"name":"Col A"}} -->
<div class="wp-block-column"><!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Col A heading</h4>
<!-- /wp:heading --></div>
<!-- /wp:column -->

<!-- wp:column {"metadata":{"name":"Col B"}} -->
<div class="wp-block-column"><!-- wp:heading {"level":4} -->
<h4 class="wp-block-heading">Col B heading</h4>
<!-- /wp:heading --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:group {"metadata":{"name":"Has a list view block"},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

</details>

## Screenshots or screencast

Same pattern and post in both.

| Before | After |
| ------ | ----- |
| ![List View and Content panel on the base branch: a flat list of headings and paragraphs under a single Pricing table label](https://github.com/user-attachments/assets/bf3e669d-4531-4171-a059-ebbd3e1ba958) | ![List View and Content panel with grouping: Lite, Premium and Expert appear as nested rows, and the Content panel headings read Pricing table/Lite, Pricing table/Premium and Pricing table/Expert](https://github.com/user-attachments/assets/9b486d17-e682-4358-89da-caee55b0006f) |

A selected grouping row gets the movers and nothing else:

![The Lite grouping row selected in List View, with a block toolbar showing only the parent selector, the block icon and the move left and move right buttons](https://github.com/user-attachments/assets/33802fce-34cf-4670-bbfc-dfc952f19ef6)

## Open questions

- Drag support: do it properly, or is mover-only enough for now?
- `Duplicate` / `Remove` are suppressed by the content-only restriction. Add them back?

## Use of AI Tools

Written with Claude Code; I reviewed it.


