### PR TITLE
Query Loop: list taxonomy terms so they can be browsed, not recalled

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -11,7 +11,7 @@
 -   Math: Declare `interactivity.clientNavigation` support. The block's front end output is static markup, and without the declaration a Math block inside a Query block forced full page reloads on pagination ([#82248](https://github.com/WordPress/gutenberg/pull/82248)).
 -   Paragraph, List, Heading, Preformatted, Columns, Group, Template Part: Read the default padding these blocks add when they have a background color from the `--wp--style--block-background-padding` custom property, so themes can change or remove it ([#82024](https://github.com/WordPress/gutenberg/pull/82024)).
 -   Query: Show a snackbar notice instead of a blocking modal when "Reload full page" is turned on automatically because a block inside the Query block doesn't support client-side navigation ([#82246](https://github.com/WordPress/gutenberg/pull/82246)).
--   Query: List the existing terms in the taxonomy filters, so categories and tags can be browsed and selected instead of recalled and typed. The controls now use `SearchableChipSelectControl` from `@wordpress/ui` ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   Query: List the existing terms in the taxonomy filters, so categories and tags can be browsed and selected instead of recalled and typed. The controls now use `SearchableChipSelectControl` from `@wordpress/ui` ([#82583](https://github.com/WordPress/gutenberg/pull/82583)).
 
 ### Bug Fixes
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Math: Declare `interactivity.clientNavigation` support. The block's front end output is static markup, and without the declaration a Math block inside a Query block forced full page reloads on pagination ([#82248](https://github.com/WordPress/gutenberg/pull/82248)).
 -   Paragraph, List, Heading, Preformatted, Columns, Group, Template Part: Read the default padding these blocks add when they have a background color from the `--wp--style--block-background-padding` custom property, so themes can change or remove it ([#82024](https://github.com/WordPress/gutenberg/pull/82024)).
 -   Query: Show a snackbar notice instead of a blocking modal when "Reload full page" is turned on automatically because a block inside the Query block doesn't support client-side navigation ([#82246](https://github.com/WordPress/gutenberg/pull/82246)).
+-   Query: List the existing terms in the taxonomy filters, so categories and tags can be browsed and selected instead of recalled and typed. The controls now use `SearchableChipSelectControl` from `@wordpress/ui` ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 
 ### Bug Fixes
 

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.jsx
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.jsx
@@ -1,10 +1,8 @@
-import {
-	FormTokenField,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { SearchableChipSelectControl } from '@wordpress/ui';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useState, useEffect, Fragment } from '@wordpress/element';
+import { useState, useEffect, useMemo, Fragment } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { sprintf, __ } from '@wordpress/i18n';
@@ -13,33 +11,34 @@ import { useTaxonomies } from '../../utils';
 const EMPTY_ARRAY = [];
 const BASE_QUERY = {
 	order: 'asc',
+	orderby: 'name',
 	_fields: 'id,name',
 	context: 'view',
 };
 
-// Helper function to get the term id based on user input in terms `FormTokenField`.
-const getTermIdByTermValue = ( terms, termValue ) => {
-	// First we check for exact match by `term.id` or case sensitive `term.name` match.
-	const termId =
-		termValue?.id || terms?.find( ( term ) => term.name === termValue )?.id;
-	if ( termId ) {
-		return termId;
-	}
+/**
+ * How the limit for the browsable list of terms was chosen:
+ *  - Matches the `per_page` range set by the REST API.
+ *  - Mirrors the limit used by the post editor's flat term selector.
+ */
+const MAX_TERMS_TO_LIST = 100;
+const MAX_SEARCH_RESULTS = 20;
 
-	/**
-	 * Here we make an extra check for entered terms in a non case sensitive way,
-	 * to match user expectations, due to `FormTokenField` behaviour that shows
-	 * suggestions which are case insensitive.
-	 *
-	 * Although WP tries to discourage users to add terms with the same name (case insensitive),
-	 * it's still possible if you manually change the name, as long as the terms have different slugs.
-	 * In this edge case we always apply the first match from the terms list.
-	 */
-	const termValueLower = termValue.toLocaleLowerCase();
-	return terms?.find(
-		( term ) => term.name.toLocaleLowerCase() === termValueLower
-	)?.id;
-};
+/**
+ * Terms are listed and selected as `{ value, label }` items, where `value` is
+ * the stringified term id. Items come from different requests than the selected
+ * value, so they are never referentially equal and have to be matched by id.
+ *
+ * @param {{value: string}} item     An item from the list.
+ * @param {{value: string}} selected A currently selected item.
+ * @return {boolean} Whether both refer to the same term.
+ */
+const isItemEqualToValue = ( item, selected ) => item.value === selected.value;
+
+const termToItem = ( term ) => ( {
+	value: String( term.id ),
+	label: decodeEntities( term.name ),
+} );
 
 export function TaxonomyControls( { onChange, query } ) {
 	const { postType, taxQuery } = query;
@@ -114,7 +113,11 @@ export function TaxonomyControls( { onChange, query } ) {
 }
 
 /**
- * Renders a `FormTokenField` for a given taxonomy.
+ * Renders a `SearchableChipSelectControl` for a given taxonomy.
+ *
+ * The list of terms is browsable: opening the control lists the existing terms
+ * without requiring the user to remember and type their names. Typing narrows
+ * the list down through a server side search.
  *
  * @param {Object}   props                 The props for the component.
  * @param {Object}   props.taxonomy        The taxonomy object.
@@ -131,45 +134,52 @@ function TaxonomyItem( {
 	onChange,
 	label,
 } ) {
+	// The list of terms is only requested once the user opens the control, so
+	// that merely rendering the inspector does not fetch terms nobody browses.
+	// Once opened, it stays subscribed to avoid refetching on every reopen.
+	const [ hasOpened, setHasOpened ] = useState( false );
+	const [ inputValue, setInputValue ] = useState( '' );
 	const [ search, setSearch ] = useState( '' );
 	const [ value, setValue ] = useState( EMPTY_ARRAY );
-	const [ suggestions, setSuggestions ] = useState( EMPTY_ARRAY );
 	const debouncedSearch = useDebounce( setSearch, 250 );
-	const { searchResults, searchHasResolved } = useSelect(
+	const { listedTerms, listHasResolved } = useSelect(
 		( select ) => {
-			if ( ! search ) {
-				return { searchResults: EMPTY_ARRAY, searchHasResolved: true };
+			if ( ! hasOpened ) {
+				return { listedTerms: EMPTY_ARRAY, listHasResolved: false };
 			}
 			const { getEntityRecords, hasFinishedResolution } =
 				select( coreStore );
-
-			// Combine current terms and opposite terms for exclusion, to prevent
-			// users from selecting the same term in both include and exclude controls.
-			const combinedExclude = [ ...termIds, ...oppositeTermIds ];
 
 			const selectorArgs = [
 				'taxonomy',
 				taxonomy.slug,
 				{
 					...BASE_QUERY,
-					search,
-					orderby: 'name',
-					exclude: combinedExclude,
-					per_page: 20,
+					// Exclude the opposite control's terms, to prevent users
+					// from selecting the same term in both the include and the
+					// exclude control. The terms selected in this control stay
+					// listed, so that they can be deselected from the list and
+					// so that selecting one does not change the query, which
+					// would refetch the list mid-selection.
+					exclude: oppositeTermIds,
+					// Without a search, list the terms so they can be browsed.
+					...( search
+						? { search, per_page: MAX_SEARCH_RESULTS }
+						: { per_page: MAX_TERMS_TO_LIST } ),
 				},
 			];
 			return {
-				searchResults: getEntityRecords( ...selectorArgs ),
-				searchHasResolved: hasFinishedResolution(
+				listedTerms: getEntityRecords( ...selectorArgs ) || EMPTY_ARRAY,
+				listHasResolved: hasFinishedResolution(
 					'getEntityRecords',
 					selectorArgs
 				),
 			};
 		},
-		[ search, taxonomy.slug, termIds, oppositeTermIds ]
+		[ hasOpened, search, taxonomy.slug, oppositeTermIds ]
 	);
 	// `existingTerms` are the ones fetched from the API and their type is `{ id: number; name: string }`.
-	// They are used to extract the terms' names to populate the `FormTokenField` properly
+	// They are used to extract the terms' names to populate the control properly
 	// and to sanitize the provided `termIds`, by setting only the ones that exist.
 	const existingTerms = useSelect(
 		( select ) => {
@@ -199,43 +209,52 @@ function TaxonomyItem( {
 		const sanitizedValue = termIds.reduce( ( accumulator, id ) => {
 			const entity = existingTerms.find( ( term ) => term.id === id );
 			if ( entity ) {
-				accumulator.push( {
-					id,
-					value: entity.name,
-				} );
+				accumulator.push( termToItem( entity ) );
 			}
 			return accumulator;
 		}, [] );
 		setValue( sanitizedValue );
 	}, [ termIds, existingTerms ] );
-	// Update suggestions only when the query has resolved.
-	useEffect( () => {
-		if ( ! searchHasResolved ) {
-			return;
-		}
-		setSuggestions( searchResults.map( ( result ) => result.name ) );
-	}, [ searchResults, searchHasResolved ] );
-	const onTermsChange = ( newTermValues ) => {
-		const newTermIds = new Set();
-		for ( const termValue of newTermValues ) {
-			const termId = getTermIdByTermValue( searchResults, termValue );
-			if ( termId ) {
-				newTermIds.add( termId );
-			}
-		}
-		setSuggestions( EMPTY_ARRAY );
-		onChange( Array.from( newTermIds ) );
+	const items = useMemo(
+		() => listedTerms.map( termToItem ),
+		[ listedTerms ]
+	);
+	const onInputValueChange = ( nextInputValue ) => {
+		setInputValue( nextInputValue );
+		debouncedSearch( nextInputValue );
 	};
+	const onTermsChange = ( newValue ) => {
+		// Reset the search so that the full list is offered for the next
+		// selection, cancelling a search the debounce has not yet run.
+		debouncedSearch.cancel();
+		setInputValue( '' );
+		setSearch( '' );
+		onChange( newValue.map( ( item ) => Number( item.value ) ) );
+	};
+	// A request is pending either while the debounce has not caught up with what
+	// has been typed, or while the request it triggered is still resolving.
+	// Without this the control would claim there are no results before it has
+	// looked for any.
+	const isPending = inputValue !== search || ! listHasResolved;
 	return (
 		<div className="block-library-query-inspector__taxonomy-control">
-			<FormTokenField
+			<SearchableChipSelectControl
 				label={ label }
+				items={ items }
 				value={ value }
-				onInputChange={ debouncedSearch }
-				suggestions={ suggestions }
-				displayTransform={ decodeEntities }
-				onChange={ onTermsChange }
-				help=""
+				onValueChange={ onTermsChange }
+				inputValue={ inputValue }
+				onInputValueChange={ onInputValueChange }
+				onOpenChange={ ( isOpen ) => {
+					if ( isOpen ) {
+						setHasOpened( true );
+					}
+				} }
+				// Terms are searched server side, so opt out of the built-in
+				// client side filtering rather than filtering twice.
+				filter={ null }
+				isItemEqualToValue={ isItemEqualToValue }
+				emptyContent={ isPending ? __( 'Loading…' ) : undefined }
 			/>
 		</div>
 	);

--- a/test/e2e/specs/editor/blocks/query.spec.js
+++ b/test/e2e/specs/editor/blocks/query.spec.js
@@ -104,4 +104,96 @@ test.describe( 'Query block', () => {
 			] );
 		} );
 	} );
+
+	test.describe( 'Taxonomy filters', () => {
+		let categoryIds = [];
+
+		test.beforeAll( async ( { requestUtils } ) => {
+			const categories = await Promise.all(
+				[ 'Alpaca', 'Beluga', 'Capybara' ].map( ( name ) =>
+					requestUtils.rest( {
+						path: '/wp/v2/categories',
+						method: 'POST',
+						data: { name },
+					} )
+				)
+			);
+			categoryIds = categories.map( ( { id } ) => id );
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await Promise.all(
+				categoryIds.map( ( id ) =>
+					requestUtils.rest( {
+						path: `/wp/v2/categories/${ id }`,
+						method: 'DELETE',
+						params: { force: true },
+					} )
+				)
+			);
+		} );
+
+		test( 'should list existing terms without typing a search', async ( {
+			page,
+			editor,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/query',
+				attributes: { query: { perPage: 3, postType: 'post' } },
+				innerBlocks: [
+					{
+						name: 'core/post-template',
+						innerBlocks: [ { name: 'core/post-title' } ],
+					},
+				],
+			} );
+			await editor.selectBlocks(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Query Loop',
+				} )
+			);
+			await editor.openDocumentSettingsSidebar();
+
+			const settings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+
+			// The taxonomies control is an optional tools panel item.
+			await settings
+				.getByRole( 'button', { name: 'Filters options' } )
+				.click();
+			await page
+				.getByRole( 'menuitemcheckbox', { name: 'Show Taxonomies' } )
+				.click();
+			await page.keyboard.press( 'Escape' );
+
+			// Opening the control lists the terms, with nothing typed.
+			await settings
+				.getByRole( 'combobox', { name: 'Categories', exact: true } )
+				.click();
+
+			await expect(
+				page.getByRole( 'option', { name: 'Alpaca' } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'option', { name: 'Beluga' } )
+			).toBeVisible();
+
+			// Selecting from that list filters the query by the term.
+			await page.getByRole( 'option', { name: 'Beluga' } ).click();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/query',
+					attributes: {
+						query: {
+							taxQuery: {
+								include: { category: [ categoryIds[ 1 ] ] },
+							},
+						},
+					},
+				},
+			] );
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?

Closes #31112

Makes the Query Loop block's taxonomy filters browsable. Opening the Categories (or Tags, or any other taxonomy) field now lists the existing terms, instead of requiring you to recall and type a term name before anything appears.

The controls move from `FormTokenField` to `SearchableChipSelectControl` from `@wordpress/ui`.

## Why?

From the [fifth FSE Outreach Program call for testing](https://make.wordpress.org/test/2021/04/14/fse-program-testing-call-5-query-quest/), two separate testers reported the same thing:

> When selecting the category of the Query block, it would be nice to be able to select from a list of existing categories instead of suggestions from input. Because I do not remember all the categories.

`FormTokenField` only requested terms once the user typed, so a term you couldn't name was unreachable.

The component choice follows https://github.com/WordPress/gutenberg/issues/64086#issuecomment-5525387401, which closed the `FormTokenField` v2 feedback issue and named `SearchableChipSelectControl` as the closest replacement. This is the first consumer of it in the repo, so it's worth a careful look.

## How?

`packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.jsx`:

- **Browsable list.** When there's no search, request up to 100 terms ordered by name. The 100 mirrors `MAX_TERMS_SUGGESTIONS` in the post editor's flat term selector, whose comment notes it matches the REST API's `per_page` range. Search results stay at 20, as before.
- **Fetched lazily.** The list is only requested once the control is first opened, so rendering the inspector doesn't fetch terms nobody browses. Each taxonomy renders two controls (include and exclude), so this matters.
- **Search unchanged.** Still a 250ms debounced server-side search. `filter={ null }` opts out of Base UI's built-in client-side filtering so results aren't filtered twice.
- **`isItemEqualToValue`.** Items and the selected value come from different requests, so they're never referentially equal. Without matching on the term id, the default `Object.is` comparison would never mark a selected term as selected.
- **Pending state.** `emptyContent` shows "Loading…" while the debounce hasn't caught up or the request hasn't resolved, so the control doesn't claim "No results found" before it has looked. `Combobox.Status` would be the better fit but isn't re-exported by `SearchableChipSelect`; this matches the "partially covered" note for loading states in the recap table on #64086.

Stored data is unchanged. The controls still write plain term ids into `taxQuery.include` / `taxQuery.exclude`, and the sanitisation that drops ids no longer resolving to a real term is kept.

Two behaviour notes worth calling out:

1. `getTermIdByTermValue()` is removed. It mapped typed text back to a term id, including a case-insensitive fallback. The new control emits selected item objects rather than raw strings, so it has no caller.
2. Only the *opposite* control's terms are excluded from the list, not the ones already selected in the current control. This still prevents a term being both included and excluded. It also means selecting a term no longer changes the query, so the list isn't refetched mid-selection — with the previous exclusion the popup dropped to "Loading…" for ~110ms on every single click, and considerably longer over a real network. Selected terms stay listed with a checkmark and can be deselected from the list.

## Testing Instructions

1. Create several categories, ideally more than a handful, and include one with an ampersand in the name (e.g. `Q&A`) to check entity decoding.
2. Add a Query Loop block to a page and select it.
3. Open the settings sidebar, and in the **Filters** panel use the ⋮ options menu to enable **Taxonomies**.
4. Click the **Categories** field **without typing anything**. The existing categories should be listed alphabetically. This is the fix.
5. Select a term. It becomes a chip, stays in the list with a checkmark, and the list should not flash "Loading…".
6. Click the checked term in the list to deselect it, or use the chip's Remove button, or "Clear all".
7. Type part of a term name. The list narrows via server-side search.
8. Check `Q&A` displays with a literal `&`, not `&amp;`, in both the list and the chip.
9. In **Exclude: Categories**, confirm a term selected in the include control is not offered.
10. Confirm the block still filters correctly, and that reloading the editor restores the selected terms.

### Testing Instructions for Keyboard

1. With the Categories field focused, press <kbd>Down</kbd> to open the list without typing.
2. Move through options with <kbd>Up</kbd> / <kbd>Down</kbd> and select with <kbd>Enter</kbd>.
3. Press <kbd>Escape</kbd> to close the list.
4. <kbd>Tab</kbd> to a chip's Remove button and activate it with <kbd>Enter</kbd> or <kbd>Space</kbd>.
5. Confirm the field is reachable by <kbd>Tab</kbd> from the surrounding controls and that its label is announced.

## Screenshots or screencast

https://github.com/user-attachments/assets/6b74cd49-c9f3-4b8b-bff5-9e87a8fd3cca

## Use of AI Tools

This PR was authored with Claude Code (Claude Opus 5). The design was decided interactively — scope, the browse limit and ordering, lazy fetching, and the loading-flash fix were all chosen by me at decision points rather than by the model. The implementation, the e2e test, and the changelog entry were written by the model under that direction.

Verification I had it perform, and reviewed: the e2e test was confirmed to fail on the unmodified code and pass with the change, rather than only asserting the passing state. Behaviour was exercised in wp-env with 24 seeded categories, checking the list contents, entity decoding, server-side search, chip removal, deselection from the list, and the resulting `taxQuery` attribute. The loading flash was measured before and after with a MutationObserver. `npm run typecheck` and `npm run lint:js` are clean.

I have reviewed the change and take responsibility for it.
