### PR TITLE
DOM: Exclude visibility-hidden elements from focusable results

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Bug Fixes
 
+-   `NavigableToolbar`: Preserve toolbar semantics while it is hidden, so asynchronous control changes do not remount custom block toolbars ([#82574](https://github.com/WordPress/gutenberg/pull/82574)).
 -   `ListView`: Drop the block icon's variation colors while the row is selected, so the icon keeps contrast against the selection background ([#82498](https://github.com/WordPress/gutenberg/pull/82498)).
 -   Flex layout: Output `flex-direction: row` when a viewport override switches a vertical layout to horizontal, so the base `flex-direction: column` no longer keeps applying on that viewport ([#82364](https://github.com/WordPress/gutenberg/pull/82364)).
 -   `BlockManager`: Color library block icons with `color` while retaining a `fill` fallback for custom icons that do not use `currentColor`. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))

--- a/packages/block-editor/src/components/navigable-toolbar/index.jsx
+++ b/packages/block-editor/src/components/navigable-toolbar/index.jsx
@@ -69,6 +69,10 @@ function useIsAccessibleToolbar( toolbarRef ) {
 
 	const determineIsAccessibleToolbar = useCallback( () => {
 		const tabbables = focus.tabbable.find( toolbarRef.current );
+		// A hidden toolbar has no tabbables, so keep its current classification.
+		if ( tabbables.length === 0 ) {
+			return;
+		}
 		const onlyToolbarItem = hasOnlyToolbarItem( tabbables );
 		if ( ! onlyToolbarItem ) {
 			deprecated( 'Using custom components as toolbar controls', {

--- a/packages/block-editor/src/components/navigable-toolbar/test/index.browser.test.js
+++ b/packages/block-editor/src/components/navigable-toolbar/test/index.browser.test.js
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+import NavigableToolbar from '..';
+
+function createToolbar( { hidden = false, extraChildren = 0 } = {} ) {
+	return createElement(
+		'div',
+		hidden ? { style: { visibility: 'hidden' } } : null,
+		createElement(
+			NavigableToolbar,
+			{ 'aria-label': 'Block tools' },
+			createElement( 'button', null, 'Custom control' ),
+			...Array.from( { length: extraChildren }, ( _, index ) =>
+				createElement( 'span', { key: index } )
+			)
+		)
+	);
+}
+
+describe( 'NavigableToolbar', () => {
+	afterEach( cleanup );
+
+	it( 'does not reclassify a visibility-hidden toolbar when its subtree changes', async () => {
+		const { rerender } = render( createToolbar() );
+		const initialToolbar = screen.getByRole( 'toolbar' );
+
+		rerender( createToolbar( { extraChildren: 1 } ) );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'toolbar' ) ).not.toBe( initialToolbar );
+		} );
+		expect( console ).toHaveWarned();
+		const toolbar = screen.getByRole( 'toolbar' );
+
+		rerender( createToolbar( { hidden: true, extraChildren: 2 } ) );
+
+		await act(
+			() =>
+				new Promise( ( resolve ) =>
+					window.requestAnimationFrame( () =>
+						window.requestAnimationFrame( resolve )
+					)
+				)
+		);
+		expect( screen.getByRole( 'toolbar', { hidden: true } ) ).toBe(
+			toolbar
+		);
+	} );
+} );

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `focusable.find`: Exclude elements hidden by CSS visibility while preserving explicitly visible descendants ([#82574](https://github.com/WordPress/gutenberg/pull/82574)).
+-   `focusable.find`: Exclude elements hidden by CSS `visibility` or `content-visibility` while preserving explicitly visible descendants ([#82574](https://github.com/WordPress/gutenberg/pull/82574)).
 
 ## 4.54.0 (2026-08-26)
 

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `focusable.find`: Exclude elements hidden by CSS visibility while preserving explicitly visible descendants ([#82574](https://github.com/WordPress/gutenberg/pull/82574)).
+
 ## 4.54.0 (2026-08-26)
 
 ### Bug Fixes

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -46,20 +46,26 @@ function buildSelector( sequential ) {
 }
 
 /**
- * Returns true if the specified element is visible (i.e. neither display: none
- * nor visibility: hidden or collapse).
+ * Returns true if the specified element has a layout box and is not hidden by
+ * CSS visibility or content visibility.
  *
  * @param {HTMLElement} element DOM element to test.
  *
  * @return {boolean} Whether element is visible.
  */
 function isVisible( element ) {
-	const visibility =
-		element.ownerDocument.defaultView?.getComputedStyle(
-			element
-		).visibility;
-	if ( visibility === 'hidden' || visibility === 'collapse' ) {
-		return false;
+	if ( typeof element.checkVisibility === 'function' ) {
+		if ( ! element.checkVisibility( { visibilityProperty: true } ) ) {
+			return false;
+		}
+	} else {
+		const visibility =
+			element.ownerDocument.defaultView?.getComputedStyle(
+				element
+			).visibility;
+		if ( visibility === 'hidden' || visibility === 'collapse' ) {
+			return false;
+		}
 	}
 
 	return (

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -47,13 +47,21 @@ function buildSelector( sequential ) {
 
 /**
  * Returns true if the specified element is visible (i.e. neither display: none
- * nor visibility: hidden).
+ * nor visibility: hidden or collapse).
  *
  * @param {HTMLElement} element DOM element to test.
  *
  * @return {boolean} Whether element is visible.
  */
 function isVisible( element ) {
+	const visibility =
+		element.ownerDocument.defaultView?.getComputedStyle(
+			element
+		).visibility;
+	if ( visibility === 'hidden' || visibility === 'collapse' ) {
+		return false;
+	}
+
 	return (
 		element.offsetWidth > 0 ||
 		element.offsetHeight > 0 ||

--- a/packages/dom/src/test/focusable.browser.test.js
+++ b/packages/dom/src/test/focusable.browser.test.js
@@ -20,11 +20,16 @@ describe( 'focusable.find() CSS visibility', () => {
 			'<div style="visibility: hidden"><input></div>',
 		],
 		[ 'visibility: collapse', '<input style="visibility: collapse">' ],
+		[
+			'content-visibility: hidden ancestor',
+			'<div style="content-visibility: hidden"><input></div>',
+		],
 	] )(
 		'excludes inputs with %s even when they have layout boxes',
 		( _, html ) => {
 			node.innerHTML = html;
 			const input = node.querySelector( 'input' );
+			const checkVisibility = vi.spyOn( input, 'checkVisibility' );
 
 			expect( input.offsetWidth ).toBeGreaterThan( 0 );
 			expect( input.offsetHeight ).toBeGreaterThan( 0 );
@@ -32,6 +37,9 @@ describe( 'focusable.find() CSS visibility', () => {
 			input.focus();
 			expect( document.activeElement ).not.toBe( input );
 			expect( find( node ) ).toEqual( [] );
+			expect( checkVisibility ).toHaveBeenCalledWith( {
+				visibilityProperty: true,
+			} );
 		}
 	);
 
@@ -45,7 +53,7 @@ describe( 'focusable.find() CSS visibility', () => {
 		expect( find( node ) ).toEqual( [ input ] );
 	} );
 
-	it( "checks visibility in the element's owning window", () => {
+	it( 'uses the owning window for the computed-style fallback', () => {
 		const iframe = document.createElement( 'iframe' );
 		node.appendChild( iframe );
 		const iframeDocument = iframe.contentDocument;
@@ -57,6 +65,12 @@ describe( 'focusable.find() CSS visibility', () => {
 		`;
 		const [ hiddenInput, visibleInput ] =
 			iframeDocument.querySelectorAll( 'input' );
+		Object.defineProperties( hiddenInput, {
+			checkVisibility: { value: undefined },
+		} );
+		Object.defineProperties( visibleInput, {
+			checkVisibility: { value: undefined },
+		} );
 		const getComputedStyle = vi.spyOn(
 			iframeDocument.defaultView,
 			'getComputedStyle'

--- a/packages/dom/src/test/focusable.browser.test.js
+++ b/packages/dom/src/test/focusable.browser.test.js
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { find } from '../focusable';
+
+describe( 'focusable.find() CSS visibility', () => {
+	let node;
+
+	beforeEach( () => {
+		node = document.createElement( 'div' );
+		document.body.appendChild( node );
+	} );
+
+	afterEach( () => {
+		node.remove();
+	} );
+
+	it.each( [
+		[ 'visibility: hidden', '<input style="visibility: hidden">' ],
+		[
+			'inherited visibility: hidden',
+			'<div style="visibility: hidden"><input></div>',
+		],
+		[ 'visibility: collapse', '<input style="visibility: collapse">' ],
+	] )(
+		'excludes inputs with %s even when they have layout boxes',
+		( _, html ) => {
+			node.innerHTML = html;
+			const input = node.querySelector( 'input' );
+
+			expect( input.offsetWidth ).toBeGreaterThan( 0 );
+			expect( input.offsetHeight ).toBeGreaterThan( 0 );
+			expect( input.getClientRects().length ).toBeGreaterThan( 0 );
+			input.focus();
+			expect( document.activeElement ).not.toBe( input );
+			expect( find( node ) ).toEqual( [] );
+		}
+	);
+
+	it( 'includes inputs that restore visibility inside a hidden ancestor', () => {
+		node.style.visibility = 'hidden';
+		node.innerHTML = '<input style="visibility: visible">';
+		const input = node.querySelector( 'input' );
+
+		input.focus();
+		expect( document.activeElement ).toBe( input );
+		expect( find( node ) ).toEqual( [ input ] );
+	} );
+
+	it( "checks visibility in the element's owning window", () => {
+		const iframe = document.createElement( 'iframe' );
+		node.appendChild( iframe );
+		const iframeDocument = iframe.contentDocument;
+		iframeDocument.body.innerHTML = `
+			<div style="visibility: hidden">
+				<input>
+				<input style="visibility: visible">
+			</div>
+		`;
+		const [ hiddenInput, visibleInput ] =
+			iframeDocument.querySelectorAll( 'input' );
+		const getComputedStyle = vi.spyOn(
+			iframeDocument.defaultView,
+			'getComputedStyle'
+		);
+
+		expect( find( iframeDocument.body ) ).toEqual( [ visibleInput ] );
+		expect( getComputedStyle ).toHaveBeenCalledWith( hiddenInput );
+		expect( getComputedStyle ).toHaveBeenCalledWith( visibleInput );
+	} );
+} );

--- a/packages/dom/src/test/focusable.jsdom.test.js
+++ b/packages/dom/src/test/focusable.jsdom.test.js
@@ -108,6 +108,7 @@ describe( 'focusable', () => {
 			const node = createElement( 'div' );
 			const input = createElement( 'input' );
 			node.appendChild( input );
+			document.body.appendChild( node );
 
 			input.style.visibility = 'hidden';
 			expect( find( node ) ).toEqual( [] );
@@ -126,6 +127,7 @@ describe( 'focusable', () => {
 			const node = createElement( 'div' );
 			const input = createElement( 'input' );
 			node.appendChild( input );
+			document.body.appendChild( node );
 
 			node.style.visibility = 'hidden';
 			expect( find( node ) ).toEqual( [] );

--- a/packages/dom/src/test/focusable.jsdom.test.js
+++ b/packages/dom/src/test/focusable.jsdom.test.js
@@ -108,6 +108,7 @@ describe( 'focusable', () => {
 			const node = createElement( 'div' );
 			const input = createElement( 'input' );
 			node.appendChild( input );
+			// Keep the fixture connected so JSDOM invalidates computed styles.
 			document.body.appendChild( node );
 
 			input.style.visibility = 'hidden';
@@ -127,6 +128,7 @@ describe( 'focusable', () => {
 			const node = createElement( 'div' );
 			const input = createElement( 'input' );
 			node.appendChild( input );
+			// Keep the fixture connected so JSDOM invalidates computed styles.
 			document.body.appendChild( node );
 
 			node.style.visibility = 'hidden';

--- a/packages/dom/src/test/utils/create-element.js
+++ b/packages/dom/src/test/utils/create-element.js
@@ -1,6 +1,6 @@
 /**
  * Given an element type, returns an HTMLElement with an emulated layout,
- * since JSDOM does have its own internal layout engine.
+ * since JSDOM does not have its own internal layout engine.
  *
  * @param {string} type Element type.
  *
@@ -14,9 +14,8 @@ export default function createElement( type ) {
 			let isHidden = false;
 			let node = this;
 			do {
-				isHidden =
-					node.style.display === 'none' ||
-					node.style.visibility === 'hidden';
+				// CSS visibility does not remove an element's layout box.
+				isHidden = node.style.display === 'none';
 
 				node = node.parentNode;
 			} while (

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -95,9 +95,7 @@ function listVitestTestsByProject() {
 		const match = line.match( /^\[([^\]]+)\]\s+(.+)$/ );
 		assert.ok( match, `Unexpected Vitest list output: ${ line }` );
 		const [ , listedProjectName, testPath ] = match;
-		const projectName = listedProjectName.startsWith( 'browser (' )
-			? 'browser'
-			: listedProjectName;
+		const projectName = listedProjectName.replace( / \(.+\)$/, '' );
 		assert.ok(
 			testsByProject[ projectName ],
 			`Unexpected Vitest project \`${ projectName }\`. Expected only: ${ VITEST_PROJECT_NAMES.join(

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -94,7 +94,10 @@ function listVitestTestsByProject() {
 	for ( const line of lines ) {
 		const match = line.match( /^\[([^\]]+)\]\s+(.+)$/ );
 		assert.ok( match, `Unexpected Vitest list output: ${ line }` );
-		const [ , projectName, testPath ] = match;
+		const [ , listedProjectName, testPath ] = match;
+		const projectName = listedProjectName.startsWith( 'browser (' )
+			? 'browser'
+			: listedProjectName;
 		assert.ok(
 			testsByProject[ projectName ],
 			`Unexpected Vitest project \`${ projectName }\`. Expected only: ${ VITEST_PROJECT_NAMES.join(


### PR DESCRIPTION
See #80995.

## What?

Exclude elements hidden by CSS `visibility` or `content-visibility` from `focusable.find()` and `tabbable.find()` results. Preserve descendants that explicitly restore `visibility: visible` and keep hidden custom block toolbars from remounting after asynchronous control changes.

## Why?

These elements can retain layout boxes even though native `.focus()` cannot focus them. The new empty result also exposed a block toolbar consumer that treated an empty list as proof that every control was a `ToolbarItem`.

## How?

Use guarded `checkVisibility( { visibilityProperty: true } )` when available. Fall back to computed visibility from the element's owning window, then retain the existing layout-box check. The block toolbar now keeps its current classification when no tabbable controls are found.

The focused Chromium coverage required one small routing update to strip Vitest's trailing instance label, such as `browser (chromium)`. No Browser Mode migration configuration is included.

## Testing Instructions

Run:

```sh
npm run test:unit:vitest -- packages/dom/src/test/focusable.browser.test.js packages/block-editor/src/components/navigable-toolbar/test/index.browser.test.js
```

The browser tests cover direct and inherited `visibility: hidden`, `visibility: collapse`, `content-visibility: hidden`, an explicitly visible descendant, the owning-window fallback, and the hidden custom-toolbar consumer.

For a manual DOM check, add the following fixture in an editor browser console and inspect `wp.dom.focus.focusable.find( container )`:

```js
const container = document.createElement( 'div' );
container.innerHTML = `
	<input style="visibility: hidden">
	<input style="visibility: collapse">
	<div style="visibility: hidden">
		<input>
		<input style="visibility: visible">
	</div>
	<div style="content-visibility: hidden"><input></div>
`;
document.body.appendChild( container );
wp.dom.focus.focusable.find( container );
```

Only the explicitly visible input should be returned. Remove the fixture with `container.remove()`.

<details>
<summary>Additional verification</summary>

Verified 239 DOM and focus-consumer tests in JSDOM and Chromium, test routing and conventions, changed-file lint, full typechecking, and the production build. Before the production fix, the focused Chromium regressions failed. Before the consumer guard, a hidden custom toolbar remounted after a subtree mutation.

</details>

### Testing Instructions for Keyboard

With the manual fixture present, focus its visible input. Tab and Shift+Tab should skip the hidden inputs.

## Follow-up

#80995 contains the same production fix and will need deduplication after this PR merges. This PR does not modify that migration stack.

## Use of AI Tools

Codex implemented and verified this change, including an independent code review.
