### PR TITLE
Editor: Render change diffs in the post title in revisions

### DIFF
--- a/packages/editor/src/components/post-revisions-preview/block-diff.js
+++ b/packages/editor/src/components/post-revisions-preview/block-diff.js
@@ -670,6 +670,21 @@ function applyRichTextDiff( currentRichText, previousRichText ) {
 }
 
 /**
+ * Apply inline diff formatting to two HTML strings, for fields that are
+ * stored as HTML rather than as blocks, such as the post title.
+ *
+ * @param {string} currentHTML  Current revision's HTML.
+ * @param {string} previousHTML Previous revision's HTML.
+ * @return {RichTextData} Rich text with the diff marks applied.
+ */
+export function diffRevisionHTML( currentHTML, previousHTML ) {
+	return applyRichTextDiff(
+		RichTextData.fromHTMLString( currentHTML || '' ),
+		RichTextData.fromHTMLString( previousHTML || '' )
+	);
+}
+
+/**
  * Apply diffs to a modified block's attributes.
  * - Rich-text attributes: applies inline diff formatting (ins/del marks).
  * - Other attributes: computes word-level diffs for the sidebar panel.

--- a/packages/editor/src/components/post-revisions-preview/test/block-diff.jsdom.test.js
+++ b/packages/editor/src/components/post-revisions-preview/test/block-diff.jsdom.test.js
@@ -9,7 +9,7 @@ import {
 import { RichTextData } from '@wordpress/rich-text';
 import * as paragraphBlock from '@wordpress/block-library/build-module/paragraph/index.mjs';
 import * as groupBlock from '@wordpress/block-library/build-module/group/index.mjs';
-import { diffRevisionContent } from '../block-diff';
+import { diffRevisionContent, diffRevisionHTML } from '../block-diff';
 import {
 	registerDiffFormatTypes,
 	unregisterDiffFormatTypes,
@@ -1333,5 +1333,35 @@ describe( 'diffRevisionContent', () => {
 				},
 			] );
 		} );
+	} );
+} );
+
+describe( 'diffRevisionHTML', () => {
+	beforeAll( () => {
+		registerDiffFormatTypes();
+	} );
+
+	afterAll( () => {
+		unregisterDiffFormatTypes();
+	} );
+
+	it( 'marks the whole value as added when there is no previous value', () => {
+		expect( diffRevisionHTML( 'Hello world', '' ).toHTMLString() ).toBe(
+			'<ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">Hello world</ins>'
+		);
+	} );
+
+	it( 'leaves an unchanged value unmarked', () => {
+		expect(
+			diffRevisionHTML( 'Hello world', 'Hello world' ).toHTMLString()
+		).toBe( 'Hello world' );
+	} );
+
+	it( 'marks changed words', () => {
+		expect(
+			diffRevisionHTML( 'Hello everyone', 'Hello world' ).toHTMLString()
+		).toBe(
+			'Hello <del aria-describedby="revision-diff-removed-desc" class="revision-diff-removed">world</del><ins aria-describedby="revision-diff-added-desc" class="revision-diff-added">everyone</ins>'
+		);
 	} );
 } );

--- a/packages/editor/src/components/post-title/use-post-title.js
+++ b/packages/editor/src/components/post-title/use-post-title.js
@@ -1,19 +1,39 @@
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { useEntityProp } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+import { diffRevisionHTML } from '../post-revisions-preview/block-diff';
 
 /**
  * Custom hook for managing the post title in the editor.
  *
+ * In the revisions preview, `useEntityProp` already returns the revision's
+ * title. When changes are shown, it is returned with inline diff marks against
+ * the previous revision, matching how the revision's blocks are marked. The
+ * setter is a no-op there, so the title cannot be edited.
+ *
  * @return {Object} An object containing the current title and a function to update the title.
  */
 export default function usePostTitle() {
-	const { postType, postId } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
+	const { postType, postId, previousTitle } = useSelect( ( select ) => {
+		const {
+			getCurrentPostType,
+			getCurrentPostId,
+			isRevisionsMode,
+			isShowingRevisionDiff,
+			getPreviousRevision,
+		} = unlock( select( editorStore ) );
+		const isDiffing = isRevisionsMode() && isShowingRevisionDiff();
 
 		return {
 			postType: getCurrentPostType(),
 			postId: getCurrentPostId(),
+			// The oldest revision has nothing to compare against, so its whole
+			// title reads as added.
+			previousTitle: isDiffing
+				? getPreviousRevision()?.title?.raw ?? ''
+				: undefined,
 		};
 	}, [] );
 
@@ -24,5 +44,13 @@ export default function usePostTitle() {
 		postId
 	);
 
-	return { title, setTitle };
+	const value = useMemo(
+		() =>
+			previousTitle === undefined
+				? title
+				: diffRevisionHTML( title, previousTitle ),
+		[ title, previousTitle ]
+	);
+
+	return { title: value, setTitle };
 }


### PR DESCRIPTION
## What?
Follow-up to #82536.

Applies the revisions preview's inline diff marks to the post title.

## How?

`diffRevisionHTML()` in `block-diff.js` wraps the existing `applyRichTextDiff` for HTML strings instead of block rich-text attributes, so the title reuses the same `revision/diff-*` formats and canvas styles as blocks. `usePostTitle` compares against `getPreviousRevision()?.title?.raw` and returns the marked-up value.

The oldest revision has no previous revision, so its full title reads as "added," matching how its blocks are marked.

## Testing Instructions
1. Open a post, publish it.
2. Change the title and a paragraph, then update. Repeat once more.
3. Open the document sidebar and click the revisions button.
5. The title shows the removed words struck through and the added words highlighted, in the same colors as the paragraph below it.
6. Slide to the oldest revision. The whole title is marked as added.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/59fa08e1-bdd1-410f-89d2-b57815ff602b

## Use of AI Tools
Assisted by Claude.
