### PR TITLE
API Fetch: Rename defaultFetchHandler parameter to options

### DIFF
--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -89,11 +89,11 @@ function clearPreloadedData() {
  * The default fetch handler, using `window.fetch`. Exposed so it can be
  * restored after `setFetchHandler` overrides it.
  *
- * @param nextOptions The options for the fetch.
+ * @param options The options for the fetch.
  */
-const defaultFetchHandler: FetchHandler = ( nextOptions ) => {
-	const { url, path, data, parse = true, ...remainingOptions } = nextOptions;
-	let { body, headers } = nextOptions;
+const defaultFetchHandler: FetchHandler = ( options ) => {
+	const { url, path, data, parse = true, ...remainingOptions } = options;
+	let { body, headers } = options;
 
 	// Merge explicitly-provided headers with default values.
 	headers = { ...DEFAULT_HEADERS, ...headers };


### PR DESCRIPTION
## What?
A quick follow-up for https://github.com/WordPress/gutenberg/pull/82553/changes#r3955005878.

PR renames the `defaultFetchHandler` parameter from `nextOptions` to `options`.

## Testing Instructions
None.
