### PR TITLE
Core Data: Add 'coalesce' option for store-level undo coalescing

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -842,6 +842,7 @@ _Parameters_
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.
 -   _options.isCached_ `[boolean]`: Whether the edit is transient (e.g. typing). Transient edits are staged and eventually merged into the preceding undo level instead of creating a new one.
+-   _options.coalesce_ `[boolean]`: Whether consecutive edits to the same properties of the same record should merge into a single undo level. An explicit `isCached` takes precedence.
 
 _Returns_
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -841,8 +841,8 @@ _Parameters_
 -   _edits_ `Object`: The edits.
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.
--   _options.isCached_ `[boolean]`: Whether the edit is transient (e.g. typing). Transient edits are staged and eventually merged into the preceding undo level instead of creating a new one.
--   _options.coalesce_ `[boolean]`: Whether consecutive edits to the same properties of the same record should merge into a single undo level. An explicit `isCached` takes precedence.
+-   _options.isCached_ `[boolean]`: Merge this edit into the previous undo level. The caller decides where a run of edits starts and ends.
+-   _options.coalesce_ `[boolean]`: Merge a burst of edits, such as typing, into one undo level. The store decides where the burst ends.
 
 _Returns_
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51223,6 +51223,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/rich-text": "file:../rich-text",

--- a/packages/block-library/src/site-tagline/edit.jsx
+++ b/packages/block-library/src/site-tagline/edit.jsx
@@ -29,7 +29,8 @@ export default function SiteTaglineEdit( props ) {
 		'root',
 		canUserEdit ? 'site' : '__unstableBase',
 		'description',
-		undefined
+		undefined,
+		{ coalesce: true }
 	);
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;

--- a/packages/block-library/src/site-title/edit.jsx
+++ b/packages/block-library/src/site-title/edit.jsx
@@ -37,7 +37,8 @@ export default function SiteTitleEdit( props ) {
 		'root',
 		canUserEdit ? 'site' : '__unstableBase',
 		canUserEdit ? 'title' : 'name',
-		undefined
+		undefined,
+		{ coalesce: true }
 	);
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const blockEditingMode = useBlockEditingMode();

