### PR TITLE
Fields: remove unused custom sort from the author fields

### DIFF
--- a/packages/edit-site/CHANGELOG.md
+++ b/packages/edit-site/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Internal
 
+-   `PostList`: Stop re-sorting the fetched page in memory when the view sorts by author. The author field now sorts by author id, the same order the REST API already returns for `orderby=author`, so the re-sort no longer changes anything ([#82559](https://github.com/WordPress/gutenberg/pull/82559)).
 -   Remove the template activation (`active_templates`) experiment: the Templates page and its sidebar always use the previous (non-activation) implementations ([#82241](https://github.com/WordPress/gutenberg/pull/82241)).
 -   Remove the `showListViewByDefault` handling from `useAdaptEditorToCanvas`; the `editor` package now applies the preference on the preview ↔ edit transition itself.
 -   Remove unused dependencies `@wordpress/blob`, `@wordpress/date`, `@wordpress/escape-html`, etc. ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).

--- a/packages/edit-site/src/components/post-list/index.jsx
+++ b/packages/edit-site/src/components/post-list/index.jsx
@@ -7,7 +7,7 @@ import {
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import { DataViews } from '@wordpress/dataviews';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { useEvent, usePrevious } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
@@ -176,27 +176,14 @@ export default function PostList( { postType } ) {
 	const { notesCount, isLoading: isLoadingNotesCount } =
 		useNotesCount( postIds );
 
-	// The REST API sort the authors by ID, but we want to sort them by name.
-	const data = useMemo( () => {
-		let processedRecords = records;
-
-		if ( view?.sort?.field === 'author' ) {
-			processedRecords = filterSortAndPaginate(
-				records,
-				{ sort: { ...view.sort } },
-				fields
-			).data;
-		}
-
-		if ( processedRecords ) {
-			return processedRecords.map( ( record ) => ( {
+	const data = useMemo(
+		() =>
+			records?.map( ( record ) => ( {
 				...record,
 				notesCount: notesCount[ record.id ] ?? 0,
-			} ) );
-		}
-
-		return processedRecords;
-	}, [ records, fields, view?.sort, notesCount ] );
+			} ) ),
+		[ records, notesCount ]
+	);
 
 	const ids = data?.map( ( record ) => getItemId( record ) ) ?? [];
 	const prevIds = usePrevious( ids ) ?? [];

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 
+-   `author`: Drop the custom `sort` callback, which read `_embedded.author` from the arguments although `Field.sort` receives the field values (the author ids), so every comparison returned `0` and in-memory sorting by author was a no-op. The field now sorts by author id through the `integer` type, matching the order the REST API returns for `orderby=author` ([#82559](https://github.com/WordPress/gutenberg/pull/82559)).
 -   Hide the slug field for posts without a permalink, such as posts of non-public post types, matching the classic post URL panel ([#82341](https://github.com/WordPress/gutenberg/pull/82341)).
 -   Normalize special characters in exported pattern filenames to prevent broken or unreadable files. ([#77033](https://github.com/WordPress/gutenberg/pull/77033))
 

--- a/packages/fields/src/fields/author/index.tsx
+++ b/packages/fields/src/fields/author/index.tsx
@@ -33,14 +33,6 @@ const authorField: Field< BasePostWithEmbeddedAuthor > = {
 	},
 	setValue: ( { value } ) => ( { author: Number( value ) } ),
 	render: AuthorView,
-	sort: ( a, b, direction ) => {
-		const nameA = a._embedded?.author?.[ 0 ]?.name || '';
-		const nameB = b._embedded?.author?.[ 0 ]?.name || '';
-
-		return direction === 'asc'
-			? nameA.localeCompare( nameB )
-			: nameB.localeCompare( nameA );
-	},
 	filterBy: {
 		operators: [ 'isAny', 'isNone' ],
 	},

--- a/packages/media-fields/CHANGELOG.md
+++ b/packages/media-fields/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `author`: Drop the custom `sort` callback, which read `_embedded.author` from the arguments although `Field.sort` receives the field values (the author ids), so every comparison returned `0` and in-memory sorting by author was a no-op. The field now sorts by author id through the `integer` type, matching the order the REST API returns for `orderby=author` ([#82559](https://github.com/WordPress/gutenberg/pull/82559)).
 -   `alt_text`, `caption`, `description`: Pass the field's disabled state to the textarea control, so disabling one of these fields stops it accepting input. ([#82516](https://github.com/WordPress/gutenberg/pull/82516))
 
 ### Internal
@@ -23,6 +24,7 @@
 ### Bug Fixes
 
 -   `attached_to`: Reserve room for the suggestions so the field's DataForm panel dropdown is placed with space for them, instead of being sized to the row and then crushing them into a box too small to scroll comfortably. Also don't expand the suggestion list until the user searches, debounce the search so a request isn't fired per keystroke, allow re-attaching straight after detaching, and drop the detach link from the help text in favour of the field's own reset button ([#81122](https://github.com/WordPress/gutenberg/issues/81122)).
+
 ## 0.17.0 (2026-07-29)
 
 ## 0.16.0 (2026-07-14)

--- a/packages/media-fields/src/author/index.tsx
+++ b/packages/media-fields/src/author/index.tsx
@@ -32,14 +32,6 @@ const authorField: Partial< Field< MediaItem > > = {
 		} ) );
 	},
 	render: AuthorView,
-	sort: ( a, b, direction ) => {
-		const nameA = a._embedded?.author?.[ 0 ]?.name || '';
-		const nameB = b._embedded?.author?.[ 0 ]?.name || '';
-
-		return direction === 'asc'
-			? nameA.localeCompare( nameB )
-			: nameB.localeCompare( nameA );
-	},
 	filterBy: {
 		operators: [ 'isAny', 'isNone' ],
 	},


### PR DESCRIPTION
## What?

Removes the custom `sort` callback from the author field in `@wordpress/fields` and `@wordpress/media-fields`. Removes the in-memory author re-sort from the site editor's post list.

## Why?

This is a bug fix. The author field's `sort` callback compared author names read from `_embedded.author`. However, `sort` receives the field values (the author ids), so `_embedded` was always undefined, both names fell back to an empty string, and every comparison returned 0.

Sorting by author in memory has been a silent no-op, and nothing in Gutenberg noticed because no screen actually relies on it: the post list and the media library sort server-side, and the other screens that sort in memory (templates, patterns, revisions) do not use these fields.

The one place that ran the broken callback was the site editor's post list, which fetched the page already sorted by author id from the REST API and then re-sorted it in memory to get author names. That re-sort was itself a bug: it can never reorder a single page correctly across the whole collection. The REST API only supports `orderby=author`, which sorts by author id, so sorting by author name is not something we can offer today.

## How?

- Drop the custom `sort` callback from both author fields. Their `type` is `integer`, so the built-in numeric comparator takes over and sorts by author id, matching the REST API order. 
- In the site editor's post list, remove the `filterSortAndPaginate` re-sort and its outdated comment, and stop depending on `fields` and `view.sort` when decorating records with their notes count.
- The extensible site editor's post list never re-sorted in memory, so it needs no change.

## Testing Instructions

There is no user-visible change in Gutenberg, since the removed code was a no-op.

Verify nothing regressed: open Posts in the site editor and the Media library, sort by Author in both directions, and confirm the order matches what trunk shows (sorted by author id). Then run `npm run test:unit -- packages/fields packages/media-fields packages/dataviews` and `npm run typecheck`.

## Use of AI Tools

Investigated and written with Claude Code, then reviewed by the author.
