### PR TITLE
Template parts as patterns: Keep the PHP template part APIs working

### DIFF
--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -12,6 +12,8 @@
  *
  * @since 5.9.0
  * @since 6.0.0 Adds the whole theme to the export archive.
+ * @since 23.9.0 Ships template parts as pattern files, with their
+ *               customizations, and customized theme patterns.
  *
  * @global string $wp_version The WordPress version string.
  *
@@ -34,10 +36,16 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	$zip->addEmptyDir( 'templates' );
-	$zip->addEmptyDir( 'parts' );
+	$zip->addEmptyDir( 'patterns' );
 
 	// Get path of the theme.
 	$theme_path = wp_normalize_path( get_stylesheet_directory() );
+
+	// Template parts are patterns: they ship as pattern files instead of the
+	// parts folder, and a customized theme pattern ships its customization.
+	$folders       = get_block_theme_folders();
+	$parts_folder  = trailingslashit( $folders['wp_template_part'] );
+	$pattern_files = gutenberg_get_exported_pattern_files();
 
 	// Create recursive directory iterator.
 	$theme_files = new RecursiveIteratorIterator(
@@ -53,7 +61,11 @@ function gutenberg_generate_block_templates_export_file() {
 			$file_path     = wp_normalize_path( $file );
 			$relative_path = substr( $file_path, strlen( $theme_path ) + 1 );
 
-			if ( ! wp_is_theme_directory_ignored( $relative_path ) ) {
+			if (
+				! wp_is_theme_directory_ignored( $relative_path ) &&
+				! str_starts_with( $relative_path, $parts_folder ) &&
+				! isset( $pattern_files[ $relative_path ] )
+			) {
 				$zip->addFile( $file_path, $relative_path );
 			}
 		}
@@ -66,6 +78,11 @@ function gutenberg_generate_block_templates_export_file() {
 			parse_blocks( $template->content ),
 			'_remove_theme_attribute_from_template_part_block'
 		);
+		// Custom parts ship as pattern files: reference them by name.
+		$template->content = traverse_and_serialize_blocks(
+			parse_blocks( $template->content ),
+			'gutenberg_export_reference_custom_parts_by_slug'
+		);
 
 		$zip->addFromString(
 			'templates/' . $template->slug . '.html',
@@ -73,13 +90,9 @@ function gutenberg_generate_block_templates_export_file() {
 		);
 	}
 
-	// Load template parts into the zip file.
-	$template_parts = get_block_templates( array(), 'wp_template_part' );
-	foreach ( $template_parts as $template_part ) {
-		$zip->addFromString(
-			'parts/' . $template_part->slug . '.html',
-			$template_part->content
-		);
+	// Load the pattern files into the zip file.
+	foreach ( $pattern_files as $relative_path => $contents ) {
+		$zip->addFromString( $relative_path, $contents );
 	}
 
 	// Load theme.json into the zip file.

--- a/lib/compat/wordpress-7.2/class-gutenberg-rest-template-parts-controller-7-2.php
+++ b/lib/compat/wordpress-7.2/class-gutenberg-rest-template-parts-controller-7-2.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Template_Parts_Controller_7_2 class.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Serves `/wp/v2/template-parts` now that template parts are registered
+ * patterns: reads come from the parts' patterns and customizations through
+ * `get_block_template(s)()`, and writes go to the customization, a `wp_block`
+ * post, instead of a `wp_template_part` post.
+ *
+ * Note: there are no changes in this class that need to be backported to
+ * core as is; it stands in for the template parts route while parts are
+ * patterns in the plugin only.
+ */
+class Gutenberg_REST_Template_Parts_Controller_7_2 extends Gutenberg_REST_Templates_Controller_7_2 {
+	/**
+	 * Updates a template part: writes its customization, creating it on the
+	 * first edit, or removes it when reverting to the theme version.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function update_item( $request ) {
+		$template = get_block_template( $request['id'], $this->post_type );
+		if ( ! $template ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+		}
+		list( $theme, $slug ) = explode( '//', $template->id, 2 );
+
+		if ( isset( $request['source'] ) && 'theme' === $request['source'] ) {
+			$copy = gutenberg_get_template_part_customization( $theme, $slug );
+			if ( $copy ) {
+				wp_trash_post( $copy->ID );
+			}
+			$request->set_param( 'context', 'edit' );
+			$template = get_block_template( $request['id'], $this->post_type );
+			return rest_ensure_response( $this->prepare_item_for_response( $template, $request ) );
+		}
+
+		$fields = $this->get_customization_fields( $request );
+		if ( is_wp_error( $fields ) ) {
+			return $fields;
+		}
+		$result = gutenberg_save_template_part( $theme, $slug, $fields );
+		if ( is_wp_error( $result ) ) {
+			$result->add_data( array( 'status' => 'db_update_error' === $result->get_error_code() ? 500 : 400 ) );
+			return $result;
+		}
+
+		$template      = get_block_template( $request['id'], $this->post_type );
+		$fields_update = $this->update_additional_fields_for_object( $template, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+		$request->set_param( 'context', 'edit' );
+		return rest_ensure_response( $this->prepare_item_for_response( $template, $request ) );
+	}
+
+	/**
+	 * Creates a template part: a user pattern filed under the part's area,
+	 * referenced by its slug.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		$theme  = $request['theme'] ?? get_stylesheet();
+		$slug   = gutenberg_get_unique_template_part_slug( $theme, sanitize_title( $request['slug'] ) );
+		$fields = $this->get_customization_fields( $request );
+		if ( is_wp_error( $fields ) ) {
+			return $fields;
+		}
+		$fields = wp_parse_args(
+			$fields,
+			array(
+				'title'   => $slug,
+				'content' => '',
+			)
+		);
+		$result = gutenberg_save_template_part( $theme, $slug, $fields );
+		if ( is_wp_error( $result ) ) {
+			$result->add_data( array( 'status' => 'db_insert_error' === $result->get_error_code() ? 500 : 400 ) );
+			return $result;
+		}
+
+		$template = get_block_template( $theme . '//' . $slug, $this->post_type );
+		if ( ! $template ) {
+			return new WP_Error( 'rest_template_insert_error', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+		$fields_update = $this->update_additional_fields_for_object( $template, $request );
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+		$request->set_param( 'context', 'edit' );
+		$response = rest_ensure_response( $this->prepare_item_for_response( $template, $request ) );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $template->id ) ) );
+		return $response;
+	}
+
+	/**
+	 * Deletes a template part: trashes (or force-deletes) its customization.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_item( $request ) {
+		$template = get_block_template( $request['id'], $this->post_type );
+		if ( ! $template ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+		}
+		if ( 'custom' !== $template->source ) {
+			return new WP_Error( 'rest_invalid_template', __( 'Templates based on theme files can\'t be removed.', 'gutenberg' ), array( 'status' => 400 ) );
+		}
+		$request->set_param( 'context', 'edit' );
+
+		if ( (bool) $request['force'] ) {
+			$previous = $this->prepare_item_for_response( $template, $request );
+			$result   = wp_delete_post( $template->wp_id, true );
+			$response = new WP_REST_Response();
+			$response->set_data(
+				array(
+					'deleted'  => true,
+					'previous' => $previous->get_data(),
+				)
+			);
+		} else {
+			$result           = wp_trash_post( $template->wp_id );
+			$template->status = 'trash';
+			$response         = $this->prepare_item_for_response( $template, $request );
+		}
+		if ( ! $result ) {
+			return new WP_Error( 'rest_cannot_delete', __( 'The template cannot be deleted.', 'gutenberg' ), array( 'status' => 500 ) );
+		}
+		return $response;
+	}
+
+	/**
+	 * Reads the customization fields off a request.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array|WP_Error Fields for `gutenberg_save_template_part()`, or an error.
+	 */
+	private function get_customization_fields( $request ) {
+		$fields = array();
+		if ( isset( $request['content'] ) ) {
+			if ( is_string( $request['content'] ) ) {
+				$fields['content'] = $request['content'];
+			} elseif ( isset( $request['content']['raw'] ) ) {
+				$fields['content'] = $request['content']['raw'];
+			}
+		}
+		if ( isset( $request['title'] ) ) {
+			if ( is_string( $request['title'] ) ) {
+				$fields['title'] = $request['title'];
+			} elseif ( ! empty( $request['title']['raw'] ) ) {
+				$fields['title'] = $request['title']['raw'];
+			}
+		}
+		if ( isset( $request['description'] ) ) {
+			$fields['description'] = $request['description'];
+		}
+		if ( isset( $request['area'] ) ) {
+			$fields['area'] = $request['area'];
+		}
+		if ( ! empty( $request['author'] ) ) {
+			$author = (int) $request['author'];
+			if ( get_current_user_id() !== $author && ! get_userdata( $author ) ) {
+				return new WP_Error( 'rest_invalid_author', __( 'Invalid author ID.', 'gutenberg' ), array( 'status' => 400 ) );
+			}
+			$fields['author'] = $author;
+		}
+		return $fields;
+	}
+}

--- a/lib/compat/wordpress-7.2/template-parts-compat.php
+++ b/lib/compat/wordpress-7.2/template-parts-compat.php
@@ -1,0 +1,632 @@
+<?php
+/**
+ * Backward compatibility for the PHP template part APIs now that template
+ * parts are registered patterns.
+ *
+ * `get_block_templates()`, `get_block_template()` and `block_template_part()`
+ * answer from the part patterns and their customizations, the
+ * `/wp/v2/template-parts` route reads and writes those customizations, the
+ * theme export ships parts as pattern files, `wp_template_part` posts can no
+ * longer be created, and any that still appear are migrated on save.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Returns the customization of a registered pattern: the published
+ * `wp_block` post carrying the pattern name in its `wp_pattern_slug` meta.
+ *
+ * @param string $pattern_name Registered pattern name.
+ * @return WP_Post|null The customization, or null when the pattern is not customized.
+ */
+function gutenberg_get_pattern_customization_post( $pattern_name ) {
+	$copies = get_posts(
+		array(
+			'post_type'      => 'wp_block',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'no_found_rows'  => true,
+			'meta_key'       => 'wp_pattern_slug', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_value'     => $pattern_name, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		)
+	);
+	return $copies ? $copies[0] : null;
+}
+
+/**
+ * Returns the customization of a template part.
+ *
+ * @param string $theme Theme stylesheet.
+ * @param string $slug  Template part slug.
+ * @return WP_Post|null The customization, or null.
+ */
+function gutenberg_get_template_part_customization( $theme, $slug ) {
+	return gutenberg_get_pattern_customization_post( gutenberg_get_template_part_pattern_name( $theme, $slug ) );
+}
+
+/**
+ * Returns the customizations of every template part of a theme, keyed by
+ * part slug.
+ *
+ * @param string $theme Theme stylesheet.
+ * @return WP_Post[] Customizations keyed by slug.
+ */
+function gutenberg_get_template_part_customizations( $theme ) {
+	$prefix  = gutenberg_get_template_part_pattern_name( $theme, '' );
+	$copies  = get_posts(
+		array(
+			'post_type'      => 'wp_block',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'no_found_rows'  => true,
+			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				array(
+					'key'     => 'wp_pattern_slug',
+					'value'   => $prefix,
+					'compare' => 'LIKE',
+				),
+			),
+		)
+	);
+	$by_slug = array();
+	foreach ( $copies as $copy ) {
+		$name = get_post_meta( $copy->ID, 'wp_pattern_slug', true );
+		if ( ! is_string( $name ) || ! str_starts_with( $name, $prefix ) ) {
+			continue;
+		}
+		$by_slug[ substr( $name, strlen( $prefix ) ) ] = $copy;
+	}
+	return $by_slug;
+}
+
+/**
+ * Builds the template part object of a customization, the way a customized
+ * `wp_template_part` post used to be built.
+ *
+ * @param WP_Post $copy  The customization.
+ * @param string  $theme Theme stylesheet.
+ * @param string  $slug  Template part slug.
+ * @return WP_Block_Template The template part.
+ */
+function gutenberg_build_template_part_from_customization( $copy, $theme, $slug ) {
+	$file           = _get_block_template_file( 'wp_template_part', $slug );
+	$has_theme_file = get_stylesheet() === $theme && null !== $file;
+	$pattern        = WP_Block_Patterns_Registry::get_instance()->get_registered( gutenberg_get_template_part_pattern_name( $theme, $slug ) );
+	$area           = get_post_meta( $copy->ID, GUTENBERG_PATTERN_AREA_META_KEY, true );
+	if ( ! $area && $pattern ) {
+		$area = $pattern['area'] ?? '';
+	}
+	$origin = null;
+	if ( $has_theme_file ) {
+		$origin = 'theme';
+	} elseif ( $pattern && 'plugin' === ( $pattern['source'] ?? '' ) ) {
+		$origin = 'plugin';
+	}
+	$content = $copy->post_content;
+	if ( function_exists( 'apply_block_hooks_to_content_from_post_object' ) ) {
+		$content = apply_block_hooks_to_content_from_post_object( $content, $copy );
+	}
+
+	$template                 = new WP_Block_Template();
+	$template->wp_id          = $copy->ID;
+	$template->id             = $theme . '//' . $slug;
+	$template->theme          = $theme;
+	$template->slug           = $slug;
+	$template->type           = 'wp_template_part';
+	$template->content        = $content;
+	$template->source         = 'custom';
+	$template->origin         = $origin;
+	$template->title          = $copy->post_title;
+	$template->description    = $copy->post_excerpt;
+	$template->status         = $copy->post_status;
+	$template->has_theme_file = $has_theme_file;
+	$template->is_custom      = true;
+	$template->author         = $copy->post_author;
+	$template->modified       = $copy->post_modified;
+	$template->date           = $copy->post_date;
+	$template->area           = $area ? _filter_block_template_part_area( $area ) : WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+	return $template;
+}
+
+/**
+ * Builds the template part object of a custom part: a user pattern with an
+ * area, referenced by its slug.
+ *
+ * @param WP_Post $post  The user pattern.
+ * @param string  $theme Theme stylesheet.
+ * @return WP_Block_Template The template part.
+ */
+function gutenberg_build_template_part_from_user_pattern( $post, $theme ) {
+	$content = $post->post_content;
+	if ( function_exists( 'apply_block_hooks_to_content_from_post_object' ) ) {
+		$content = apply_block_hooks_to_content_from_post_object( $content, $post );
+	}
+	$area = get_post_meta( $post->ID, GUTENBERG_PATTERN_AREA_META_KEY, true );
+
+	$template                 = new WP_Block_Template();
+	$template->wp_id          = $post->ID;
+	$template->id             = $theme . '//' . $post->post_name;
+	$template->theme          = $theme;
+	$template->slug           = $post->post_name;
+	$template->type           = 'wp_template_part';
+	$template->content        = $content;
+	$template->source         = 'custom';
+	$template->origin         = null;
+	$template->title          = $post->post_title;
+	$template->description    = $post->post_excerpt;
+	$template->status         = $post->post_status;
+	$template->has_theme_file = false;
+	$template->is_custom      = true;
+	$template->author         = $post->post_author;
+	$template->modified       = $post->post_modified;
+	$template->date           = $post->post_date;
+	$template->area           = $area ? _filter_block_template_part_area( $area ) : WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+	return $template;
+}
+
+/**
+ * Builds the template part object of a registered part pattern that has no
+ * customization: a plugin-registered part, or a custom part registered from
+ * its migrated copy.
+ *
+ * @param array  $pattern Registered pattern properties.
+ * @param string $theme   Theme stylesheet.
+ * @param string $slug    Template part slug.
+ * @return WP_Block_Template The template part.
+ */
+function gutenberg_build_template_part_from_pattern( $pattern, $theme, $slug ) {
+	$file           = _get_block_template_file( 'wp_template_part', $slug );
+	$has_theme_file = get_stylesheet() === $theme && null !== $file;
+	$source         = $pattern['source'] ?? 'theme';
+
+	$template                 = new WP_Block_Template();
+	$template->id             = $theme . '//' . $slug;
+	$template->theme          = $theme;
+	$template->slug           = $slug;
+	$template->type           = 'wp_template_part';
+	$template->content        = $pattern['content'] ?? '';
+	$template->source         = 'plugin' === $source ? 'plugin' : 'theme';
+	$template->origin         = null;
+	$template->title          = $pattern['title'] ?? $slug;
+	$template->description    = $pattern['description'] ?? '';
+	$template->status         = 'publish';
+	$template->has_theme_file = $has_theme_file;
+	$template->is_custom      = false;
+	$template->area           = ! empty( $pattern['area'] ) ? _filter_block_template_part_area( $pattern['area'] ) : WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
+	return $template;
+}
+
+/**
+ * Answers `get_block_templates()` queries for template parts with the parts'
+ * customizations: a customized part takes its content from the
+ * customization, and parts that only exist as customizations are listed.
+ *
+ * @param WP_Block_Template[] $templates     The query result.
+ * @param array               $query         The query.
+ * @param string              $template_type Template type.
+ * @return WP_Block_Template[] The query result.
+ */
+function gutenberg_filter_template_parts_with_customizations( $templates, $query, $template_type ) {
+	if ( 'wp_template_part' !== $template_type ) {
+		return $templates;
+	}
+	$theme  = get_stylesheet();
+	$prefix = gutenberg_get_template_part_pattern_name( $theme, '' );
+
+	if ( isset( $query['wp_id'] ) ) {
+		$copy = get_post( $query['wp_id'] );
+		if ( $copy && 'wp_block' === $copy->post_type ) {
+			$name = get_post_meta( $copy->ID, 'wp_pattern_slug', true );
+			if ( is_string( $name ) && str_starts_with( $name, $prefix ) ) {
+				return array( gutenberg_build_template_part_from_customization( $copy, $theme, substr( $name, strlen( $prefix ) ) ) );
+			}
+			if ( ! $name && get_post_meta( $copy->ID, GUTENBERG_PATTERN_AREA_META_KEY, true ) ) {
+				return array( gutenberg_build_template_part_from_user_pattern( $copy, $theme ) );
+			}
+		}
+		return $templates;
+	}
+
+	$customizations = gutenberg_get_template_part_customizations( $theme );
+
+	$seen = array();
+	foreach ( $templates as $i => $template ) {
+		$seen[ $template->slug ] = true;
+		if ( $template->theme === $theme && isset( $customizations[ $template->slug ] ) ) {
+			$templates[ $i ] = gutenberg_build_template_part_from_customization( $customizations[ $template->slug ], $theme, $template->slug );
+		}
+	}
+	foreach ( $customizations as $slug => $copy ) {
+		if ( isset( $seen[ $slug ] ) ) {
+			continue;
+		}
+		if ( ! empty( $query['slug__in'] ) && ! in_array( $slug, $query['slug__in'], true ) ) {
+			continue;
+		}
+		$templates[]   = gutenberg_build_template_part_from_customization( $copy, $theme, $slug );
+		$seen[ $slug ] = true;
+	}
+	// Registered part patterns without a theme file: plugin-registered parts
+	// and custom parts registered from their copy.
+	foreach ( WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+		if ( ! str_starts_with( $pattern['name'], $prefix ) ) {
+			continue;
+		}
+		$slug = substr( $pattern['name'], strlen( $prefix ) );
+		if ( isset( $seen[ $slug ] ) ) {
+			continue;
+		}
+		if ( ! empty( $query['slug__in'] ) && ! in_array( $slug, $query['slug__in'], true ) ) {
+			continue;
+		}
+		$templates[]   = gutenberg_build_template_part_from_pattern( $pattern, $theme, $slug );
+		$seen[ $slug ] = true;
+	}
+	// Custom parts: user patterns with an area.
+	foreach ( gutenberg_get_user_template_parts() as $slug => $part ) {
+		if ( isset( $seen[ $slug ] ) ) {
+			continue;
+		}
+		if ( ! empty( $query['slug__in'] ) && ! in_array( $slug, $query['slug__in'], true ) ) {
+			continue;
+		}
+		$post = get_post( $part['id'] );
+		if ( $post ) {
+			$templates[]   = gutenberg_build_template_part_from_user_pattern( $post, $theme );
+			$seen[ $slug ] = true;
+		}
+	}
+	if ( isset( $query['area'] ) ) {
+		$templates = array_values(
+			array_filter(
+				$templates,
+				static function ( $template ) use ( $query ) {
+					return $template->area === $query['area'];
+				}
+			)
+		);
+	}
+	return $templates;
+}
+add_filter( 'get_block_templates', 'gutenberg_filter_template_parts_with_customizations', 10, 3 );
+
+/**
+ * Answers `get_block_template()` for a template part: its customization when
+ * there is one, else the theme file or plugin registration, else the user
+ * pattern of a custom part. Runs before the lookup of `wp_template_part`
+ * posts, which are trashed by the migration.
+ *
+ * @param WP_Block_Template|null $template      The template, if already resolved.
+ * @param string                 $id            Template id (`theme//slug`).
+ * @param string                 $template_type Template type.
+ * @return WP_Block_Template|null The template part, or null to let the lookup continue.
+ */
+function gutenberg_resolve_template_part_from_pattern( $template, $id, $template_type ) {
+	if ( null !== $template || 'wp_template_part' !== $template_type ) {
+		return $template;
+	}
+	$parts = explode( '//', $id, 2 );
+	if ( 2 !== count( $parts ) ) {
+		return $template;
+	}
+	list( $theme, $slug ) = $parts;
+	$copy                 = gutenberg_get_template_part_customization( $theme, $slug );
+	if ( $copy ) {
+		return gutenberg_build_template_part_from_customization( $copy, $theme, $slug );
+	}
+	$template = get_block_file_template( $id, $template_type );
+	if ( $template ) {
+		return $template;
+	}
+	$pattern = WP_Block_Patterns_Registry::get_instance()->get_registered( gutenberg_get_template_part_pattern_name( $theme, $slug ) );
+	if ( $pattern ) {
+		return gutenberg_build_template_part_from_pattern( $pattern, $theme, $slug );
+	}
+	$user_part = get_stylesheet() === $theme ? gutenberg_get_user_template_part( $slug ) : null;
+	return $user_part ? gutenberg_build_template_part_from_user_pattern( $user_part, $theme ) : null;
+}
+add_filter( 'pre_get_block_template', 'gutenberg_resolve_template_part_from_pattern', 10, 3 );
+
+/**
+ * Returns a slug that no template part of the theme uses yet.
+ *
+ * @param string $theme Theme stylesheet.
+ * @param string $slug  Wanted slug.
+ * @return string The slug, suffixed when taken.
+ */
+function gutenberg_get_unique_template_part_slug( $theme, $slug ) {
+	$registry  = WP_Block_Patterns_Registry::get_instance();
+	$candidate = $slug;
+	$suffix    = 2;
+	while (
+		$registry->is_registered( gutenberg_get_template_part_pattern_name( $theme, $candidate ) ) ||
+		gutenberg_get_template_part_customization( $theme, $candidate ) ||
+		gutenberg_get_user_template_part( $candidate ) ||
+		( get_stylesheet() === $theme && null !== _get_block_template_file( 'wp_template_part', $candidate ) )
+	) {
+		$candidate = $slug . '-' . $suffix;
+		++$suffix;
+	}
+	return $candidate;
+}
+
+/**
+ * Writes a template part: its customization when it has a registered
+ * original (created on the first write, from the registered version, like a
+ * template part's first save copied its theme file), else the user pattern
+ * of the custom part (created when there is none).
+ *
+ * @param string $theme  Theme stylesheet.
+ * @param string $slug   Template part slug.
+ * @param array  $fields Fields to write: `title`, `content`, `description`, `area`, `author`, `status`.
+ * @return int|WP_Error The `wp_block` post id, or an error.
+ */
+function gutenberg_save_template_part( $theme, $slug, $fields ) {
+	$post = gutenberg_get_template_part_customization( $theme, $slug );
+	if ( ! $post && get_stylesheet() === $theme ) {
+		$post = gutenberg_get_user_template_part( $slug );
+	}
+	$postarr          = array(
+		'post_type'   => 'wp_block',
+		'post_status' => 'publish',
+	);
+	$is_new_user_part = false;
+	if ( $post ) {
+		$postarr['ID'] = $post->ID;
+	} else {
+		$template = get_block_template( $theme . '//' . $slug, 'wp_template_part' );
+		if ( $template ) {
+			// A first edit starts from the registered version.
+			$postarr['post_title']   = $template->title;
+			$postarr['post_content'] = $template->content;
+			$postarr['post_excerpt'] = $template->description;
+			$postarr['meta_input']   = array(
+				'wp_pattern_slug'               => gutenberg_get_template_part_pattern_name( $theme, $slug ),
+				GUTENBERG_PATTERN_AREA_META_KEY => $template->area ? $template->area : WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
+			);
+		} else {
+			// A new custom part is a user pattern with an area.
+			$is_new_user_part        = true;
+			$postarr['post_name']    = $slug;
+			$postarr['post_title']   = $slug;
+			$postarr['post_content'] = '';
+			$postarr['meta_input']   = array(
+				GUTENBERG_PATTERN_AREA_META_KEY => WP_TEMPLATE_PART_AREA_UNCATEGORIZED,
+			);
+		}
+	}
+	if ( isset( $fields['title'] ) ) {
+		$postarr['post_title'] = $fields['title'];
+	}
+	if ( isset( $fields['content'] ) ) {
+		$postarr['post_content'] = $fields['content'];
+	}
+	if ( isset( $fields['description'] ) ) {
+		$postarr['post_excerpt'] = $fields['description'];
+	}
+	if ( isset( $fields['author'] ) ) {
+		$postarr['post_author'] = $fields['author'];
+	}
+	if ( isset( $fields['status'] ) ) {
+		$postarr['post_status'] = $fields['status'];
+	}
+	if ( isset( $fields['area'] ) ) {
+		$postarr['meta_input'][ GUTENBERG_PATTERN_AREA_META_KEY ] = _filter_block_template_part_area( $fields['area'] );
+	}
+	$result = $post ? wp_update_post( wp_slash( $postarr ), true ) : wp_insert_post( wp_slash( $postarr ), true );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+	if ( ( $is_new_user_part || isset( $fields['area'] ) ) && ! get_post_meta( $result, 'wp_pattern_slug', true ) ) {
+		// A user part is filed under its area.
+		gutenberg_assign_template_part_area_category( $result, get_post_meta( $result, GUTENBERG_PATTERN_AREA_META_KEY, true ) );
+	}
+	return $result;
+}
+
+/**
+ * Serves the template parts REST route with the controller that reads and
+ * writes pattern customizations, and closes the `wp_template_part` post type
+ * to new posts: parts live in `wp_block` now.
+ *
+ * @param array $args Post type arguments.
+ * @return array Post type arguments.
+ */
+function gutenberg_close_template_part_post_type( $args ) {
+	$args['rest_controller_class'] = 'Gutenberg_REST_Template_Parts_Controller_7_2';
+	$args['capabilities']          = array_merge(
+		$args['capabilities'] ?? array(),
+		array(
+			'create_posts'           => 'do_not_allow',
+			'edit_posts'             => 'do_not_allow',
+			'edit_others_posts'      => 'do_not_allow',
+			'edit_published_posts'   => 'do_not_allow',
+			'publish_posts'          => 'do_not_allow',
+			'delete_posts'           => 'do_not_allow',
+			'delete_others_posts'    => 'do_not_allow',
+			'delete_published_posts' => 'do_not_allow',
+		)
+	);
+	return $args;
+}
+add_filter( 'register_wp_template_part_post_type_args', 'gutenberg_close_template_part_post_type', 20 );
+
+/**
+ * Migrates a `wp_template_part` post that appears after the migration ran,
+ * for instance inserted by a plugin, as soon as it is saved with its theme.
+ *
+ * @param int     $post_id Post id.
+ * @param WP_Post $post    The post.
+ */
+function gutenberg_migrate_template_part_on_save( $post_id, $post ) {
+	if (
+		wp_is_post_revision( $post_id ) ||
+		wp_is_post_autosave( $post_id ) ||
+		in_array( $post->post_status, array( 'auto-draft', 'trash', 'inherit' ), true )
+	) {
+		return;
+	}
+	$theme_terms = get_the_terms( $post_id, 'wp_theme' );
+	if ( ! is_array( $theme_terms ) || empty( $theme_terms ) ) {
+		// Not a usable template part yet; the bulk migration picks it up.
+		return;
+	}
+	gutenberg_migrate_template_part_post( $post );
+}
+add_action( 'save_post_wp_template_part', 'gutenberg_migrate_template_part_on_save', 100, 2 );
+
+/**
+ * Redirects legacy site editor URLs of template parts to the part's
+ * customization in the pattern editor, or to the Patterns page.
+ */
+function gutenberg_redirect_template_part_site_editor_urls() {
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only URL inspection.
+	$path = isset( $_GET['p'] ) ? sanitize_text_field( wp_unslash( $_GET['p'] ) ) : '';
+	if ( isset( $_GET['postType'] ) && 'wp_template_part' === $_GET['postType'] ) {
+		$path = '/wp_template_part/' . ( isset( $_GET['postId'] ) ? sanitize_text_field( wp_unslash( $_GET['postId'] ) ) : '' );
+	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	if ( ! str_starts_with( $path, '/wp_template_part' ) ) {
+		return;
+	}
+	$id    = trim( substr( $path, strlen( '/wp_template_part' ) ), '/' );
+	$parts = explode( '//', $id, 2 );
+	$url   = admin_url( 'site-editor.php?p=%2Fpattern' );
+	if ( 2 === count( $parts ) ) {
+		$copy = gutenberg_get_template_part_customization( $parts[0], $parts[1] );
+		if ( $copy ) {
+			$url = admin_url( 'site-editor.php?p=%2Fwp_block%2F' . $copy->ID . '&canvas=edit' );
+		}
+	}
+	wp_safe_redirect( $url );
+	exit;
+}
+add_action( 'load-site-editor.php', 'gutenberg_redirect_template_part_site_editor_urls' );
+
+/**
+ * Builds the contents of a theme pattern file (`patterns/*.php`) from a
+ * registered pattern and its content.
+ *
+ * @param array  $pattern Registered pattern properties.
+ * @param string $content Block markup.
+ * @return string The file contents.
+ */
+function gutenberg_build_pattern_file_contents( $pattern, $content ) {
+	$headers = array(
+		'Title' => $pattern['title'] ?? '',
+		'Slug'  => $pattern['name'],
+	);
+	if ( ! empty( $pattern['description'] ) ) {
+		$headers['Description'] = $pattern['description'];
+	}
+	if ( ! empty( $pattern['synced'] ) ) {
+		$headers['Synced'] = 'yes';
+	}
+	if ( ! empty( $pattern['area'] ) ) {
+		$headers['Area'] = $pattern['area'];
+	}
+	$lists = array(
+		'Categories'     => 'categories',
+		'Keywords'       => 'keywords',
+		'Block Types'    => 'blockTypes',
+		'Post Types'     => 'postTypes',
+		'Template Types' => 'templateTypes',
+	);
+	foreach ( $lists as $header => $property ) {
+		if ( ! empty( $pattern[ $property ] ) ) {
+			$headers[ $header ] = implode( ', ', (array) $pattern[ $property ] );
+		}
+	}
+	if ( isset( $pattern['inserter'] ) && ! $pattern['inserter'] ) {
+		$headers['Inserter'] = 'no';
+	}
+	if ( ! empty( $pattern['viewportWidth'] ) ) {
+		$headers['Viewport Width'] = (string) $pattern['viewportWidth'];
+	}
+
+	$file = "<?php\n/**\n";
+	foreach ( $headers as $header => $value ) {
+		$file .= ' * ' . $header . ': ' . preg_replace( '/\s+/', ' ', trim( (string) $value ) ) . "\n";
+	}
+	$file .= " */\n?>\n";
+	// Block markup is static; keep a literal `<?` from being read as PHP.
+	$file .= str_replace( '<?', "<?php echo '<?'; ?>", $content );
+	return rtrim( $file ) . "\n";
+}
+
+/**
+ * Rewrites, for a theme export, a Pattern block referencing a custom part by
+ * its user pattern's id to reference it by the part's pattern name, which the
+ * exported pattern file registers.
+ *
+ * @param array $block The parsed block, passed by reference.
+ * @return string Nothing to prepend.
+ */
+function gutenberg_export_reference_custom_parts_by_slug( &$block ) {
+	static $by_id = null;
+	if ( null === $by_id ) {
+		$by_id = array();
+		foreach ( gutenberg_get_user_template_parts() as $slug => $part ) {
+			$by_id[ $part['id'] ] = gutenberg_get_template_part_pattern_name( get_stylesheet(), $slug );
+		}
+	}
+	if ( 'core/block' === ( $block['blockName'] ?? '' ) && isset( $block['attrs']['ref'], $by_id[ $block['attrs']['ref'] ] ) ) {
+		$block['attrs']['slug'] = $by_id[ $block['attrs']['ref'] ];
+		unset( $block['attrs']['ref'] );
+	}
+	return '';
+}
+
+/**
+ * Returns the pattern files a theme export ships in place of the `parts/`
+ * folder: every template part of the active theme as a pattern file (custom
+ * parts included), and every theme pattern that has a customization, with
+ * the customized content.
+ *
+ * @return string[] File contents keyed by theme-relative path.
+ */
+function gutenberg_get_exported_pattern_files() {
+	$theme      = get_stylesheet();
+	$theme_path = wp_normalize_path( get_stylesheet_directory() ) . '/';
+	$prefix     = gutenberg_get_template_part_pattern_name( $theme, '' );
+	$files      = array();
+
+	foreach ( WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+		$name          = $pattern['name'];
+		$is_part       = str_starts_with( $name, $prefix );
+		$file_path     = ! empty( $pattern['filePath'] ) ? wp_normalize_path( $pattern['filePath'] ) : '';
+		$relative_path = $file_path && str_starts_with( $file_path, $theme_path ) ? substr( $file_path, strlen( $theme_path ) ) : '';
+		if ( ! $is_part && ! $relative_path ) {
+			continue;
+		}
+		$customization = gutenberg_get_pattern_customization_post( $name );
+		if ( ! $is_part && ! $customization ) {
+			// An uncustomized theme pattern ships as its own file.
+			continue;
+		}
+		if ( ! $relative_path || ! str_ends_with( $relative_path, '.php' ) ) {
+			$relative_path = 'patterns/part-' . substr( $name, strlen( $prefix ) ) . '.php';
+		}
+		$content = $customization ? $customization->post_content : $pattern['content'];
+		if ( $customization ) {
+			$pattern['title'] = $customization->post_title;
+			$area             = get_post_meta( $customization->ID, GUTENBERG_PATTERN_AREA_META_KEY, true );
+			if ( $area ) {
+				$pattern['area'] = $area;
+			}
+		}
+		$files[ $relative_path ] = gutenberg_build_pattern_file_contents( $pattern, $content );
+	}
+
+	// Custom parts: user patterns with an area become theme parts.
+	foreach ( gutenberg_get_user_template_parts() as $slug => $part ) {
+		$post = get_post( $part['id'] );
+		if ( ! $post ) {
+			continue;
+		}
+		$pattern                                    = gutenberg_get_template_part_pattern_properties( $post->post_title, $part['area'] );
+		$pattern['name']                            = gutenberg_get_template_part_pattern_name( $theme, $slug );
+		$files[ 'patterns/part-' . $slug . '.php' ] = gutenberg_build_pattern_file_contents( $pattern, $post->post_content );
+	}
+	return $files;
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -73,6 +73,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 7.2 compat.
 	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-templates-controller-7-2.php';
+	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-template-parts-controller-7-2.php';
 	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-block-patterns-controller-7-2.php';
 	require __DIR__ . '/compat/wordpress-7.2/view-config-api.php';
 	require __DIR__ . '/compat/wordpress-7.2/class-gutenberg-rest-view-config-controller-7-2.php';
@@ -132,6 +133,7 @@ require __DIR__ . '/compat/wordpress-7.1/icons.php';
 // WordPress 7.2 compat.
 require __DIR__ . '/compat/wordpress-7.2/block-patterns.php';
 require __DIR__ . '/compat/wordpress-7.2/template-parts-as-patterns.php';
+require __DIR__ . '/compat/wordpress-7.2/template-parts-compat.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/phpunit/template-parts-compat-test.php
+++ b/phpunit/template-parts-compat-test.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Tests for the PHP template part APIs backed by pattern customizations.
+ *
+ * @package Gutenberg
+ * @group blocks
+ */
+class Template_Parts_Compat_Test extends WP_UnitTestCase {
+
+	/**
+	 * Administrator user id.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * The active theme's stylesheet.
+	 *
+	 * @var string
+	 */
+	protected $theme;
+
+	/**
+	 * Posts to delete after each test.
+	 *
+	 * @var int[]
+	 */
+	protected $posts = array();
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		$this->theme = get_stylesheet();
+		delete_option( 'gutenberg_template_parts_migrated' );
+		register_block_pattern(
+			$this->theme . '/part/header',
+			array(
+				'title'   => 'Header',
+				'synced'  => true,
+				'area'    => 'header',
+				'content' => '<!-- wp:paragraph --><p>Theme header</p><!-- /wp:paragraph -->',
+			)
+		);
+	}
+
+	public function tear_down() {
+		unregister_block_pattern( $this->theme . '/part/header' );
+		foreach ( $this->posts as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		foreach ( get_posts(
+			array(
+				'post_type'      => 'wp_block',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'meta_key'       => 'wp_pattern_slug',
+				'meta_value'     => $this->theme . '/part/',
+				'meta_compare'   => 'LIKE',
+			)
+		) as $copy ) { // phpcs:ignore WordPress.DB.SlowDBQuery
+			wp_delete_post( $copy->ID, true );
+		}
+		$this->posts = array();
+		foreach ( get_posts(
+			array(
+				'post_type'      => 'wp_block',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'meta_key'       => 'wp_pattern_area',
+			)
+		) as $part ) { // phpcs:ignore WordPress.DB.SlowDBQuery
+			wp_delete_post( $part->ID, true );
+		}
+		delete_option( 'gutenberg_template_parts_migrated' );
+		parent::tear_down();
+	}
+
+	private function create_user_part( $slug, $content, $title, $area ) {
+		$id            = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_name'    => $slug,
+				'post_title'   => $title,
+				'post_content' => $content,
+				'meta_input'   => array( 'wp_pattern_area' => $area ),
+			)
+		);
+		$this->posts[] = $id;
+		return $id;
+	}
+
+	private function create_customization( $slug, $content, $title = 'Customized', $area = 'header' ) {
+		$id            = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => $title,
+				'post_content' => $content,
+				'meta_input'   => array(
+					'wp_pattern_slug' => $this->theme . '/part/' . $slug,
+					'wp_pattern_area' => $area,
+				),
+			)
+		);
+		$this->posts[] = $id;
+		return $id;
+	}
+
+	/**
+	 * @covers ::gutenberg_resolve_template_part_from_pattern
+	 * @covers ::gutenberg_build_template_part_from_customization
+	 */
+	public function test_get_block_template_and_block_template_part_use_the_customization() {
+		$template = get_block_template( $this->theme . '//header', 'wp_template_part' );
+		$this->assertInstanceOf( WP_Block_Template::class, $template );
+		$this->assertSame( 'theme', $template->source );
+		$this->assertSame( 'header', $template->area );
+		$this->assertStringContainsString( 'Theme header', $template->content );
+
+		$copy_id  = $this->create_customization( 'header', '<!-- wp:paragraph --><p>Edited header</p><!-- /wp:paragraph -->', 'My header' );
+		$template = get_block_template( $this->theme . '//header', 'wp_template_part' );
+		$this->assertSame( 'custom', $template->source );
+		$this->assertSame( $copy_id, $template->wp_id );
+		$this->assertSame( 'My header', $template->title );
+		$this->assertSame( 'header', $template->area );
+		$this->assertStringContainsString( 'Edited header', $template->content );
+
+		ob_start();
+		block_template_part( 'header' );
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'Edited header', $output );
+
+		// Trashing the customization reverts to the registered version.
+		wp_trash_post( $copy_id );
+		$template = get_block_template( $this->theme . '//header', 'wp_template_part' );
+		$this->assertSame( 'theme', $template->source );
+		$this->assertStringContainsString( 'Theme header', $template->content );
+	}
+
+	/**
+	 * @covers ::gutenberg_filter_template_parts_with_customizations
+	 */
+	public function test_get_block_templates_lists_customized_and_custom_parts() {
+		$this->create_customization( 'header', '<!-- wp:paragraph --><p>Edited header</p><!-- /wp:paragraph -->' );
+		// A custom part is a user pattern with an area.
+		$sidebar_id = $this->create_user_part( 'my-sidebar', '<!-- wp:paragraph --><p>Sidebar</p><!-- /wp:paragraph -->', 'My sidebar', 'footer' );
+
+		$parts = get_block_templates( array(), 'wp_template_part' );
+		$slugs = wp_list_pluck( $parts, 'slug' );
+		$this->assertContains( 'header', $slugs );
+		$this->assertContains( 'my-sidebar', $slugs );
+		$header = $parts[ array_search( 'header', $slugs, true ) ];
+		$this->assertSame( 'custom', $header->source );
+		$this->assertStringContainsString( 'Edited header', $header->content );
+
+		$sidebars = get_block_templates( array( 'area' => 'footer' ), 'wp_template_part' );
+		$this->assertSame( array( 'my-sidebar' ), wp_list_pluck( $sidebars, 'slug' ) );
+		$this->assertSame( 'footer', $sidebars[0]->area );
+		$this->assertSame( 'custom', $sidebars[0]->source );
+		$this->assertFalse( $sidebars[0]->has_theme_file );
+		$this->assertSame( $sidebar_id, $sidebars[0]->wp_id );
+		$this->assertSame( $sidebar_id, get_block_template( $this->theme . '//my-sidebar', 'wp_template_part' )->wp_id );
+
+		$by_slug = get_block_templates( array( 'slug__in' => array( 'header' ) ), 'wp_template_part' );
+		$this->assertSame( array( 'header' ), wp_list_pluck( $by_slug, 'slug' ) );
+
+		$by_id = get_block_templates( array( 'wp_id' => $sidebar_id ), 'wp_template_part' );
+		$this->assertCount( 1, $by_id );
+		$this->assertSame( $this->theme . '//my-sidebar', $by_id[0]->id );
+	}
+
+	/**
+	 * @covers Gutenberg_REST_Template_Parts_Controller_7_2::update_item
+	 * @covers Gutenberg_REST_Template_Parts_Controller_7_2::delete_item
+	 */
+	public function test_rest_update_and_delete_write_the_customization() {
+		wp_set_current_user( self::$admin_id );
+		$id = $this->theme . '//header';
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/template-parts/' . $id );
+		$request->set_body_params( array( 'content' => '<!-- wp:paragraph --><p>REST edited</p><!-- /wp:paragraph -->' ) );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'custom', $data['source'] );
+		$this->assertSame( 'header', $data['area'] );
+		$this->assertStringContainsString( 'REST edited', $data['content']['raw'] );
+		$this->assertSame( 'wp_block', get_post_type( $data['wp_id'] ) );
+		$this->assertSame( $this->theme . '/part/header', get_post_meta( $data['wp_id'], 'wp_pattern_slug', true ) );
+		$copy_id = $data['wp_id'];
+
+		// A second update edits the same customization.
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/template-parts/' . $id );
+		$request->set_body_params(
+			array(
+				'title' => 'Renamed',
+				'area'  => 'footer',
+			)
+		);
+		$data = rest_do_request( $request )->get_data();
+		$this->assertSame( $copy_id, $data['wp_id'] );
+		$this->assertSame( 'Renamed', $data['title']['raw'] );
+		$this->assertSame( 'footer', $data['area'] );
+
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/template-parts/' . $id ) );
+		$this->assertSame( 'Renamed', $response->get_data()['title']['raw'] );
+
+		// Deleting trashes the customization and reverts to the theme version.
+		$response = rest_do_request( new WP_REST_Request( 'DELETE', '/wp/v2/template-parts/' . $id ) );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'trash', get_post_status( $copy_id ) );
+		$data = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/template-parts/' . $id ) )->get_data();
+		$this->assertSame( 'theme', $data['source'] );
+		$this->assertStringContainsString( 'Theme header', $data['content']['raw'] );
+	}
+
+	/**
+	 * @covers Gutenberg_REST_Template_Parts_Controller_7_2::create_item
+	 */
+	public function test_rest_create_makes_a_user_pattern() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/template-parts' );
+		$request->set_body_params(
+			array(
+				'slug'    => 'promo',
+				'title'   => 'Promo',
+				'area'    => 'footer',
+				'content' => '<!-- wp:paragraph --><p>Promo</p><!-- /wp:paragraph -->',
+			)
+		);
+		$response = rest_do_request( $request );
+		$this->assertSame( 201, $response->get_status(), wp_json_encode( $response->get_data() ) );
+		$data = $response->get_data();
+		$this->assertSame( $this->theme . '//promo', $data['id'] );
+		$this->assertSame( 'custom', $data['source'] );
+		$this->assertSame( 'footer', $data['area'] );
+		$this->assertSame( 'wp_block', get_post_type( $data['wp_id'] ) );
+		$this->posts[] = $data['wp_id'];
+		// A custom part is a user pattern, not the customization of a pattern.
+		$this->assertSame( 'promo', get_post( $data['wp_id'] )->post_name );
+		$this->assertSame( '', get_post_meta( $data['wp_id'], 'wp_pattern_slug', true ) );
+		$this->assertSame( 'footer', get_post_meta( $data['wp_id'], 'wp_pattern_area', true ) );
+		$this->assertContains( 'footer', wp_get_object_terms( $data['wp_id'], 'wp_pattern_category', array( 'fields' => 'slugs' ) ) );
+		$this->assertInstanceOf( WP_Block_Template::class, get_block_template( $this->theme . '//promo', 'wp_template_part' ) );
+
+		// Updating it through the route edits the user pattern.
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/template-parts/' . $data['id'] );
+		$request->set_body_params( array( 'title' => 'Promo renamed' ) );
+		$updated = rest_do_request( $request )->get_data();
+		$this->assertSame( $data['wp_id'], $updated['wp_id'] );
+		$this->assertSame( 'Promo renamed', get_post( $data['wp_id'] )->post_title );
+
+		// A taken slug is suffixed, as before.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/template-parts' );
+		$request->set_body_params(
+			array(
+				'slug'  => 'promo',
+				'title' => 'Promo',
+			)
+		);
+		$data          = rest_do_request( $request )->get_data();
+		$this->posts[] = $data['wp_id'];
+		$this->assertSame( $this->theme . '//promo-2', $data['id'] );
+	}
+
+	/**
+	 * @covers ::gutenberg_close_template_part_post_type
+	 */
+	public function test_template_part_post_type_is_closed() {
+		$type = get_post_type_object( 'wp_template_part' );
+		$this->assertSame( 'do_not_allow', $type->cap->create_posts );
+		$this->assertSame( 'do_not_allow', $type->cap->edit_posts );
+		$this->assertSame( 'Gutenberg_REST_Template_Parts_Controller_7_2', $type->rest_controller_class );
+	}
+
+	/**
+	 * @covers ::gutenberg_migrate_template_part_on_save
+	 */
+	public function test_template_part_post_saved_later_is_migrated() {
+		$part_id       = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_status'  => 'publish',
+				'post_name'    => 'late-part',
+				'post_title'   => 'Late part',
+				'post_content' => '<!-- wp:paragraph --><p>Late</p><!-- /wp:paragraph -->',
+			)
+		);
+		$this->posts[] = $part_id;
+		// Without a theme it is not a template part yet.
+		$this->assertSame( 'publish', get_post_status( $part_id ) );
+
+		wp_set_post_terms( $part_id, array( $this->theme ), 'wp_theme' );
+		wp_set_post_terms( $part_id, array( 'footer' ), 'wp_template_part_area' );
+		wp_update_post(
+			array(
+				'ID'         => $part_id,
+				'post_title' => 'Late part',
+			)
+		);
+
+		$this->assertSame( 'trash', get_post_status( $part_id ) );
+		// A custom part becomes a user pattern with the part's slug and area.
+		$user_part = gutenberg_get_user_template_part( 'late-part' );
+		$this->assertInstanceOf( WP_Post::class, $user_part );
+		$this->posts[] = $user_part->ID;
+		$this->assertSame( 'footer', get_post_meta( $user_part->ID, 'wp_pattern_area', true ) );
+		$template = get_block_template( $this->theme . '//late-part', 'wp_template_part' );
+		$this->assertSame( $user_part->ID, $template->wp_id );
+		$this->assertStringContainsString( 'Late', $template->content );
+	}
+
+	/**
+	 * @covers ::gutenberg_generate_block_templates_export_file
+	 * @covers ::gutenberg_get_exported_pattern_files
+	 * @covers ::gutenberg_build_pattern_file_contents
+	 */
+	public function test_export_ships_template_parts_as_pattern_files() {
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			$this->markTestSkipped( 'ZipArchive is not available.' );
+		}
+		$this->create_customization( 'header', '<!-- wp:paragraph --><p>Exported header</p><!-- /wp:paragraph -->', 'Exported' );
+		$promo_id = $this->create_user_part( 'promo', '<!-- wp:paragraph --><p>Promo</p><!-- /wp:paragraph -->', 'Promo', 'footer' );
+
+		// Templates reference a custom part by the name its pattern file registers.
+		$this->assertSame(
+			'<!-- wp:block {"hasWrapper":true,"slug":"' . $this->theme . '/part/promo"} /-->',
+			traverse_and_serialize_blocks(
+				parse_blocks( '<!-- wp:block {"ref":' . $promo_id . ',"hasWrapper":true} /-->' ),
+				'gutenberg_export_reference_custom_parts_by_slug'
+			)
+		);
+
+		$filename = gutenberg_generate_block_templates_export_file();
+		$this->assertIsString( $filename );
+		$zip = new ZipArchive();
+		$this->assertTrue( $zip->open( $filename ) );
+
+		$entries = array();
+		for ( $i = 0; $i < $zip->numFiles; $i++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$entries[] = $zip->getNameIndex( $i );
+		}
+		$this->assertNotContains( 'parts/', $entries );
+		$this->assertEmpty( preg_grep( '#^parts/#', $entries ) );
+		$this->assertContains( 'patterns/part-header.php', $entries );
+		$this->assertContains( 'patterns/part-promo.php', $entries );
+		$promo_file = $zip->getFromName( 'patterns/part-promo.php' );
+		$this->assertStringContainsString( ' * Slug: ' . $this->theme . '/part/promo', $promo_file );
+		$this->assertStringContainsString( ' * Area: footer', $promo_file );
+		$this->assertStringContainsString( '<p>Promo</p>', $promo_file );
+
+		$file = $zip->getFromName( 'patterns/part-header.php' );
+		$this->assertStringContainsString( ' * Title: Exported', $file );
+		$this->assertStringContainsString( ' * Slug: ' . $this->theme . '/part/header', $file );
+		$this->assertStringContainsString( ' * Synced: yes', $file );
+		$this->assertStringContainsString( ' * Area: header', $file );
+		$this->assertStringContainsString( 'Exported header', $file );
+		$zip->close();
+		unlink( $filename );
+	}
+}