--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   Export `ContextualField` so plugins can describe context-sensitive fields when extending the entity record map. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   `PostStatus` accepts statuses registered by WordPress or plugins while preserving autocomplete for the built-in values. ([#81863](https://github.com/WordPress/gutenberg/pull/81863))
 -   Add `page_for_privacy_policy` to the `Settings` entity type, exposed by the Gutenberg plugin from the `wp_page_for_privacy_policy` option ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
+-   `editEntityRecord` accepts a `coalesce` option that merges consecutive edits to the same properties of the same record into a single undo level, and starts a new one when an unrelated edit or a pause of more than a second interrupts the run. `useEntityProp` forwards it through a new options argument. ([#82564](https://github.com/WordPress/gutenberg/pull/82564))
 
 ### Internal
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -219,6 +219,7 @@ _Parameters_
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.
 -   _options.isCached_ `[boolean]`: Whether the edit is transient (e.g. typing). Transient edits are staged and eventually merged into the preceding undo level instead of creating a new one.
+-   _options.coalesce_ `[boolean]`: Whether consecutive edits to the same properties of the same record should merge into a single undo level. An explicit `isCached` takes precedence.
 
 _Returns_
 
@@ -1068,6 +1069,8 @@ _Parameters_
 -   _name_ `string`: The entity name.
 -   _prop_ `string`: The property name.
 -   _\_id_ `[number|string]`: An entity ID to use instead of the context-provided one.
+-   _options_ `[Object]`: Options for the edits made by the setter.
+-   _options.coalesce_ `[boolean]`: Whether consecutive edits to this property should merge into a single undo level.
 
 _Returns_
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -218,8 +218,8 @@ _Parameters_
 -   _edits_ `Object`: The edits.
 -   _options_ `Object`: Options for the edit.
 -   _options.undoIgnore_ `[boolean]`: Whether to ignore the edit in undo history or not.
--   _options.isCached_ `[boolean]`: Whether the edit is transient (e.g. typing). Transient edits are staged and eventually merged into the preceding undo level instead of creating a new one.
--   _options.coalesce_ `[boolean]`: Whether consecutive edits to the same properties of the same record should merge into a single undo level. An explicit `isCached` takes precedence.
+-   _options.isCached_ `[boolean]`: Merge this edit into the previous undo level. The caller decides where a run of edits starts and ends.
+-   _options.coalesce_ `[boolean]`: Merge a burst of edits, such as typing, into one undo level. The store decides where the burst ends.
 
 _Returns_
 
@@ -1070,7 +1070,7 @@ _Parameters_
 -   _prop_ `string`: The property name.
 -   _\_id_ `[number|string]`: An entity ID to use instead of the context-provided one.
 -   _options_ `[Object]`: Options for the edits made by the setter.
--   _options.coalesce_ `[boolean]`: Whether consecutive edits to this property should merge into a single undo level.
+-   _options.coalesce_ `[boolean]`: Merge a burst of edits, such as typing, into one undo level.
 
 _Returns_
 

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/rich-text": "file:../rich-text",

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -427,12 +427,10 @@ export const deleteEntityRecord =
  * @param {Object}                  edits                The edits.
  * @param {Object}                  options              Options for the edit.
  * @param {boolean}                 [options.undoIgnore] Whether to ignore the edit in undo history or not.
- * @param {boolean}                 [options.isCached]   Whether the edit is transient (e.g. typing). Transient
- *                                                       edits are staged and eventually merged into the
- *                                                       preceding undo level instead of creating a new one.
- * @param {boolean}                 [options.coalesce]   Whether consecutive edits to the same properties of
- *                                                       the same record should merge into a single undo
- *                                                       level. An explicit `isCached` takes precedence.
+ * @param {boolean}                 [options.isCached]   Merge this edit into the previous undo level. The
+ *                                                       caller decides where a run of edits starts and ends.
+ * @param {boolean}                 [options.coalesce]   Merge a burst of edits, such as typing, into one undo
+ *                                                       level. The store decides where the burst ends.
  *
  * @return {Object} Action object.
  */

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
+import { isShallowEqual } from '@wordpress/is-shallow-equal';
 import { clearUnchangedEdits, getNestedValue, setNestedValue } from './utils';
 import { receiveItems, removeItems, receiveQueriedItems } from './queried-data';
 import { DEFAULT_ENTITY_KEY } from './entities';
@@ -19,6 +20,10 @@ import {
 	getRawValue,
 	POST_META_KEY_FOR_CRDT_DOC_PERSISTENCE,
 } from './utils/crdt';
+
+// Matches the block editor's `useMarkPersistent`, so an entity field and a
+// block attribute build undo levels at the same rate.
+const COALESCE_TIMEOUT = 1000;
 
 function addTitleToAutoDraft( record ) {
 	return record.status === 'auto-draft' ? { ...record, title: '' } : record;
@@ -425,6 +430,9 @@ export const deleteEntityRecord =
  * @param {boolean}                 [options.isCached]   Whether the edit is transient (e.g. typing). Transient
  *                                                       edits are staged and eventually merged into the
  *                                                       preceding undo level instead of creating a new one.
+ * @param {boolean}                 [options.coalesce]   Whether consecutive edits to the same properties of
+ *                                                       the same record should merge into a single undo
+ *                                                       level. An explicit `isCached` takes precedence.
  *
  * @return {Object} Action object.
  */
@@ -464,6 +472,50 @@ export const editEntityRecord =
 			// so that the property is not considered dirty.
 			edits: clearUnchangedEdits( editsWithMerges, record ),
 		};
+
+		// `undoIgnore` edits (selection changes, for example) fire on every
+		// keystroke, so they neither read nor write the session and cannot break
+		// a run.
+		let coalesceSession;
+		let isCached = options.isCached;
+		if ( ! options.undoIgnore ) {
+			// Record plus the set of edited keys, so editing a different
+			// property starts a new level. Values are irrelevant, and may be
+			// functions.
+			const target = `${ kind }|${ name }|${ recordId }|${ Object.keys(
+				edits
+			)
+				.sort()
+				.join( ',' ) }`;
+			const session = select.getUndoCoalesceSession();
+			const now = Date.now();
+
+			// An explicit `isCached` always wins, so callers that assert it
+			// themselves, such as `useEntityBlockEditor`, are unaffected.
+			isCached =
+				options.isCached ??
+				( !! options.coalesce &&
+					session?.target === target &&
+					now - session.time < COALESCE_TIMEOUT );
+
+			// The undo manager opens no level for a record that changes nothing,
+			// so neither should this. Otherwise the next edit of the run stages
+			// into whichever level happens to be last.
+			const hasChanges = Object.keys( edits ).some( ( key ) => {
+				const from = editedRecord[ key ];
+				const to = edits[ key ];
+				return (
+					typeof from !== 'function' &&
+					typeof to !== 'function' &&
+					! isShallowEqual( from, to )
+				);
+			} );
+
+			if ( hasChanges ) {
+				coalesceSession = { target, time: now };
+			}
+		}
+
 		if ( entityConfig.syncConfig ) {
 			const objectType = `${ kind }/${ name }`;
 			const objectId = recordId;
@@ -480,9 +532,7 @@ export const editEntityRecord =
 			//
 			// Additionally, `undoIgnore: true` means the change should not
 			// affect the undo history at all (e.g., selection-only changes).
-			const isNewUndoLevel = options.undoIgnore
-				? false
-				: ! options.isCached;
+			const isNewUndoLevel = options.undoIgnore ? false : ! isCached;
 
 			// Use an untracked origin for undoIgnore changes so the Yjs
 			// UndoManager does not capture them as undo levels, while
@@ -513,12 +563,13 @@ export const editEntityRecord =
 						}, {} ),
 					},
 				],
-				options.isCached
+				isCached
 			);
 		}
 		dispatch( {
 			type: 'EDIT_ENTITY_RECORD',
 			...edit,
+			coalesceSession,
 		} );
 	};
 
