### PR TITLE
Media & Text: replace deprecated word-break with overflow-wrap: anywhere

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -53,8 +53,8 @@
 	grid-row: 1;
 	/*rtl:end:ignore*/
 	padding: 0 8% 0 8%;
-	// stylelint-disable-next-line declaration-property-value-keyword-no-deprecated -- Pending review of overflow-wrap alternative.
-	word-break: break-word;
+	word-break: normal;
+	overflow-wrap: anywhere;
 }
 
 .wp-block-media-text.has-media-on-the-right > .wp-block-media-text__media {


### PR DESCRIPTION
Part of #82293.

Split out of #82480, following @aaronrobertshaw's suggestion to do this per block so each one can be tested and reverted independently.

## What?

Replace the deprecated `word-break: break-word` in the Media & Text block with `word-break: normal` + `overflow-wrap: anywhere`, and remove the Stylelint suppression covering it.

- `packages/block-library/src/media-text/style.scss` — the content column

## Why?

`word-break: break-word` is deprecated. Per CSS Text 3 it is defined as `word-break: normal` plus **`overflow-wrap: anywhere`** — not `overflow-wrap: break-word`. Both halves are set explicitly, so an inherited value such as a theme's `word-break: break-all` cannot change how the content column wraps.

The `anywhere` half matters because the content column is a grid track, so its width comes from intrinsic sizing. With `break-word` the column measured 475px instead of 323px at a 1280px viewport, pushing the media column narrower; `anywhere` preserves the current split exactly.

## How?

Straight declaration swap.

Measured the content column at 375px, 600px, 1024px and 1280px against both candidates. `overflow-wrap: anywhere` reproduced the current geometry at every width; `overflow-wrap: break-word` changed it at every width.

Verification screenshots — front end at two viewports, the editor, and a theme-level `word-break: break-all` compared against trunk — are in the comment below.

## Testing Instructions

1. Add a Media & Text block with a long unbroken string (a long URL works) in the content column.
2. Confirm the text wraps and the media/content split is unchanged, in the editor and on the front end.
3. Narrow the viewport to ~375px and confirm the block stacks and the page does not scroll horizontally.
4. Add `.wp-site-blocks { word-break: break-all; }` as Additional CSS and confirm the content column still wraps on word boundaries while surrounding paragraphs break mid-word.
5. Run `npm run lint:css` — no violations in the changed file.

## Use of AI Tools

Claude Code
