### PR TITLE
Test: Strengthen Menu iframe listener cleanup assertions

### DIFF
--- a/packages/ui/src/menu/test/index.jsdom.test.tsx
+++ b/packages/ui/src/menu/test/index.jsdom.test.tsx
@@ -584,10 +584,15 @@ describe( 'Menu', () => {
 				true
 			);
 		} );
+		const reloadedPointerDownListener =
+			reloadedAddEventListener.mock.calls.find(
+				( [ type, , capture ] ) =>
+					type === 'pointerdown' && capture === true
+			)?.[ 1 ];
 		unmount();
-		expect( reloadedRemoveEventListener ).toHaveBeenCalledWith(
+		expect( reloadedRemoveEventListener ).toHaveBeenCalledExactlyOnceWith(
 			'pointerdown',
-			expect.any( Function ),
+			reloadedPointerDownListener,
 			true
 		);
 	} );
@@ -637,11 +642,15 @@ describe( 'Menu', () => {
 			);
 		} );
 
+		const firstPointerDownListener = firstAddEventListener.mock.calls.find(
+			( [ type, , capture ] ) =>
+				type === 'pointerdown' && capture === true
+		)?.[ 1 ];
 		rerender( <MenuWithIframe iframeKey="second" /> );
 		await waitFor( () => {
 			expect( firstRemoveEventListener ).toHaveBeenCalledWith(
 				'pointerdown',
-				expect.any( Function ),
+				firstPointerDownListener,
 				true
 			);
 		} );


### PR DESCRIPTION
Follow-up to #80995.

## What?

Strengthen two Menu iframe-listener cleanup assertions that are not covered on `trunk`.

## Why?

#80995 now waits for listener attachment before unmount and iframe replacement. The remaining assertions still allow cleanup to remove a different callback, and the unmount test does not require exactly one removal.

## How?

Capture the `pointerdown` callbacks passed to `addEventListener`. Assert that iframe replacement removes the callback registered on the old document, and that unmount removes its registered callback exactly once.

Only the test file changes.

## Testing Instructions

```sh
npm run test:unit:vitest -- --project=jsdom packages/ui/src/menu/test
```

All 51 Menu tests should pass.

### Testing Instructions for Keyboard

Not applicable. This changes test assertions only.

## Use of AI Tools

Codex rebased the branch, resolved the overlapping test changes, ran an adversarial self-review and verification, and drafted this description.