@@ -568,6 +619,9 @@ export const clearEntityRecordEdits =
 			name,
 			recordId,
 			edits: clearedEdits,
+			// Discarding ends any open run, so a later edit cannot stage into
+			// the level that preceded the discard.
+			coalesceSession: null,
 		} );
 	};
 
@@ -606,14 +660,16 @@ export const redo =
 	};
 
 /**
- * Forces the creation of a new undo level.
+ * Flushes any staged edits into the preceding undo level and ends the current
+ * run of coalesced edits, so that the next edit starts a new undo level.
  *
- * @return {Object} Action object.
+ * Despite its name it does not create an undo level of its own.
  */
 export const __unstableCreateUndoLevel =
 	() =>
-	( { select } ) => {
+	( { select, dispatch } ) => {
 		select.getUndoManager().addRecord();
+		dispatch( { type: 'END_UNDO_COALESCE_SESSION' } );
 	};
 
 /**
@@ -641,6 +697,15 @@ export const saveEntityRecord =
 		} = options;
 
 		logEntityDeprecation( kind, name, 'saveEntityRecord' );
+
+		// Every save funnels through here, so this also ends the run for
+		// `saveEditedEntityRecord` and the post and site editor save flows. An
+		// autosave is not a user checkpoint, so it leaves the run alone rather
+		// than splitting an undo level mid-word.
+		if ( ! isAutosave ) {
+			dispatch( { type: 'END_UNDO_COALESCE_SESSION' } );
+		}
+
 		const configs = await resolveSelect.getEntitiesConfig( kind );
 		const entityConfig = configs.find(
 			( config ) => config.kind === kind && config.name === name

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -23,8 +23,8 @@ const REVISION_QUERY = {
  * @param {string}        prop               The property name.
  * @param {number|string} [_id]              An entity ID to use instead of the context-provided one.
  * @param {Object}        [options]          Options for the edits made by the setter.
- * @param {boolean}       [options.coalesce] Whether consecutive edits to this property
- *                                           should merge into a single undo level.
+ * @param {boolean}       [options.coalesce] Merge a burst of edits, such as typing, into
+ *                                           one undo level.
  *
  * @return {[*, Function, *]} An array where the first item is the
  *                            property value, the second is the

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -18,10 +18,13 @@ const REVISION_QUERY = {
  * specified property of the nearest provided
  * entity of the specified type.
  *
- * @param {string}        kind  The entity kind.
- * @param {string}        name  The entity name.
- * @param {string}        prop  The property name.
- * @param {number|string} [_id] An entity ID to use instead of the context-provided one.
+ * @param {string}        kind               The entity kind.
+ * @param {string}        name               The entity name.
+ * @param {string}        prop               The property name.
+ * @param {number|string} [_id]              An entity ID to use instead of the context-provided one.
+ * @param {Object}        [options]          Options for the edits made by the setter.
+ * @param {boolean}       [options.coalesce] Whether consecutive edits to this property
+ *                                           should merge into a single undo level.
  *
  * @return {[*, Function, *]} An array where the first item is the
  *                            property value, the second is the
@@ -30,7 +33,8 @@ const REVISION_QUERY = {
  * 							  information like `raw`, `rendered` and
  * 							  `protected` props.
  */
-export default function useEntityProp( kind, name, prop, _id ) {
+export default function useEntityProp( kind, name, prop, _id, options = {} ) {
+	const { coalesce } = options;
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
 	const context = useContext( EntityContext );
@@ -86,11 +90,17 @@ export default function useEntityProp( kind, name, prop, _id ) {
 			if ( revisionId ) {
 				return;
 			}
-			editEntityRecord( kind, name, id, {
-				[ prop ]: newValue,
-			} );
+			editEntityRecord(
+				kind,
+				name,
+				id,
+				{ [ prop ]: newValue },
+				{ coalesce }
+			);
 		},
-		[ editEntityRecord, kind, name, id, prop, revisionId ]
+		// `coalesce` rather than `options`, so that an inline object literal
+		// from the caller does not churn the callback.
+		[ editEntityRecord, kind, name, id, prop, revisionId, coalesce ]
 	);
 
 	return [ value, setValue, fullValue ];

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -24,6 +24,19 @@ export function getUndoManager( state: State ) {
 }
 
 /**
+ * Returns the open undo coalescing session, if any. It records the last
+ * undoable edit so that `editEntityRecord` can tell a continued run of edits
+ * from a new one.
+ *
+ * @param state State tree.
+ *
+ * @return The session, or `null` when no run is open.
+ */
+export function getUndoCoalesceSession( state: State ) {
+	return state.undoCoalesceSession;
+}
+
+/**
  * Retrieve the fallback Navigation.
  *
  * @param state Data state.

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -469,6 +469,34 @@ export function syncUndoManagerState(
 	return state;
 }
 
+/**
+ * Tracks the last undoable edit so that `editEntityRecord` can decide whether
+ * a new edit continues the same undo level or starts a new one. `target`
+ * identifies the record and the set of edited keys; `time` is when the edit
+ * was dispatched.
+ *
+ * @param {Object|null} state  Current state.
+ * @param {Object}      action Dispatched action.
+ *
+ * @return {Object|null} Updated state.
+ */
+export function undoCoalesceSession( state = null, action ) {
+	switch ( action.type ) {
+		case 'EDIT_ENTITY_RECORD':
+			// An absent field leaves the session untouched, which is what
+			// edits that do not touch the undo history want, `undoIgnore`
+			// among them. `null` ends the run, an object starts or extends it.
+			return action.coalesceSession !== undefined
+				? action.coalesceSession
+				: state;
+		case 'UNDO':
+		case 'REDO':
+		case 'END_UNDO_COALESCE_SESSION':
+			return null;
+	}
+	return state;
+}
+
 export function editsReference( state = {}, action ) {
 	switch ( action.type ) {
 		case 'EDIT_ENTITY_RECORD':
@@ -768,6 +796,7 @@ export default combineReducers( {
 	editsReference,
 	syncUndoManagerState,
 	undoManager,
+	undoCoalesceSession,
 	embedPreviews,
 	userPermissions,
 	autosaves,

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -38,6 +38,7 @@ export interface State {
 	themeGlobalStyleVariations: Record< string, string >;
 	themeGlobalStyleRevisions: Record< number, Array< object > >;
 	undoManager: UndoManager;
+	undoCoalesceSession: { target: string; time: number } | null;
 	syncUndoManagerState: {
 		hasRedo: boolean;
 		hasUndo: boolean;

--- a/packages/core-data/src/test/actions.jsdom.test.js
+++ b/packages/core-data/src/test/actions.jsdom.test.js
@@ -71,6 +71,7 @@ describe( 'editEntityRecord', () => {
 				title: 'Original Title',
 				content: 'Original Content',
 			} ),
+			getUndoCoalesceSession: () => null,
 			getUndoManager: () => ( {
 				addRecord: vi.fn(),
 			} ),
@@ -87,6 +88,7 @@ describe( 'editEntityRecord', () => {
 			name: 'post',
 			recordId: 1,
 			edits: { title: 'New Title' },
+			coalesceSession: expect.any( Object ),
 		} );
 	} );
 
@@ -109,6 +111,7 @@ describe( 'editEntityRecord', () => {
 					editedKey: 'editedValue',
 				},
 			} ),
+			getUndoCoalesceSession: () => null,
 			getUndoManager: () => ( {
 				addRecord: vi.fn(),
 			} ),
@@ -133,6 +136,7 @@ describe( 'editEntityRecord', () => {
 					newKey: 'newValue',
 				},
 			},
+			coalesceSession: expect.any( Object ),
 		} );
 	} );
 
@@ -154,6 +158,7 @@ describe( 'editEntityRecord', () => {
 				title: 'Original Title',
 				meta: { existingKey: 'existingValue' },
 			} ),
+			getUndoCoalesceSession: () => null,
 			getUndoManager: () => ( {
 				addRecord: vi.fn(),
 			} ),
@@ -176,6 +181,7 @@ describe( 'editEntityRecord', () => {
 					newKey: 'newValue',
 				},
 			},
+			coalesceSession: expect.any( Object ),
 		} );
 	} );
 