### PR DESCRIPTION
## What?

Part 6, stacked on #82569. With template parts registered as patterns and edited through `wp_block` customizations, this makes the PHP template part APIs keep answering as before, from that store.

- **`get_block_templates()` / `get_block_template()` / `block_template_part()`** for `wp_template_part` answer from the part patterns, their customizations and the custom parts: a customized part carries the customization's content, title, area, `wp_id` and `source: custom`; a custom part (a user pattern with an area, migrated or created from the Navigation block) is listed as `theme//<slug>` with `source: custom` and no theme file; registered patterns without a theme file are listed too. `block_header_area()`, `block_footer_area()` and any theme or plugin calling `block_template_part()` see the edits again.
- **`/wp/v2/template-parts`** is served by a controller that reads through those functions and writes to the customization: `PUT` creates the customization on first edit (from the registered version, like the old first save copied the theme file) and updates it afterwards, `PUT` with `source=theme` trashes it (Reset), `DELETE` trashes or force-deletes it, `POST` creates a custom part: a user pattern with the slug (suffixed `-2` when taken) filed under the part's area, which template part blocks reference by id. `PUT` on a custom part edits that user pattern. Ids stay `theme//slug`.
- **Theme export** stops shipping the `parts/` folder. Every template part of the theme, custom parts included, ships as `patterns/part-<slug>.php` with the pattern headers (`Slug`, `Synced`, `Area`, `Categories`, `Block Types`, `Inserter`) and the customized content when there is one, and a customized theme pattern ships its customization in place of its file. Exported templates referencing a custom part by its user pattern's id are rewritten to reference it by the name the pattern file registers. Exported templates keep referencing parts by `<theme>/part/<slug>`, which the export's theme name resolves, the same way core stripped the `theme` attribute from template part blocks.
- **`wp_template_part` post type** is closed: its create/edit/delete capabilities map to `do_not_allow` (the type stays registered, core registers it as built-in and it can't be unregistered), and a post that still appears, inserted by a plugin for instance, is migrated to a customization as soon as it is saved with its theme.
- **Legacy site editor URLs** (`p=/wp_template_part/<theme>//<slug>` and `postType=wp_template_part&postId=`) redirect to the part's customization in the pattern editor when there is one, else to the Patterns page.

## How?

- `lib/compat/wordpress-7.2/template-parts-compat.php`: `pre_get_block_template` resolves a part to its customization, else the theme file, else the registered pattern; `get_block_templates` replaces customized entries and appends the rest; the `WP_Block_Template` objects are built the way `_build_block_template_object_from_post_object()` built them from a `wp_template_part` post. Also the post type args, the save hook, the redirect, and the pattern file writer used by the export.
- `lib/compat/wordpress-7.2/class-gutenberg-rest-template-parts-controller-7-2.php`: `update_item`, `create_item` and `delete_item` over `gutenberg_save_template_part()`, which writes the customization when the part has a registered original and the user pattern otherwise. Reads and permissions are the parent's.
- `lib/block-template-utils.php`: the export skips the parts folder and the files it replaces, then writes the pattern files.
- The save hook reuses the per-post migration from #82569.

## Testing Instructions

`phpunit/template-parts-compat-test.php` covers resolution, listing (area, `slug__in`, `wp_id`) of customized and custom parts, REST update/reset/delete/create (a custom part as user pattern, edits to it), the closed post type, the late migration and the export archive with the reference rewrite. On a site:

1. Edit the header (Patterns → Header → Edit). `wp eval 'echo get_block_template( get_stylesheet() . "//header", "wp_template_part" )->source;'` prints `custom`; the front end of a classic `block_template_part( "header" )` call shows the edit.
2. `GET /wp/v2/template-parts?context=edit` lists the theme's parts; the edited one has `source: custom` and a `wp_id` pointing at a `wp_block` post.
3. `PUT /wp/v2/template-parts/<theme>//footer` with `content` creates the footer's customization; the Patterns page shows it as Customized. `PUT` with `source=theme` resets it.
4. Tools → Export (or `/wp-block-editor/v1/export`): the zip has no `parts/` folder and a `patterns/part-header.php` carrying the edit.
5. Open `site-editor.php?p=/wp_template_part/<theme>//header`: it lands in the header's pattern editor.

## Notes

- Revisions and autosaves under `/wp/v2/template-parts/<id>/revisions` are not served: their controller expects a `wp_template_part` parent post. The site editor no longer uses that route for parts; revisions of a part are the `wp_block` post's.
- The `wp_template_part_area` taxonomy is not written anymore (the area is the `wp_pattern_area` meta); it stays registered by core.
- `render_block_core_template_part()` is defined by core, so a direct call still works there; the plugin just doesn't register the block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
