### PR TITLE
Global Styles: Remove the Typography panel from the Buttons block

### DIFF
--- a/packages/global-styles-ui/src/screen-block.tsx
+++ b/packages/global-styles-ui/src/screen-block.tsx
@@ -195,6 +195,8 @@ function ScreenBlock( {
 		disableAspectRatio = true;
 	}
 
+	const disableTypography = name === 'core/buttons';
+
 	const settings = useMemo( () => {
 		const updatedSettings = structuredClone( settingsForBlockElement );
 		if ( disableBlockGap ) {
@@ -203,8 +205,16 @@ function ScreenBlock( {
 		if ( disableAspectRatio ) {
 			updatedSettings.dimensions.aspectRatio = false;
 		}
+		if ( disableTypography ) {
+			updatedSettings.typography = {};
+		}
 		return updatedSettings;
-	}, [ settingsForBlockElement, disableBlockGap, disableAspectRatio ] );
+	}, [
+		settingsForBlockElement,
+		disableBlockGap,
+		disableAspectRatio,
+		disableTypography,
+	] );
 
 	const blockVariations = useBlockVariations( name );
 	const hasBackgroundPanel = useHasBackgroundPanel( settings );

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -64,6 +64,44 @@ test.describe( 'Global styles sidebar', () => {
 		).toHaveAttribute( 'aria-pressed', 'false' );
 	} );
 
+	test( 'should offer typography controls on the Button block but not on Buttons', async ( {
+		page,
+	} ) => {
+		const panel = ( scope, name ) =>
+			scope
+				.getByRole( 'heading', { name, exact: true } )
+				.or( scope.getByRole( 'button', { name, exact: true } ) );
+
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Styles' } )
+			.click();
+
+		const settings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		await settings.getByRole( 'button', { name: 'Blocks' } ).click();
+		await settings
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'button' );
+
+		await settings
+			.getByRole( 'button', { name: 'Buttons', exact: true } )
+			.click();
+		await expect( panel( settings, 'Color' ) ).toBeVisible();
+		await expect( panel( settings, 'Typography' ) ).toBeHidden();
+
+		await settings
+			.getByRole( 'button', { name: 'Back', exact: true } )
+			.click();
+
+		await settings
+			.getByRole( 'button', { name: 'Button', exact: true } )
+			.click();
+		await expect( panel( settings, 'Typography' ) ).toBeVisible();
+	} );
+
 	test( 'should filter blocks list results', async ( { page } ) => {
 		// Navigate to Styles -> Blocks.
 		await page


### PR DESCRIPTION
## What?
Closes #57317

Hides the Typography panel on the **Buttons** (plural) block screen in Global Styles. Typography for buttons is now set in one place: the **Button** (singular) block.

This only affects Global Styles. The Buttons block keeps its typography controls in the block inspector, and its `typography` block support is unchanged.

## Testing Instructions
1. Open the Site Editor and click **Styles** in the top bar.
2. Go to **Blocks** and select **Buttons**.
3. The screen shows Background, Dimensions, Borders and Advanced, no Typography panel.
4. Go **Back** and select **Button**.
5. The Typography panel is present, with Font size, Appearance, Line height and the rest.
6. Set a font size there and confirm it applies to buttons in the canvas and the Style Book.
7. Insert a Buttons block in a post or template, select the **Buttons** wrapper, and open the **Styles** tab in the settings sidebar. Its Typography controls are still there and still work, this PR does not touch them.
8. If you have a site that already customised Buttons typography in Global Styles, confirm the existing styles still render on the front end.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/30ad1baa-c8aa-4805-9ee2-411395949341

## Use of AI Tools
This PR was helped with Claude Opus 5. 