@@ -195,6 +201,7 @@ describe( 'editEntityRecord', () => {
 				id: 1,
 				meta: { key1: 'value1' },
 			} ),
+			getUndoCoalesceSession: () => null,
 			getUndoManager: () => ( {
 				addRecord: vi.fn(),
 			} ),
@@ -214,6 +221,7 @@ describe( 'editEntityRecord', () => {
 				// meta should be undefined because merged value equals persisted record
 				meta: undefined,
 			},
+			coalesceSession: expect.any( Object ),
 		} );
 	} );
 
@@ -233,6 +241,7 @@ describe( 'editEntityRecord', () => {
 				id: 1,
 				title: 'Edited Title',
 			} ),
+			getUndoCoalesceSession: () => null,
 			getUndoManager: () => ( {
 				addRecord: vi.fn(),
 			} ),
@@ -251,6 +260,7 @@ describe( 'editEntityRecord', () => {
 			edits: {
 				title: undefined,
 			},
+			coalesceSession: expect.any( Object ),
 		} );
 	} );
 
@@ -289,6 +299,7 @@ describe( 'editEntityRecord', () => {
 						editedKey: 'editedValue',
 					},
 				} ),
+				getUndoCoalesceSession: () => null,
 				getUndoManager: () => ( {
 					addRecord: vi.fn(),
 				} ),
