### PR TITLE
Grid: Migrate Emotion styles to SCSS Modules

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Components that compose Emotion style fragments with `cx()` should pass source-order-dependent fragments in a single `css()` call. Passing separate fragments can change override order after the following components stopped rendering styles through Emotion:
+    -   `Grid` ([#82571](https://github.com/WordPress/gutenberg/pull/82571))
+
 ### Enhancements
 
 -   `CheckboxControl`: Match the `@wordpress/ui` checkmark size and disabled fill ([#82555](https://github.com/WordPress/gutenberg/pull/82555)).

--- a/packages/components/src/grid/hook.ts
+++ b/packages/components/src/grid/hook.ts
@@ -46,9 +46,9 @@ export default function useGrid(
 	const row = useResponsiveValue( rowsAsArray );
 
 	const gridTemplateColumns =
-		templateColumns || ( !! columns && `repeat( ${ column }, 1fr )` );
+		templateColumns || ( !! column && `repeat( ${ column }, 1fr )` );
 	const gridTemplateRows =
-		templateRows || ( !! rows && `repeat( ${ row }, 1fr )` );
+		templateRows || ( !! row && `repeat( ${ row }, 1fr )` );
 	const alignmentProps = getAlignmentProps( alignment );
 	const values = {
 		align: alignmentProps.alignItems ?? align,
@@ -63,7 +63,17 @@ export default function useGrid(
 		...otherProps,
 		className: clsx(
 			styles.grid,
-			{ [ styles[ 'is-inline' ] ]: isInline },
+			{
+				[ styles[ 'is-inline' ] ]: isInline,
+				[ styles[ 'has-align' ] ]: !! values.align?.trim(),
+				[ styles[ 'has-justify' ] ]: !! values.justify?.trim(),
+				[ styles[ 'has-template-columns' ] ]: !! toCSSValue(
+					values[ 'template-columns' ]
+				),
+				[ styles[ 'has-template-rows' ] ]: !! toCSSValue(
+					values[ 'template-rows' ]
+				),
+			},
 			// CSS-wide keywords apply to custom properties themselves. Use the
 			// matching declaration instead so, for example, rowGap="inherit"
 			// inherits the parent's row gap rather than its internal variable.

--- a/packages/components/src/grid/hook.ts
+++ b/packages/components/src/grid/hook.ts
@@ -1,12 +1,24 @@
-import { css } from '@emotion/react';
-import { useMemo } from '@wordpress/element';
+import clsx from 'clsx';
 import type { WordPressComponentProps } from '../context';
 import { useContextSystem } from '../context';
 import { getAlignmentProps } from './utils';
 import { useResponsiveValue } from '../utils/use-responsive-value';
-import CONFIG from '../utils/config-values';
-import { useCx } from '../utils/hooks/use-cx';
 import type { GridProps } from './types';
+import styles from './style.module.scss';
+
+const CSS_WIDE_KEYWORDS = new Set( [
+	'inherit',
+	'initial',
+	'unset',
+	'revert',
+	'revert-layer',
+] );
+
+function toCSSValue( value: string | number | undefined ) {
+	return typeof value === 'number'
+		? `${ value }px`
+		: value?.trim() || undefined;
+}
 
 export default function useGrid(
 	props: WordPressComponentProps< GridProps, 'div' >
@@ -22,6 +34,7 @@ export default function useGrid(
 		justify,
 		rowGap,
 		rows,
+		style,
 		templateColumns,
 		templateRows,
 		...otherProps
@@ -36,39 +49,47 @@ export default function useGrid(
 		templateColumns || ( !! columns && `repeat( ${ column }, 1fr )` );
 	const gridTemplateRows =
 		templateRows || ( !! rows && `repeat( ${ row }, 1fr )` );
+	const alignmentProps = getAlignmentProps( alignment );
+	const values = {
+		align: alignmentProps.alignItems ?? align,
+		justify: alignmentProps.justifyContent ?? justify,
+		'template-columns': gridTemplateColumns || undefined,
+		'template-rows': gridTemplateRows || undefined,
+		'row-gap': rowGap,
+		'column-gap': columnGap,
+	};
 
-	const cx = useCx();
-
-	const classes = useMemo( () => {
-		const alignmentProps = getAlignmentProps( alignment );
-
-		const gridClasses = css( {
-			alignItems: align,
-			display: isInline ? 'inline-grid' : 'grid',
-			gap: `calc( ${ CONFIG.gridBase } * ${ gap } )`,
-			gridTemplateColumns: gridTemplateColumns || undefined,
-			gridTemplateRows: gridTemplateRows || undefined,
-			gridRowGap: rowGap,
-			gridColumnGap: columnGap,
-			justifyContent: justify,
-			verticalAlign: isInline ? 'middle' : undefined,
-			...alignmentProps,
-		} );
-
-		return cx( gridClasses, className );
-	}, [
-		align,
-		alignment,
-		className,
-		columnGap,
-		cx,
-		gap,
-		gridTemplateColumns,
-		gridTemplateRows,
-		isInline,
-		justify,
-		rowGap,
-	] );
-
-	return { ...otherProps, className: classes };
+	return {
+		...otherProps,
+		className: clsx(
+			styles.grid,
+			{ [ styles[ 'is-inline' ] ]: isInline },
+			// CSS-wide keywords apply to custom properties themselves. Use the
+			// matching declaration instead so, for example, rowGap="inherit"
+			// inherits the parent's row gap rather than its internal variable.
+			Object.entries( values ).map( ( [ property, value ] ) => {
+				const keyword =
+					typeof value === 'string' ? value.trim().toLowerCase() : '';
+				return (
+					CSS_WIDE_KEYWORDS.has( keyword ) &&
+					styles[ `${ property }-${ keyword }` ]
+				);
+			} ),
+			className
+		),
+		style: {
+			'--wp-components-grid-align': values.align,
+			'--wp-components-grid-justify': values.justify,
+			'--wp-components-grid-gap': gap,
+			'--wp-components-grid-template-columns': toCSSValue(
+				values[ 'template-columns' ]
+			),
+			'--wp-components-grid-template-rows': toCSSValue(
+				values[ 'template-rows' ]
+			),
+			'--wp-components-grid-row-gap': toCSSValue( rowGap ),
+			'--wp-components-grid-column-gap': toCSSValue( columnGap ),
+			...style,
+		},
+	};
 }

--- a/packages/components/src/grid/style.module.scss
+++ b/packages/components/src/grid/style.module.scss
@@ -10,13 +10,26 @@
 	--wp-components-grid-row-gap: initial;
 	--wp-components-grid-column-gap: initial;
 
-	align-items: var(--wp-components-grid-align);
 	display: grid;
-	grid-template-columns: var(--wp-components-grid-template-columns);
-	grid-template-rows: var(--wp-components-grid-template-rows);
 	row-gap: var(--wp-components-grid-row-gap, calc(#{$grid-unit-05} * var(--wp-components-grid-gap)));
 	column-gap: var(--wp-components-grid-column-gap, calc(#{$grid-unit-05} * var(--wp-components-grid-gap)));
+}
+
+// Omitted props leave consumer stylesheet declarations intact.
+.has-align {
+	align-items: var(--wp-components-grid-align);
+}
+
+.has-justify {
 	justify-content: var(--wp-components-grid-justify);
+}
+
+.has-template-columns {
+	grid-template-columns: var(--wp-components-grid-template-columns);
+}
+
+.has-template-rows {
+	grid-template-rows: var(--wp-components-grid-template-rows);
 }
 
 .is-inline {

--- a/packages/components/src/grid/style.module.scss
+++ b/packages/components/src/grid/style.module.scss
@@ -1,0 +1,42 @@
+@use "@wordpress/base-styles/variables" as *;
+
+.grid {
+	// Nested Grids only use their own layout props.
+	--wp-components-grid-align: initial;
+	--wp-components-grid-justify: initial;
+	--wp-components-grid-gap: initial;
+	--wp-components-grid-template-columns: initial;
+	--wp-components-grid-template-rows: initial;
+	--wp-components-grid-row-gap: initial;
+	--wp-components-grid-column-gap: initial;
+
+	align-items: var(--wp-components-grid-align);
+	display: grid;
+	grid-template-columns: var(--wp-components-grid-template-columns);
+	grid-template-rows: var(--wp-components-grid-template-rows);
+	row-gap: var(--wp-components-grid-row-gap, calc(#{$grid-unit-05} * var(--wp-components-grid-gap)));
+	column-gap: var(--wp-components-grid-column-gap, calc(#{$grid-unit-05} * var(--wp-components-grid-gap)));
+	justify-content: var(--wp-components-grid-justify);
+}
+
+.is-inline {
+	display: inline-grid;
+	vertical-align: middle;
+}
+
+// Preserve CSS-wide values without moving declarations into inline styles,
+// where they would override consumer stylesheets.
+@each $name, $property in (
+	align: align-items,
+	justify: justify-content,
+	template-columns: grid-template-columns,
+	template-rows: grid-template-rows,
+	row-gap: row-gap,
+	column-gap: column-gap
+) {
+	@each $keyword in (inherit, initial, unset, revert, revert-layer) {
+		.#{$name}-#{$keyword} {
+			#{$property}: $keyword;
+		}
+	}
+}

--- a/packages/components/src/grid/style.module.scss
+++ b/packages/components/src/grid/style.module.scss
@@ -11,24 +11,66 @@
 	--wp-components-grid-column-gap: initial;
 
 	display: grid;
+}
+
+.grid:not(:where(
+	.row-gap-inherit,
+	.row-gap-initial,
+	.row-gap-unset,
+	.row-gap-revert,
+	.row-gap-revert-layer
+)) {
 	row-gap: var(--wp-components-grid-row-gap, calc(#{$grid-unit-05} * var(--wp-components-grid-gap)));
+}
+
+.grid:not(:where(
+	.column-gap-inherit,
+	.column-gap-initial,
+	.column-gap-unset,
+	.column-gap-revert,
+	.column-gap-revert-layer
+)) {
 	column-gap: var(--wp-components-grid-column-gap, calc(#{$grid-unit-05} * var(--wp-components-grid-gap)));
 }
 
 // Omitted props leave consumer stylesheet declarations intact.
-.has-align {
+.has-align:not(:where(
+	.align-inherit,
+	.align-initial,
+	.align-unset,
+	.align-revert,
+	.align-revert-layer
+)) {
 	align-items: var(--wp-components-grid-align);
 }
 
-.has-justify {
+.has-justify:not(:where(
+	.justify-inherit,
+	.justify-initial,
+	.justify-unset,
+	.justify-revert,
+	.justify-revert-layer
+)) {
 	justify-content: var(--wp-components-grid-justify);
 }
 
-.has-template-columns {
+.has-template-columns:not(:where(
+	.template-columns-inherit,
+	.template-columns-initial,
+	.template-columns-unset,
+	.template-columns-revert,
+	.template-columns-revert-layer
+)) {
 	grid-template-columns: var(--wp-components-grid-template-columns);
 }
 
-.has-template-rows {
+.has-template-rows:not(:where(
+	.template-rows-inherit,
+	.template-rows-initial,
+	.template-rows-unset,
+	.template-rows-revert,
+	.template-rows-revert-layer
+)) {
 	grid-template-rows: var(--wp-components-grid-template-rows);
 }
 

--- a/packages/components/src/grid/test/grid.browser.test.tsx
+++ b/packages/components/src/grid/test/grid.browser.test.tsx
@@ -109,6 +109,22 @@ describe( 'props', () => {
 		expect( style.justifyContent ).toBe( 'space-between' );
 	} );
 
+	test( 'should ignore unsupported runtime alignment values', async () => {
+		await render(
+			<Grid
+				// @ts-expect-error Runtime JavaScript consumers can pass unsupported values.
+				alignment="unsupported"
+				data-testid="grid"
+			>
+				<View />
+			</Grid>
+		);
+
+		const style = readStyle();
+		expect( style.alignItems ).toBe( 'normal' );
+		expect( style.justifyContent ).toBe( 'normal' );
+	} );
+
 	test( 'should render justify', async () => {
 		await render(
 			<Grid justify="flex-start" data-testid="grid">
@@ -451,7 +467,11 @@ describe( 'style composition', () => {
 			screen.getByRole( 'link', { name: 'Grid link' } )
 		);
 		expect( ref.current?.getAttribute( 'href' ) ).toBe( '#target' );
-		expect( ref.current?.classList.contains( 'components-grid' ) ).toBe( true );
-		expect( ref.current?.classList.contains( 'consumer-class' ) ).toBe( true );
+		expect( ref.current?.classList.contains( 'components-grid' ) ).toBe(
+			true
+		);
+		expect( ref.current?.classList.contains( 'consumer-class' ) ).toBe(
+			true
+		);
 	} );
 } );

--- a/packages/components/src/grid/test/grid.browser.test.tsx
+++ b/packages/components/src/grid/test/grid.browser.test.tsx
@@ -297,6 +297,64 @@ describe( 'style composition', () => {
 		expect( style.gridTemplateColumns ).toBe( '100px 100px' );
 	} );
 
+	test.each( [
+		{ name: 'zero tracks', columns: 0, rows: 0 },
+		{ name: 'empty responsive tracks', columns: [], rows: [] },
+		{
+			name: 'undefined responsive tracks',
+			columns: [ undefined ],
+			rows: [ undefined ],
+		},
+		{ name: 'zero responsive tracks', columns: [ 0 ], rows: [ 0 ] },
+	] )(
+		'preserves consumer styles with $name and overrides them with explicit values',
+		async ( { columns, rows } ) => {
+			const consumerStyle = document.createElement( 'style' );
+			consumerStyle.textContent =
+				'.grid-consumer { align-items: end; justify-content: end; grid-template-columns: 100px; grid-template-rows: 90px; }';
+			document.head.prepend( consumerStyle );
+
+			try {
+				const { rerender } = await render(
+					<Grid
+						data-testid="grid"
+						className="grid-consumer"
+						columns={ columns }
+						rows={ rows }
+					>
+						<View />
+					</Grid>
+				);
+				let style = getComputedStyle( screen.getByTestId( 'grid' ) );
+				expect( style.alignItems ).toBe( 'end' );
+				expect( style.justifyContent ).toBe( 'end' );
+				expect( style.gridTemplateColumns ).toBe( '100px' );
+				expect( style.gridTemplateRows ).toBe( '90px' );
+
+				await rerender(
+					<Grid
+						data-testid="grid"
+						className="grid-consumer"
+						columns={ 0 }
+						align="start"
+						justify="start"
+						templateColumns="200px"
+						templateRows="120px"
+					>
+						<View />
+					</Grid>
+				);
+				style = getComputedStyle( screen.getByTestId( 'grid' ) );
+				expect( style.alignItems ).toBe( 'start' );
+				expect( style.justifyContent ).toBe( 'start' );
+				expect( style.gridTemplateColumns ).toBe( '200px' );
+				expect( style.gridTemplateRows ).toBe( '120px' );
+			} finally {
+				consumerStyle.remove();
+			}
+		}
+	);
+
 	test( 'CSS-wide values apply to the layout properties', async () => {
 		await render(
 			<div

--- a/packages/components/src/grid/test/grid.browser.test.tsx
+++ b/packages/components/src/grid/test/grid.browser.test.tsx
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { createRef } from '@wordpress/element';
 import { screen } from '@testing-library/react';
 import { render } from 'vitest-browser-react';
 import { View } from '../../view';
@@ -170,5 +172,228 @@ describe( 'props', () => {
 		const style = readStyle();
 		expect( style.display ).toBe( 'grid' );
 		expect( style.gridTemplateRows ).toBe( '126px 24px 126px' );
+	} );
+} );
+
+describe( 'style composition', () => {
+	test.each( [
+		[ undefined, undefined, '20px', '20px' ],
+		[ 0, '2em', '0px', '28px' ],
+		[ '10%', 7, '10%', '7px' ],
+		[ '', '', '20px', '20px' ],
+	] )(
+		'rowGap %s and columnGap %s override the shared gap',
+		async ( rowGap, columnGap, expectedRowGap, expectedColumnGap ) => {
+			await render(
+				<Grid
+					data-testid="grid"
+					gap={ 5 }
+					rowGap={ rowGap }
+					columnGap={ columnGap }
+					style={ { fontSize: 14 } }
+				>
+					<View />
+				</Grid>
+			);
+			const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+			expect( style.rowGap ).toBe( expectedRowGap );
+			expect( style.columnGap ).toBe( expectedColumnGap );
+		}
+	);
+
+	test( 'alignment takes precedence over align and justify', async () => {
+		await render(
+			<Grid
+				data-testid="grid"
+				alignment="spaced"
+				align="end"
+				justify="end"
+			>
+				<View />
+			</Grid>
+		);
+		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+		expect( style.alignItems ).toBe( 'center' );
+		expect( style.justifyContent ).toBe( 'space-between' );
+	} );
+
+	test( 'nested Grids use their own layout props', async () => {
+		await render(
+			<Grid
+				columns={ 1 }
+				rows={ 2 }
+				rowGap={ 40 }
+				columnGap={ 50 }
+				align="end"
+				justify="end"
+			>
+				<Grid data-testid="grid" style={ { width: 300 } }>
+					<View />
+					<View />
+				</Grid>
+			</Grid>
+		);
+		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+		expect( style.gridTemplateColumns ).toBe( '144px 144px' );
+		expect( style.rowGap ).toBe( '12px' );
+		expect( style.columnGap ).toBe( '12px' );
+		expect( style.alignItems ).toBe( 'normal' );
+		expect( style.justifyContent ).toBe( 'normal' );
+	} );
+
+	test( 'zero columns and rows leave track generation to CSS', async () => {
+		await render(
+			<Grid data-testid="grid" columns={ 0 } rows={ 0 } gap={ 0 }>
+				{ null }
+			</Grid>
+		);
+		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+		expect( style.gridTemplateColumns ).toBe( 'none' );
+		expect( style.gridTemplateRows ).toBe( 'none' );
+		expect( style.gap ).toBe( '0px' );
+	} );
+
+	test( 'inline styles override layout props', async () => {
+		await render(
+			<Grid
+				data-testid="grid"
+				align="end"
+				gap={ 5 }
+				columns={ 3 }
+				style={ {
+					display: 'flex',
+					gap: 9,
+					alignItems: 'start',
+					gridTemplateColumns: '50px',
+				} }
+			>
+				<View />
+			</Grid>
+		);
+		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+		expect( style.display ).toBe( 'flex' );
+		expect( style.gap ).toBe( '9px' );
+		expect( style.alignItems ).toBe( 'start' );
+		expect( style.gridTemplateColumns ).toBe( '50px' );
+	} );
+
+	test( 'consumer stylesheets can override layout props', async () => {
+		await render(
+			<>
+				<style>{ `.grid-consumer.grid-consumer { gap: 23px; align-items: end; grid-template-columns: 100px 100px; }` }</style>
+				<Grid
+					data-testid="grid"
+					className="grid-consumer"
+					align="start"
+					columns={ 3 }
+				>
+					<View />
+				</Grid>
+			</>
+		);
+		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+		expect( style.gap ).toBe( '23px' );
+		expect( style.alignItems ).toBe( 'end' );
+		expect( style.gridTemplateColumns ).toBe( '100px 100px' );
+	} );
+
+	test( 'CSS-wide values apply to the layout properties', async () => {
+		await render(
+			<div
+				style={ {
+					display: 'grid',
+					alignItems: 'end',
+					justifyContent: 'end',
+					rowGap: 27,
+					columnGap: 29,
+					gridTemplateColumns: '300px',
+					gridTemplateRows: '100px',
+				} }
+			>
+				<Grid
+					data-testid="grid"
+					align="inherit"
+					justify="inherit"
+					rowGap="inherit"
+					columnGap="inherit"
+					templateColumns="inherit"
+					templateRows="inherit"
+				>
+					<View />
+				</Grid>
+			</div>
+		);
+		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+		expect( style.alignItems ).toBe( 'end' );
+		expect( style.justifyContent ).toBe( 'end' );
+		expect( style.rowGap ).toBe( '27px' );
+		expect( style.columnGap ).toBe( '29px' );
+		expect( style.gridTemplateColumns ).toBe( '300px' );
+		expect( style.gridTemplateRows ).toBe( '100px' );
+	} );
+
+	test( 'CSS-wide gap resets override the shared gap', async () => {
+		await render(
+			<Grid
+				data-testid="grid"
+				gap={ 5 }
+				rowGap="initial"
+				columnGap="initial"
+			>
+				<View />
+			</Grid>
+		);
+		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
+		expect( style.rowGap ).toBe( 'normal' );
+		expect( style.columnGap ).toBe( 'normal' );
+	} );
+
+	test( 'responsive tracks follow the existing viewport breakpoints', async () => {
+		await render(
+			<Grid
+				data-testid="grid"
+				columns={ [ 1, 2, 3, 4 ] }
+				rows={ [ 1, 2, 3, 4 ] }
+				style={ { width: 300, height: 300 } }
+			>
+				<View />
+			</Grid>
+		);
+		for ( const [ width, tracks ] of [
+			[ 600, 1 ],
+			[ 700, 2 ],
+			[ 900, 3 ],
+			[ 1100, 4 ],
+		] ) {
+			await page.viewport( width, 800 );
+			await expect
+				.poll(
+					() =>
+						getComputedStyle(
+							screen.getByTestId( 'grid' )
+						).gridTemplateColumns.split( ' ' ).length
+				)
+				.toBe( tracks );
+			expect(
+				getComputedStyle(
+					screen.getByTestId( 'grid' )
+				).gridTemplateRows.split( ' ' )
+			).toHaveLength( tracks );
+		}
+	} );
+
+	test( 'forwards the element type, ref, and consumer props', async () => {
+		const ref = createRef< HTMLAnchorElement >();
+		await render(
+			<Grid as="a" ref={ ref } href="#target" className="consumer-class">
+				Grid link
+			</Grid>
+		);
+		expect( ref.current ).toBe(
+			screen.getByRole( 'link', { name: 'Grid link' } )
+		);
+		expect( ref.current?.getAttribute( 'href' ) ).toBe( '#target' );
+		expect( ref.current?.classList.contains( 'components-grid' ) ).toBe( true );
+		expect( ref.current?.classList.contains( 'consumer-class' ) ).toBe( true );
 	} );
 } );

--- a/packages/components/src/grid/test/grid.browser.test.tsx
+++ b/packages/components/src/grid/test/grid.browser.test.tsx
@@ -1,6 +1,4 @@
 import { describe, expect, test } from 'vitest';
-import { page } from 'vitest/browser';
-import { createRef } from '@wordpress/element';
 import { screen } from '@testing-library/react';
 import { render } from 'vitest-browser-react';
 import { View } from '../../view';
@@ -192,38 +190,17 @@ describe( 'props', () => {
 } );
 
 describe( 'style composition', () => {
-	test.each( [
-		[ undefined, undefined, '20px', '20px' ],
-		[ 0, '2em', '0px', '28px' ],
-		[ '10%', 7, '10%', '7px' ],
-		[ '', '', '20px', '20px' ],
-	] )(
-		'rowGap %s and columnGap %s override the shared gap',
-		async ( rowGap, columnGap, expectedRowGap, expectedColumnGap ) => {
-			await render(
-				<Grid
-					data-testid="grid"
-					gap={ 5 }
-					rowGap={ rowGap }
-					columnGap={ columnGap }
-					style={ { fontSize: 14 } }
-				>
-					<View />
-				</Grid>
-			);
-			const style = getComputedStyle( screen.getByTestId( 'grid' ) );
-			expect( style.rowGap ).toBe( expectedRowGap );
-			expect( style.columnGap ).toBe( expectedColumnGap );
-		}
-	);
-
-	test( 'alignment takes precedence over align and justify', async () => {
+	test( 'specific layout props override their fallbacks', async () => {
 		await render(
 			<Grid
 				data-testid="grid"
 				alignment="spaced"
 				align="end"
 				justify="end"
+				gap={ 5 }
+				rowGap={ 0 }
+				columnGap="2em"
+				style={ { fontSize: 14 } }
 			>
 				<View />
 			</Grid>
@@ -231,6 +208,8 @@ describe( 'style composition', () => {
 		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
 		expect( style.alignItems ).toBe( 'center' );
 		expect( style.justifyContent ).toBe( 'space-between' );
+		expect( style.rowGap ).toBe( '0px' );
+		expect( style.columnGap ).toBe( '28px' );
 	} );
 
 	test( 'nested Grids use their own layout props', async () => {
@@ -257,18 +236,6 @@ describe( 'style composition', () => {
 		expect( style.justifyContent ).toBe( 'normal' );
 	} );
 
-	test( 'zero columns and rows leave track generation to CSS', async () => {
-		await render(
-			<Grid data-testid="grid" columns={ 0 } rows={ 0 } gap={ 0 }>
-				{ null }
-			</Grid>
-		);
-		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
-		expect( style.gridTemplateColumns ).toBe( 'none' );
-		expect( style.gridTemplateRows ).toBe( 'none' );
-		expect( style.gap ).toBe( '0px' );
-	} );
-
 	test( 'inline styles override layout props', async () => {
 		await render(
 			<Grid
@@ -293,83 +260,50 @@ describe( 'style composition', () => {
 		expect( style.gridTemplateColumns ).toBe( '50px' );
 	} );
 
-	test( 'consumer stylesheets can override layout props', async () => {
-		await render(
-			<>
-				<style>{ `.grid-consumer.grid-consumer { gap: 23px; align-items: end; grid-template-columns: 100px 100px; }` }</style>
-				<Grid
-					data-testid="grid"
-					className="grid-consumer"
-					align="start"
-					columns={ 3 }
-				>
-					<View />
-				</Grid>
-			</>
-		);
-		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
-		expect( style.gap ).toBe( '23px' );
-		expect( style.alignItems ).toBe( 'end' );
-		expect( style.gridTemplateColumns ).toBe( '100px 100px' );
-	} );
+	test( 'consumer stylesheets retain precedence', async () => {
+		const consumerStyle = document.createElement( 'style' );
+		consumerStyle.textContent =
+			'.grid-consumer.grid-consumer, .grid-disabled { align-items: end; justify-content: end; grid-template-columns: 100px; grid-template-rows: 90px; }';
+		document.head.prepend( consumerStyle );
 
-	test.each( [
-		{ name: 'zero tracks', columns: 0, rows: 0 },
-		{ name: 'empty responsive tracks', columns: [], rows: [] },
-		{
-			name: 'undefined responsive tracks',
-			columns: [ undefined ],
-			rows: [ undefined ],
-		},
-		{ name: 'zero responsive tracks', columns: [ 0 ], rows: [ 0 ] },
-	] )(
-		'preserves consumer styles with $name and overrides them with explicit values',
-		async ( { columns, rows } ) => {
-			const consumerStyle = document.createElement( 'style' );
-			consumerStyle.textContent =
-				'.grid-consumer { align-items: end; justify-content: end; grid-template-columns: 100px; grid-template-rows: 90px; }';
-			document.head.prepend( consumerStyle );
-
-			try {
-				const { rerender } = await render(
+		try {
+			await render(
+				<>
 					<Grid
-						data-testid="grid"
+						data-testid="grid-with-props"
 						className="grid-consumer"
-						columns={ columns }
-						rows={ rows }
+						align="start"
+						justify="start"
+						columns={ 3 }
+						rows={ 2 }
 					>
 						<View />
 					</Grid>
-				);
-				let style = getComputedStyle( screen.getByTestId( 'grid' ) );
+					<Grid
+						data-testid="grid-with-disabled-tracks"
+						className="grid-disabled"
+						columns={ [ 0 ] }
+						rows={ [ 0 ] }
+					>
+						<View />
+					</Grid>
+				</>
+			);
+
+			for ( const testId of [
+				'grid-with-props',
+				'grid-with-disabled-tracks',
+			] ) {
+				const style = getComputedStyle( screen.getByTestId( testId ) );
 				expect( style.alignItems ).toBe( 'end' );
 				expect( style.justifyContent ).toBe( 'end' );
 				expect( style.gridTemplateColumns ).toBe( '100px' );
 				expect( style.gridTemplateRows ).toBe( '90px' );
-
-				await rerender(
-					<Grid
-						data-testid="grid"
-						className="grid-consumer"
-						columns={ 0 }
-						align="start"
-						justify="start"
-						templateColumns="200px"
-						templateRows="120px"
-					>
-						<View />
-					</Grid>
-				);
-				style = getComputedStyle( screen.getByTestId( 'grid' ) );
-				expect( style.alignItems ).toBe( 'start' );
-				expect( style.justifyContent ).toBe( 'start' );
-				expect( style.gridTemplateColumns ).toBe( '200px' );
-				expect( style.gridTemplateRows ).toBe( '120px' );
-			} finally {
-				consumerStyle.remove();
 			}
+		} finally {
+			consumerStyle.remove();
 		}
-	);
+	} );
 
 	test( 'CSS-wide values apply to the layout properties', async () => {
 		await render(
@@ -404,74 +338,5 @@ describe( 'style composition', () => {
 		expect( style.columnGap ).toBe( '29px' );
 		expect( style.gridTemplateColumns ).toBe( '300px' );
 		expect( style.gridTemplateRows ).toBe( '100px' );
-	} );
-
-	test( 'CSS-wide gap resets override the shared gap', async () => {
-		await render(
-			<Grid
-				data-testid="grid"
-				gap={ 5 }
-				rowGap="initial"
-				columnGap="initial"
-			>
-				<View />
-			</Grid>
-		);
-		const style = getComputedStyle( screen.getByTestId( 'grid' ) );
-		expect( style.rowGap ).toBe( 'normal' );
-		expect( style.columnGap ).toBe( 'normal' );
-	} );
-
-	test( 'responsive tracks follow the existing viewport breakpoints', async () => {
-		await render(
-			<Grid
-				data-testid="grid"
-				columns={ [ 1, 2, 3, 4 ] }
-				rows={ [ 1, 2, 3, 4 ] }
-				style={ { width: 300, height: 300 } }
-			>
-				<View />
-			</Grid>
-		);
-		for ( const [ width, tracks ] of [
-			[ 600, 1 ],
-			[ 700, 2 ],
-			[ 900, 3 ],
-			[ 1100, 4 ],
-		] ) {
-			await page.viewport( width, 800 );
-			await expect
-				.poll(
-					() =>
-						getComputedStyle(
-							screen.getByTestId( 'grid' )
-						).gridTemplateColumns.split( ' ' ).length
-				)
-				.toBe( tracks );
-			expect(
-				getComputedStyle(
-					screen.getByTestId( 'grid' )
-				).gridTemplateRows.split( ' ' )
-			).toHaveLength( tracks );
-		}
-	} );
-
-	test( 'forwards the element type, ref, and consumer props', async () => {
-		const ref = createRef< HTMLAnchorElement >();
-		await render(
-			<Grid as="a" ref={ ref } href="#target" className="consumer-class">
-				Grid link
-			</Grid>
-		);
-		expect( ref.current ).toBe(
-			screen.getByRole( 'link', { name: 'Grid link' } )
-		);
-		expect( ref.current?.getAttribute( 'href' ) ).toBe( '#target' );
-		expect( ref.current?.classList.contains( 'components-grid' ) ).toBe(
-			true
-		);
-		expect( ref.current?.classList.contains( 'consumer-class' ) ).toBe(
-			true
-		);
 	} );
 } );

--- a/packages/components/src/grid/utils.ts
+++ b/packages/components/src/grid/utils.ts
@@ -18,7 +18,7 @@ export function getAlignmentProps( alignment?: keyof typeof ALIGNMENTS ): {
 	alignItems?: CSSProperties[ 'alignItems' ];
 	justifyContent?: CSSProperties[ 'justifyContent' ];
 } {
-	const alignmentProps = alignment ? ALIGNMENTS[ alignment ] : {};
+	const alignmentProps = alignment ? ALIGNMENTS[ alignment ] ?? {} : {};
 
 	return alignmentProps;
 }

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -4668,11 +4668,6 @@
 			"count": 1
 		}
 	},
-	"packages/components/src/grid/hook.ts": {
-		"no-restricted-imports": {
-			"count": 1
-		}
-	},
 	"packages/components/src/input-control/input-field.tsx": {
 		"react-hooks/immutability": {
 			"count": 2


### PR DESCRIPTION
See #66806. Follow-up to the migration guide in #82567.

## What?

Migrate `Grid` from Emotion to SCSS Modules while preserving its layout props, responsive tracks, polymorphism, and consumer overrides.

## Why?

Continue removing Emotion from `@wordpress/components`.

## How?

Use module classes and custom properties for dynamic layout values. Omit optional declarations when their props are absent so consumer styles retain their precedence. Preserve CSS-wide values, tolerate unsupported runtime alignment values, and keep separate row and column gap fallbacks so production CSS sorting cannot reset an axis override. Extend the existing Vitest Browser Mode coverage for cascade behavior, nesting, and Grid consumers.

## Testing Instructions

1. Open the Grid Storybook story. Change columns, rows, templates, alignment, gap, and inline mode. Confirm the layout matches the base branch.
2. Open BoxControl's default and axial stories. Link and unlink the sides. Confirm the inputs, label, and buttons retain their layout in LTR and RTL.
3. Open ToolsPanel's Default story and confirm the header and controls retain their spacing. In the editor, select a Paragraph block and compare the Color and Dimensions panels with the base branch.

### Testing Instructions for Keyboard

Tab through the BoxControl and ToolsPanel controls. Use Space or Enter to activate their buttons and confirm focus and layout remain unchanged.

## Use of AI Tools

Codex authored the implementation, test changes, and this description.
