### PR TITLE
Core Data: Return a stable record for equivalent `_fields` queries

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -9,15 +9,11 @@
 -   The `getGlobalStyles` and `saveGlobalStyles` shortcuts now use `GlobalStyles` instead of the unrelated `GlobalStylesRevision` record. `saveGlobalStyles` requires the record ID and accepts a plain string title, matching the REST API update route and schema. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   `RenderedText` omits `raw` outside the edit context instead of typing it as `never`, so a record requested with `context: 'view'` or `context: 'embed'` no longer exposes `title.raw` or `content.raw`. Read `rendered` in those contexts, or request the record with `context: 'edit'`. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 
-### Enhancements
-
--   Add `page_for_privacy_policy` to the `Settings` entity type, exposed by the Gutenberg plugin from the `wp_page_for_privacy_policy` option ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
-
 ### Bug Fixes
 
 -   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 -   `EntityProvider`: a `revisionId` now only affects the entity it is set on. Other entities rendered inside it, such as the posts in a Query Loop, keep showing their own data ([#82517](https://github.com/WordPress/gutenberg/pull/82517)).
--   `getEntityRecord` and `getRevision` return the same record for queries that request the same `_fields`, instead of a new object on every call, which made `useSelect` warn under `SCRIPT_DEBUG` ([#00000](https://github.com/WordPress/gutenberg/pull/00000)).
+-   `getEntityRecord` and `getRevision` return the same record for queries that request the same `_fields`, instead of a new object on every call, which made `useSelect` warn under `SCRIPT_DEBUG` ([#82552](https://github.com/WordPress/gutenberg/pull/82552)).
 
 ### Enhancements
 
@@ -28,6 +24,7 @@
 -   Match the Navigation embed record and current global styles ID types to their REST responses. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   Export `ContextualField` so plugins can describe context-sensitive fields when extending the entity record map. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   `PostStatus` accepts statuses registered by WordPress or plugins while preserving autocomplete for the built-in values. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
+-   Add `page_for_privacy_policy` to the `Settings` entity type, exposed by the Gutenberg plugin from the `wp_page_for_privacy_policy` option ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
 
 ### Internal
 

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 -   Keep a query's `totalItems` in sync when records are removed from it, so the page count is correct after a deletion instead of only after the next fetch ([#82244](https://github.com/WordPress/gutenberg/pull/82244)).
 -   `EntityProvider`: a `revisionId` now only affects the entity it is set on. Other entities rendered inside it, such as the posts in a Query Loop, keep showing their own data ([#82517](https://github.com/WordPress/gutenberg/pull/82517)).
+-   `getEntityRecord` and `getRevision` return the same record for queries that request the same `_fields`, instead of a new object on every call, which made `useSelect` warn under `SCRIPT_DEBUG` ([#00000](https://github.com/WordPress/gutenberg/pull/00000)).
 
 ### Enhancements
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -12,8 +12,8 @@ import {
 import { DEFAULT_ENTITY_KEY } from './entities';
 import { getUndoManager } from './private-selectors';
 import {
+	getFilteredItem,
 	getNormalizedCommaSeparable,
-	setNestedValue,
 	isNumericID,
 	getUserPermissionCacheKey,
 } from './utils';
@@ -443,17 +443,7 @@ export const getEntityRecord = createSelector(
 			return item;
 		}
 
-		const filteredItem = {};
-		const fields = getNormalizedCommaSeparable( query._fields ) ?? [];
-		for ( let f = 0; f < fields.length; f++ ) {
-			const field = fields[ f ].split( '.' );
-			let value = item;
-			field.forEach( ( fieldName ) => {
-				value = value?.[ fieldName ];
-			} );
-			setNestedValue( filteredItem, field, value );
-		}
-		return filteredItem as EntityRecord;
+		return getFilteredItem< EntityRecord >( item, query._fields );
 	} ) as GetEntityRecord,
 	( state: State, kind, name, recordId, query ) => {
 		const context = query?.context ?? 'default';
@@ -1754,19 +1744,7 @@ export const getRevision = createSelector(
 			return item;
 		}
 
-		const filteredItem = {};
-		const fields = getNormalizedCommaSeparable( query._fields ) ?? [];
-
-		for ( let f = 0; f < fields.length; f++ ) {
-			const field = fields[ f ].split( '.' );
-			let value = item;
-			field.forEach( ( fieldName ) => {
-				value = value?.[ fieldName ];
-			} );
-			setNestedValue( filteredItem, field, value );
-		}
-
-		return filteredItem;
+		return getFilteredItem( item, query._fields );
 	},
 	( state: State, kind, name, recordKey, revisionKey, query ) => {
 		const context = query?.context ?? 'default';

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -409,52 +409,41 @@ export interface GetEntityRecord {
  *
  * @return Record.
  */
-export const getEntityRecord = createSelector(
-	( <
-		EntityRecord extends
-			| ET.EntityRecord< any >
-			| Partial< ET.EntityRecord< any > >,
-	>(
-		state: State,
-		kind: string,
-		name: string,
-		recordId?: EntityRecordKey,
-		query?: GetRecordsHttpQuery
-	): EntityRecord | undefined => {
-		logEntityDeprecation( kind, name, 'getEntityRecord' );
-		const queriedState =
-			state.entities.records?.[ kind ]?.[ name ]?.queriedData;
-		if ( ! queriedState ) {
+export const getEntityRecord = ( <
+	EntityRecord extends
+		| ET.EntityRecord< any >
+		| Partial< ET.EntityRecord< any > >,
+>(
+	state: State,
+	kind: string,
+	name: string,
+	recordId?: EntityRecordKey,
+	query?: GetRecordsHttpQuery
+): EntityRecord | undefined => {
+	logEntityDeprecation( kind, name, 'getEntityRecord' );
+	const queriedState =
+		state.entities.records?.[ kind ]?.[ name ]?.queriedData;
+	if ( ! queriedState ) {
+		return undefined;
+	}
+	const context = query?.context ?? 'default';
+
+	if ( ! query || ! query._fields ) {
+		// If expecting a complete item, validate that completeness.
+		if ( ! queriedState.itemIsComplete[ context ]?.[ recordId ] ) {
 			return undefined;
 		}
-		const context = query?.context ?? 'default';
 
-		if ( ! query || ! query._fields ) {
-			// If expecting a complete item, validate that completeness.
-			if ( ! queriedState.itemIsComplete[ context ]?.[ recordId ] ) {
-				return undefined;
-			}
-
-			return queriedState.items[ context ][ recordId ];
-		}
-
-		const item = queriedState.items[ context ]?.[ recordId ];
-		if ( ! item ) {
-			return item;
-		}
-
-		return getFilteredItem< EntityRecord >( item, query._fields );
-	} ) as GetEntityRecord,
-	( state: State, kind, name, recordId, query ) => {
-		const context = query?.context ?? 'default';
-		const queriedState =
-			state.entities.records?.[ kind ]?.[ name ]?.queriedData;
-		return [
-			queriedState?.items[ context ]?.[ recordId ],
-			queriedState?.itemIsComplete[ context ]?.[ recordId ],
-		];
+		return queriedState.items[ context ][ recordId ];
 	}
-) as GetEntityRecord;
+
+	const item = queriedState.items[ context ]?.[ recordId ];
+	if ( ! item ) {
+		return item;
+	}
+
+	return getFilteredItem< EntityRecord >( item, query._fields );
+} ) as GetEntityRecord;
 
 /**
  * Normalizes `recordKey`s that look like numeric IDs to numbers.
@@ -1709,52 +1698,37 @@ export function hasRevision(
  *
  * @return Record.
  */
-export const getRevision = createSelector(
-	(
-		state: State,
-		kind: string,
-		name: string,
-		recordKey: EntityRecordKey,
-		revisionKey: EntityRecordKey,
-		query?: GetRecordsHttpQuery
-	): RevisionRecord | Record< PropertyKey, never > | undefined => {
-		logEntityDeprecation( kind, name, 'getRevision' );
-		const queriedState =
-			state.entities.records?.[ kind ]?.[ name ]?.revisions?.[
-				recordKey
-			];
+export const getRevision = (
+	state: State,
+	kind: string,
+	name: string,
+	recordKey: EntityRecordKey,
+	revisionKey: EntityRecordKey,
+	query?: GetRecordsHttpQuery
+): RevisionRecord | Record< PropertyKey, never > | undefined => {
+	logEntityDeprecation( kind, name, 'getRevision' );
+	const queriedState =
+		state.entities.records?.[ kind ]?.[ name ]?.revisions?.[ recordKey ];
 
-		if ( ! queriedState ) {
+	if ( ! queriedState ) {
+		return undefined;
+	}
+
+	const context = query?.context ?? 'default';
+
+	if ( ! query || ! query._fields ) {
+		// If expecting a complete item, validate that completeness.
+		if ( ! queriedState.itemIsComplete[ context ]?.[ revisionKey ] ) {
 			return undefined;
 		}
 
-		const context = query?.context ?? 'default';
-
-		if ( ! query || ! query._fields ) {
-			// If expecting a complete item, validate that completeness.
-			if ( ! queriedState.itemIsComplete[ context ]?.[ revisionKey ] ) {
-				return undefined;
-			}
-
-			return queriedState.items[ context ][ revisionKey ];
-		}
-
-		const item = queriedState.items[ context ]?.[ revisionKey ];
-		if ( ! item ) {
-			return item;
-		}
-
-		return getFilteredItem( item, query._fields );
-	},
-	( state: State, kind, name, recordKey, revisionKey, query ) => {
-		const context = query?.context ?? 'default';
-		const queriedState =
-			state.entities.records?.[ kind ]?.[ name ]?.revisions?.[
-				recordKey
-			];
-		return [
-			queriedState?.items?.[ context ]?.[ revisionKey ],
-			queriedState?.itemIsComplete?.[ context ]?.[ revisionKey ],
-		];
+		return queriedState.items[ context ][ revisionKey ];
 	}
-);
+
+	const item = queriedState.items[ context ]?.[ revisionKey ];
+	if ( ! item ) {
+		return item;
+	}
+
+	return getFilteredItem( item, query._fields );
+};

--- a/packages/core-data/src/test/selectors.jsdom.test.js
+++ b/packages/core-data/src/test/selectors.jsdom.test.js
@@ -321,6 +321,120 @@ describe( 'getEntityRecord', () => {
 			},
 		} );
 	} );
+
+	it( 'should return the same filtered item for equivalent queries', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							queriedData: {
+								items: {
+									default: {
+										1: {
+											id: 1,
+											title: { raw: 'chicken' },
+											author: 'bob',
+										},
+									},
+								},
+								itemIsComplete: { default: { 1: true } },
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+
+		const first = getEntityRecord( state, 'postType', 'post', 1, {
+			_fields: 'id,title.raw',
+		} );
+		const second = getEntityRecord( state, 'postType', 'post', 1, {
+			_fields: 'id,title.raw',
+		} );
+		// The array form is equivalent to the comma-separated string.
+		const third = getEntityRecord( state, 'postType', 'post', 1, {
+			_fields: [ 'id', 'title.raw' ],
+		} );
+
+		expect( second ).toBe( first );
+		expect( third ).toBe( first );
+		expect( first ).toEqual( { id: 1, title: { raw: 'chicken' } } );
+	} );
+
+	it( 'should not reuse a cached item across different field sets', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							queriedData: {
+								items: {
+									default: {
+										1: { id: 1, content: 'chicken' },
+									},
+								},
+								itemIsComplete: { default: { 1: true } },
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+
+		expect(
+			getEntityRecord( state, 'postType', 'post', 1, { _fields: 'id' } )
+		).toEqual( { id: 1 } );
+		expect(
+			getEntityRecord( state, 'postType', 'post', 1, {
+				_fields: 'content',
+			} )
+		).toEqual( { content: 'chicken' } );
+	} );
+
+	it( 'should not return a stale filtered item when the record changes', () => {
+		const stateWithContent = ( content ) =>
+			deepFreeze( {
+				entities: {
+					records: {
+						postType: {
+							post: {
+								queriedData: {
+									items: {
+										default: { 1: { id: 1, content } },
+									},
+									itemIsComplete: { default: { 1: true } },
+									queries: {},
+								},
+							},
+						},
+					},
+				},
+			} );
+
+		expect(
+			getEntityRecord(
+				stateWithContent( 'chicken' ),
+				'postType',
+				'post',
+				1,
+				{ _fields: 'content' }
+			)
+		).toEqual( { content: 'chicken' } );
+		expect(
+			getEntityRecord(
+				stateWithContent( 'ribs' ),
+				'postType',
+				'post',
+				1,
+				{
+					_fields: 'content',
+				}
+			)
+		).toEqual( { content: 'ribs' } );
+	} );
 } );
 
 describe( 'hasEntityRecord', () => {
@@ -1256,6 +1370,46 @@ describe( 'getRevision', () => {
 			author: 'bob',
 			parent: 1,
 		} );
+	} );
+
+	it( 'should return the same filtered revision for equivalent queries', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							revisions: {
+								1: {
+									items: {
+										edit: {
+											10: {
+												id: 10,
+												title: { raw: 'chicken' },
+												parent: 1,
+											},
+										},
+									},
+									itemIsComplete: { edit: { 10: true } },
+									queries: {},
+								},
+							},
+						},
+					},
+				},
+			},
+		} );
+
+		const first = getRevision( state, 'postType', 'post', 1, 10, {
+			context: 'edit',
+			_fields: 'id,title.raw',
+		} );
+		const second = getRevision( state, 'postType', 'post', 1, 10, {
+			context: 'edit',
+			_fields: 'id,title.raw',
+		} );
+
+		expect( second ).toBe( first );
+		expect( first ).toEqual( { id: 10, title: { raw: 'chicken' } } );
 	} );
 } );
 

--- a/packages/core-data/src/utils/get-filtered-item.ts
+++ b/packages/core-data/src/utils/get-filtered-item.ts
@@ -1,0 +1,62 @@
+import getNormalizedCommaSeparable from './get-normalized-comma-separable';
+import setNestedValue from './set-nested-value';
+
+/**
+ * Cache of items to a map of the normalized `_fields` they were projected with
+ * and the resulting projection. Keying on the item rather than on the state
+ * keeps the cache alive across unrelated state updates, and lets it be
+ * collected along with the item it projects.
+ */
+const filteredItemCache = new WeakMap<
+	object,
+	Map< string, Record< string, any > >
+>();
+
+/**
+ * Returns the item reduced to the requested `_fields`. Caches the result per
+ * item (by reference) and per field set (by value), so that:
+ *
+ * `getFilteredItem( item, 'id' ) === getFilteredItem( item, [ 'id' ] )`
+ *
+ * @param item    Item to filter.
+ * @param _fields Fields to keep, as a comma-separated string or an array of paths.
+ *
+ * @return Item containing only the requested fields.
+ */
+export default function getFilteredItem< T = Record< string, any > >(
+	item: object,
+	_fields: string | string[] | undefined
+): T {
+	const fields = getNormalizedCommaSeparable( _fields ) ?? [];
+	// The normalized fields joined back together is a canonical primitive key,
+	// so equivalent queries hit the same entry whichever form they used.
+	const fieldsKey = fields.join( ',' );
+
+	let itemCache = filteredItemCache.get( item );
+	if ( itemCache ) {
+		const filtered = itemCache.get( fieldsKey );
+		if ( filtered !== undefined ) {
+			return filtered as T;
+		}
+	} else if ( item !== null && typeof item === 'object' ) {
+		// A record is object-like, but it comes from a REST response, so a
+		// malformed one must not throw on the `WeakMap` write. Project it
+		// uncached instead.
+		itemCache = new Map();
+		filteredItemCache.set( item, itemCache );
+	}
+
+	const filteredItem = {};
+	for ( let f = 0; f < fields.length; f++ ) {
+		const field = fields[ f ].split( '.' );
+		let value: any = item;
+		field.forEach( ( fieldName ) => {
+			value = value?.[ fieldName ];
+		} );
+
+		setNestedValue( filteredItem, field, value );
+	}
+
+	itemCache?.set( fieldsKey, filteredItem );
+	return filteredItem as T;
+}

--- a/packages/core-data/src/utils/index.js
+++ b/packages/core-data/src/utils/index.js
@@ -1,5 +1,6 @@
 export { default as clearUnchangedEdits } from './clear-unchanged-edits';
 export { default as conservativeMapItem } from './conservative-map-item';
+export { default as getFilteredItem } from './get-filtered-item';
 export { default as getNormalizedCommaSeparable } from './get-normalized-comma-separable';
 export { default as ifMatchingAction } from './if-matching-action';
 export { default as forwardResolver } from './forward-resolver';


### PR DESCRIPTION
## What?
Related #82517. Props to @ntsekouras for spotting the issue.

`getEntityRecord` and `getRevision` now return the same object for queries that request the same `_fields`, instead of a new one on every call. Calling either twice with an equivalent inline query previously returned two deep-equal but non-identical objects, which logged the `useSelect` warning "returns different values when called with the same state and parameters" under `SCRIPT_DEBUG`.

## Why?

Both selectors build a fresh projection when the query includes `_fields`, and both memoize with rememo, which compares query arguments by reference. An inline query object is a new reference on every render, so the memo never hits, and the projection is rebuilt.

Only the singular selectors are affected. The plural ones go through `getQueriedItems`, which already caches by state in a WeakMap and by query in an EquivalentKeyMap.

## How?
Extracts the filtering logic into `getFilteredItem`, a shared util that caches per-item references (WeakMap) and per-normalized-field-set (Map, keyed on the fields joined back into a string). Keyed on the item rather than the state, so the cache survives unrelated dispatches: state gets a new reference on every dispatch, item references do not.

A plain Map on a canonical string key rather than an EquivalentKeyMap, because it collapses `'id,title'` and `[ 'id', 'title' ]` into one entry and `getEntityRecord` is a hot path. `getQueryParts` already canonicalizes `_fields` the same way for its `stableKey`. A non-object item skips the cache instead of throwing on the WeakMap write, following `withWeakMapCache` in the same directory.

PR also removes `createSelector` for these selectors, as it was redundant after internal caching.

## Testing Instructions
1. Open a post.
2. Open the browser console.
3. Paste the test code (see below).
4. Run `get()` once so the record resolves.
5. Run `get() === get()`. Expected `true`. On trunk, it is `false`.

```js
   const get = () =>
   	wp.data.select( 'core' ).getEntityRecord(
   		'postType',
   		'post',
   		wp.data.select( 'core/editor' ).getCurrentPostId(),
   		{ _fields: 'id,title' }
   	);
```

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