@@ -334,6 +345,7 @@ describe( 'editEntityRecord', () => {
 					id: 1,
 					meta: { key1: 'value1' },
 				} ),
+				getUndoCoalesceSession: () => null,
 				getUndoManager: () => ( {
 					addRecord: vi.fn(),
 				} ),
@@ -367,6 +379,7 @@ describe( 'editEntityRecord', () => {
 				edits: {
 					meta: undefined,
 				},
+				coalesceSession: expect.any( Object ),
 			} );
 		} );
 
@@ -389,6 +402,7 @@ describe( 'editEntityRecord', () => {
 					title: 'Original Title',
 					meta: { existingKey: 'existingValue' },
 				} ),
+				getUndoCoalesceSession: () => null,
 				getUndoManager: () => ( {
 					addRecord: vi.fn(),
 				} ),
@@ -432,6 +446,7 @@ describe( 'editEntityRecord', () => {
 					id: 1,
 					meta: { existingKey: 'existingValue' },
 				} ),
+				getUndoCoalesceSession: () => null,
 				getUndoManager: () => ( {
 					addRecord: vi.fn(),
 				} ),
@@ -524,6 +539,7 @@ describe( 'clearEntityRecordEdits', () => {
 				title: undefined,
 				content: undefined,
 			},
+			coalesceSession: null,
 		} );
 	} );
 } );
@@ -772,7 +788,10 @@ describe( 'saveEntityRecord', () => {
 			data: post,
 		} );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 2 );
+		expect( dispatch ).toHaveBeenCalledTimes( 3 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'END_UNDO_COALESCE_SESSION',
+		} );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
 			kind: 'postType',
@@ -881,7 +900,10 @@ describe( 'saveEntityRecord', () => {
 			data: post,
 		} );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 2 );
+		expect( dispatch ).toHaveBeenCalledTimes( 3 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'END_UNDO_COALESCE_SESSION',
+		} );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
 			kind: 'postType',
@@ -1677,7 +1699,10 @@ describe( 'saveEntityRecord', () => {
 			data: postType,
 		} );
 
-		expect( dispatch ).toHaveBeenCalledTimes( 2 );
+		expect( dispatch ).toHaveBeenCalledTimes( 3 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'END_UNDO_COALESCE_SESSION',
+		} );
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
 			kind: 'root',

