### PR TITLE
API Fetch: Expose defaultFetchHandler so overrides can restore it

### DIFF
--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New Features
 
--   Add `apiFetch.unregister` to remove a registered middleware, and expose `apiFetch.httpV1Middleware` so the `X-HTTP-Method-Override` behavior can be opted out of. ([#82408](https://github.com/WordPress/gutenberg/pull/82408))
+-   Add `apiFetch.unregister` to remove a registered middleware, and expose `apiFetch.httpV1Middleware` so the `X-HTTP-Method-Override` behavior can be opted out of ([#82408](https://github.com/WordPress/gutenberg/pull/82408)).
+-   Expose `apiFetch.defaultFetchHandler` so the default fetch handler can be restored after `setFetchHandler` overrides it ([#82553](https://github.com/WordPress/gutenberg/pull/82553))
 
 ## 7.54.0 (2026-08-26)
 

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -175,6 +175,12 @@ apiFetch.setFetchHandler( ( options ) => {
 } );
 ```
 
+The default handler remains available, so it can be restored later.
+
+```js
+apiFetch.setFetchHandler( apiFetch.defaultFetchHandler );
+```
+
 ## Contributing to this package
 
 This is an individual package that's part of the Gutenberg project. The project is organized as a monorepo. It's made up of multiple self-contained software packages, each with a specific purpose. The packages in this monorepo are published to [npm](https://www.npmjs.com/) and used by [WordPress](https://make.wordpress.org/core/) as well as other software projects.

--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -85,6 +85,12 @@ function clearPreloadedData() {
 	}
 }
 
+/**
+ * The default fetch handler, using `window.fetch`. Exposed so it can be
+ * restored after `setFetchHandler` overrides it.
+ *
+ * @param nextOptions The options for the fetch.
+ */
 const defaultFetchHandler: FetchHandler = ( nextOptions ) => {
 	const { url, path, data, parse = true, ...remainingOptions } = nextOptions;
 	let { body, headers } = nextOptions;
@@ -168,6 +174,7 @@ export interface ApiFetch {
 	use: ( middleware: APIFetchMiddleware ) => void;
 	unregister: ( middleware: APIFetchMiddleware ) => boolean;
 	setFetchHandler: ( newFetchHandler: FetchHandler ) => void;
+	defaultFetchHandler: FetchHandler;
 	createNonceMiddleware: typeof createNonceMiddleware;
 	createPreloadingMiddleware: typeof createPreloadingMiddleware;
 	createRootURLMiddleware: typeof createRootURLMiddleware;
@@ -224,6 +231,7 @@ const apiFetch: ApiFetch = ( options ) => {
 apiFetch.use = registerMiddleware;
 apiFetch.unregister = unregisterMiddleware;
 apiFetch.setFetchHandler = setFetchHandler;
+apiFetch.defaultFetchHandler = defaultFetchHandler;
 
 // Attached to the function (rather than a named export) because
 // `wpScriptDefaultExport: true` flattens this module to its default


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/82408#issuecomment-5570940507.

Attach the default `window.fetch` based handler to the `apiFetch` function as `apiFetch.defaultFetchHandler`. Consumers that call `setFetchHandler` can now put the default back with `apiFetch.setFetchHandler( apiFetch.defaultFetchHandler )`.

`setFetchHandler` overwrites the module-local `fetchHandler`, and since the default was never exported, an override was one way.

## Testing Instructions

Code-only change, no UI surface.

1. Build the plugin, load any admin screen with the editor.
2. In the console: `wp.apiFetch.setFetchHandler( () => Promise.reject( { code: 'nope' } ) )`.
3. Confirm REST requests fail.
4. `wp.apiFetch.setFetchHandler( wp.apiFetch.defaultFetchHandler )`.
5. Confirm requests succeed again.

## Use of AI Tools

Assisted by Claude.