--- a/packages/core-data/src/test/undo-coalescing.jsdom.test.js
+++ b/packages/core-data/src/test/undo-coalescing.jsdom.test.js
@@ -1,0 +1,283 @@
+/**
+ * Consecutive edits to the same entity property merge into one undo level when
+ * the caller opts in with `coalesce`. Anything else starts a new level.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import apiFetch from '@wordpress/api-fetch';
+import { createRegistry } from '@wordpress/data';
+import { store as coreDataStore } from '../index';
+
+vi.mock( '@wordpress/api-fetch' );
+
+// The site entity is loaded lazily in production, so tests register it by hand.
+const SITE_ENTITY = {
+	kind: 'root',
+	name: 'site',
+	key: false,
+	baseURL: '/wp/v2/settings',
+};
+
+const ORIGINAL = {
+	title: 'Original Title',
+	description: 'Original Tagline',
+};
+
+const COALESCE = { coalesce: true };
+
+function createTestRegistry() {
+	const registry = createRegistry();
+	registry.register( coreDataStore );
+	registry.dispatch( coreDataStore ).addEntities( [ SITE_ENTITY ] );
+	registry
+		.dispatch( coreDataStore )
+		.receiveEntityRecords( 'root', 'site', { ...ORIGINAL } );
+	return registry;
+}
+
+describe( 'undo coalescing', () => {
+	let registry;
+
+	beforeEach( () => {
+		vi.useFakeTimers();
+		apiFetch.mockReset();
+		registry = createTestRegistry();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
+	function edit( prop, value, options, target = registry ) {
+		target
+			.dispatch( coreDataStore )
+			.editEntityRecord(
+				'root',
+				'site',
+				undefined,
+				{ [ prop ]: value },
+				options
+			);
+	}
+
+	function editTitle( value, options ) {
+		edit( 'title', value, options );
+	}
+
+	function getRecord( target = registry ) {
+		return target
+			.select( coreDataStore )
+			.getEditedEntityRecord( 'root', 'site' );
+	}
+
+	// The store exposes no level count, so drain the stack to measure it.
+	function countUndoLevels( target = registry ) {
+		let levels = 0;
+		while ( target.select( coreDataStore ).hasUndo() ) {
+			target.dispatch( coreDataStore ).undo();
+			levels += 1;
+		}
+		return levels;
+	}
+
+	it( 'merges a burst of edits to one property into a single level', () => {
+		editTitle( 'H', COALESCE );
+		editTitle( 'He', COALESCE );
+		editTitle( 'Hel', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 1 );
+		expect( getRecord().title ).toBe( ORIGINAL.title );
+	} );
+
+	it( 'starts a new level once the coalescing window has passed', () => {
+		editTitle( 'H', COALESCE );
+		editTitle( 'He', COALESCE );
+		vi.advanceTimersByTime( 1000 );
+		editTitle( 'Hel', COALESCE );
+		editTitle( 'Hell', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 2 );
+	} );
+
+	it( 'does not fold an edit into the level of an unrelated property', () => {
+		editTitle( 'New Title', COALESCE );
+		edit( 'description', 'New Tagline', COALESCE );
+		editTitle( 'Newer Title', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 3 );
+	} );
+
+	it.each( [
+		[ 'no options', undefined ],
+		[ '`isCached: false`', { isCached: false } ],
+	] )(
+		'starts a new level when a plain edit (%s) interrupts a run',
+		( _label, options ) => {
+			editTitle( 'New Title', COALESCE );
+			edit( 'description', 'New Tagline', options );
+			editTitle( 'Newer Title', COALESCE );
+
+			expect( countUndoLevels() ).toBe( 3 );
+		}
+	);
+
+	it( 'starts a new level when the set of edited keys changes', () => {
+		editTitle( 'New Title', COALESCE );
+		registry
+			.dispatch( coreDataStore )
+			.editEntityRecord(
+				'root',
+				'site',
+				undefined,
+				{ title: 'Newer Title', description: 'New Tagline' },
+				COALESCE
+			);
+
+		expect( countUndoLevels() ).toBe( 2 );
+	} );
+
+	it( 'stages an explicit `isCached` edit regardless of identity', () => {
+		editTitle( 'New Title' );
+		edit( 'description', 'New Tagline', { isCached: true } );
+
+		expect( countUndoLevels() ).toBe( 1 );
+	} );
+
+	it( 'keeps a run open across an `undoIgnore` edit', () => {
+		editTitle( 'H', COALESCE );
+		edit( 'description', 'Ignored Tagline', { undoIgnore: true } );
+		editTitle( 'He', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 1 );
+	} );
+
+	it( 'does not start a run on an edit that changes nothing', () => {
+		edit( 'description', 'New Tagline' );
+		// The Site Title block trims its value, so typing a trailing space
+		// edits the title to the value it already has.
+		editTitle( ORIGINAL.title, COALESCE );
+		editTitle( 'New Title', COALESCE );
+
+		registry.dispatch( coreDataStore ).undo();
+
+		expect( getRecord().title ).toBe( ORIGINAL.title );
+		expect( getRecord().description ).toBe( 'New Tagline' );
+	} );
+
+	it( 'does not end a run on an edit that changes nothing', () => {
+		editTitle( 'H', COALESCE );
+		edit( 'description', ORIGINAL.description, COALESCE );
+		editTitle( 'He', COALESCE );
+
+		registry.dispatch( coreDataStore ).undo();
+
+		expect( getRecord().title ).toBe( ORIGINAL.title );
+		expect( registry.select( coreDataStore ).hasUndo() ).toBe( false );
+	} );
+
+	it( 'starts a new level when editing after an undo', () => {
+		editTitle( 'H', COALESCE );
+		editTitle( 'He', COALESCE );
+
+		registry.dispatch( coreDataStore ).undo();
+		expect( registry.select( coreDataStore ).hasRedo() ).toBe( true );
+
+		editTitle( 'Ha', COALESCE );
+
+		// A staged edit does not drop pending redos, so a stale session would
+		// leave a redo entry that no longer matches the history.
+		expect( registry.select( coreDataStore ).hasRedo() ).toBe( false );
+	} );
+
+	it( 'starts a new level when editing after a redo', () => {
+		editTitle( 'H', COALESCE );
+		vi.advanceTimersByTime( 1000 );
+		editTitle( 'He', COALESCE );
+
+		registry.dispatch( coreDataStore ).undo();
+		registry.dispatch( coreDataStore ).redo();
+
+		editTitle( 'Hel', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 3 );
+	} );
+
+	it( 'ends the run when `saveEntityRecord` is called directly', async () => {
+		// Real timers: resolving the entity config goes through the data
+		// registry's async resolver queue, which never drains under fake ones.
+		vi.useRealTimers();
+		apiFetch.mockResolvedValue( { ...ORIGINAL } );
+
+		editTitle( 'H', COALESCE );
+		await registry
+			.dispatch( coreDataStore )
+			.saveEntityRecord( 'root', 'site', { title: 'H' } );
+		editTitle( 'He', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 2 );
+	} );
+
+	it( 'ends the run when `saveEditedEntityRecord` is called', async () => {
+		// Real timers: resolving the entity config goes through the data
+		// registry's async resolver queue, which never drains under fake ones.
+		vi.useRealTimers();
+		apiFetch.mockResolvedValue( { ...ORIGINAL } );
+
+		editTitle( 'H', COALESCE );
+		await registry
+			.dispatch( coreDataStore )
+			.saveEditedEntityRecord( 'root', 'site' );
+		editTitle( 'He', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 2 );
+	} );
+
+	it( 'keeps the run open across an autosave', async () => {
+		// Real timers: resolving the entity config goes through the data
+		// registry's async resolver queue, which never drains under fake ones.
+		vi.useRealTimers();
+		apiFetch.mockResolvedValue( { ...ORIGINAL } );
+
+		editTitle( 'H', COALESCE );
+		await registry
+			.dispatch( coreDataStore )
+			.saveEntityRecord(
+				'root',
+				'site',
+				{ title: 'H' },
+				{ isAutosave: true }
+			);
+		editTitle( 'He', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 1 );
+	} );
+
+	it( 'ends the run when edits are discarded', () => {
+		editTitle( 'H', COALESCE );
+		registry
+			.dispatch( coreDataStore )
+			.clearEntityRecordEdits( 'root', 'site' );
+		editTitle( 'He', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 2 );
+	} );
+
+	it( 'ends the run on `__unstableCreateUndoLevel`', () => {
+		editTitle( 'H', COALESCE );
+		registry.dispatch( coreDataStore ).__unstableCreateUndoLevel();
+		editTitle( 'He', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 2 );
+	} );
+
+	it( 'keeps sessions separate between registries', () => {
+		const otherRegistry = createTestRegistry();
+
+		editTitle( 'H', COALESCE );
+		// A different key set. Were the session shared, this would end the run.
+		edit( 'description', 'New Tagline', COALESCE, otherRegistry );
+		editTitle( 'He', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 1 );
+		expect( countUndoLevels( otherRegistry ) ).toBe( 1 );
+	} );
+} );

--- a/packages/core-data/src/test/undo-coalescing.jsdom.test.js
+++ b/packages/core-data/src/test/undo-coalescing.jsdom.test.js
@@ -17,20 +17,37 @@ const SITE_ENTITY = {
 	baseURL: '/wp/v2/settings',
 };
 
+// A keyed entity, so that the record ID takes part in the identity check.
+const POST_ENTITY = {
+	kind: 'postType',
+	name: 'post',
+	baseURL: '/wp/v2/posts',
+};
+
 const ORIGINAL = {
 	title: 'Original Title',
 	description: 'Original Tagline',
 };
+
+const ORIGINAL_POSTS = [
+	{ id: 1, title: 'First Post' },
+	{ id: 2, title: 'Second Post' },
+];
 
 const COALESCE = { coalesce: true };
 
 function createTestRegistry() {
 	const registry = createRegistry();
 	registry.register( coreDataStore );
-	registry.dispatch( coreDataStore ).addEntities( [ SITE_ENTITY ] );
+	registry
+		.dispatch( coreDataStore )
+		.addEntities( [ SITE_ENTITY, POST_ENTITY ] );
 	registry
 		.dispatch( coreDataStore )
 		.receiveEntityRecords( 'root', 'site', { ...ORIGINAL } );
+	registry
+		.dispatch( coreDataStore )
+		.receiveEntityRecords( 'postType', 'post', ORIGINAL_POSTS );
 	return registry;
 }
 
@@ -61,6 +78,24 @@ describe( 'undo coalescing', () => {
 
 	function editTitle( value, options ) {
 		edit( 'title', value, options );
+	}
+
+	function editPost( id, value, options ) {
+		registry
+			.dispatch( coreDataStore )
+			.editEntityRecord(
+				'postType',
+				'post',
+				id,
+				{ title: value },
+				options
+			);
+	}
+
+	function getPost( id ) {
+		return registry
+			.select( coreDataStore )
+			.getEditedEntityRecord( 'postType', 'post', id );
 	}
 
 	function getRecord( target = registry ) {
@@ -133,6 +168,25 @@ describe( 'undo coalescing', () => {
 			);
 
 		expect( countUndoLevels() ).toBe( 2 );
+	} );
+
+	it( 'starts a new level when the edited record changes', () => {
+		editPost( 1, 'Edited First', COALESCE );
+		editPost( 2, 'Edited Second', COALESCE );
+		editPost( 1, 'Edited First Again', COALESCE );
+
+		expect( countUndoLevels() ).toBe( 3 );
+	} );
+
+	it( 'folds into the matching record and leaves the others alone', () => {
+		editPost( 1, 'E', COALESCE );
+		editPost( 1, 'Ed', COALESCE );
+		editPost( 2, 'Edited Second', COALESCE );
+
+		registry.dispatch( coreDataStore ).undo();
+
+		expect( getPost( 2 ).title ).toBe( 'Second Post' );
+		expect( getPost( 1 ).title ).toBe( 'Ed' );
 	} );
 
 	it( 'stages an explicit `isCached` edit regardless of identity', () => {

--- a/packages/core-data/tsconfig.build.json
+++ b/packages/core-data/tsconfig.build.json
@@ -19,6 +19,7 @@
 		{ "path": "../html-entities/tsconfig.build.json" },
 		{ "path": "../i18n/tsconfig.build.json" },
 		{ "path": "../icons/tsconfig.build.json" },
+		{ "path": "../is-shallow-equal/tsconfig.build.json" },
 		{ "path": "../notices/tsconfig.build.json" },
 		{ "path": "../private-apis" },
 		{ "path": "../rich-text" },

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -18,6 +18,7 @@
 		{ "path": "../html-entities/tsconfig.build.json" },
 		{ "path": "../i18n/tsconfig.build.json" },
 		{ "path": "../icons/tsconfig.build.json" },
+		{ "path": "../is-shallow-equal/tsconfig.build.json" },
 		{ "path": "../notices/tsconfig.build.json" },
 		{ "path": "../private-apis" },
 		{ "path": "../rich-text" },

--- a/packages/editor/src/components/post-title/use-post-title.js
+++ b/packages/editor/src/components/post-title/use-post-title.js
@@ -41,7 +41,8 @@ export default function usePostTitle() {
 		'postType',
 		postType,
 		'title',
-		postId
+		postId,
+		{ coalesce: true }
 	);
 
 	const value = useMemo(

--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -493,6 +493,9 @@ test.describe( 'undo', () => {
 		await editor.canvas
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.type( 'a' ); // First step.
+		// Title edits made less than a second apart share an undo level, so
+		// pause to give the backspace its own.
+		await editor.page.waitForTimeout( 1000 );
 		await page.keyboard.press( 'Backspace' ); // Second step.
 		await editor.canvas
 			.getByRole( 'document', { name: 'Add default block' } )


### PR DESCRIPTION
## What?
Previous work #82275.

Adds a `coalesce` option to `editEntityRecord` (forwarded by `useEntityProp`).

Consecutive edits to the same properties of the same record merge into one undo level. An unrelated edit, a pause over a second, an undo, a redo, a user save or a discard starts a new one.

No consumer has opted in yet, so this behavior is neutral in the UI. Can opt in here or in a follow-up PR.

## Why?

`editEntityRecord`'s `isCached` is a caller assertion with no identity check. `undo-manager` stages the change, and staged changes always fold into `history[history.length - 1]`, whichever level that happens to be. A consumer coalescing on its own timer could type in one field, edit a second, then type in the first again within the window and have that third edit fold into the second's level, so one undo reverted two unrelated changes.

`block-editor` does not have this bug because its store compares the incoming action against `lastAction` for the same `clientIds` and attribute keys (`isUpdatingSameBlockAttribute`). `core-data` had no equivalent, so every consumer wanting coalescing had to own both the identity check and the timer.

Blast radius is limited to callers passing `coalesce`. An explicit `isCached` still wins, so `useEntityBlockEditor` and third-party callers behave exactly as before.

## How?

Identity and timing both live in the store, in a new `undoCoalesceSession` reducer slice holding `{ target, time }` for the last undoable edit. `target` is the record plus the sorted set of edited keys, matching the block editor's `hasSameKeys`. `EDIT_ENTITY_RECORD` carries the next session value, so a keystroke stays one dispatch: absent keeps the run, `null` ends it, and an object starts or extends it.

Timing in the store deviates from the block editor, which keeps identity in the store and the 1s timer in the consumer (`useMarkPersistent`). A consumer-owned timer means `coalesce: true` alone is not sufficient, since every new consumer must also remember to end its session. Lexical, ProseMirror and Yjs all evaluate identity and a rolling window inside the history layer.

An edit that changes nothing neither starts nor ends a run, using the same predicate `undo-manager` applies in `isRecordEmpty`. That keeps the invariant that a session exists only if its first edit opened a level.

## Testing Instructions
Nothing opts in, so the UI check is a regression check.

1. Open a post or page.
2. Insert a Site Title block and type in it.
3. Press Cmd/Ctrl+Z repeatedly. Each keystroke undoes separately, as on trunk.
4. Publish, reload and confirm the title persisted.

To see the new behavior, add `{ coalesce: true }` as the 5th argument to the `useEntityProp` call in `packages/block-library/src/site-title/edit.jsx`, then repeat steps 2 and 3. The typed burst undoes as a single level, and pausing for a second before typing again splits it in two.

### Testing Instructions for Keyboard
Same.

## Screencast

**Before**

https://github.com/user-attachments/assets/1a18c55c-ab5e-458a-abab-d302bbc557ef

**After**

https://github.com/user-attachments/assets/03edb134-0559-4bc8-ba40-7bd9f4f9418b



## Use of AI Tools

Assisted by Claude.
