### PR TITLE
Dependency Extraction Webpack Plugin: Add global-styles-engine and global-styles-ui as bundled packages

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add `@wordpress/global-styles-engine` and `@wordpress/global-styles-ui` as bundled packages, so consumer builds bundle them instead of externalizing them to the nonexistent `wp-global-styles-engine` and `wp-global-styles-ui` scripts ([#82589](https://github.com/WordPress/gutenberg/pull/82589)).
+
 ## 6.54.0 (2026-08-26)
 
 ## 6.53.0 (2026-08-12)

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -4,6 +4,8 @@ const BUNDLED_PACKAGES = [
 	'@wordpress/dataviews',
 	'@wordpress/dataviews/wp',
 	'@wordpress/fields',
+	'@wordpress/global-styles-engine',
+	'@wordpress/global-styles-ui',
 	'@wordpress/grid',
 	'@wordpress/icons',
 	'@wordpress/interface',

--- a/packages/dependency-extraction-webpack-plugin/test/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/util.js
@@ -58,6 +58,15 @@ describe( 'defaultRequestToExternal', () => {
 			'ReactDOM'
 		);
 	} );
+
+	test( 'Does not externalize bundled @wordpress packages', () => {
+		expect(
+			defaultRequestToExternal( '@wordpress/global-styles-engine' )
+		).toBeUndefined();
+		expect(
+			defaultRequestToExternal( '@wordpress/global-styles-ui' )
+		).toBeUndefined();
+	} );
 } );
 
 describe( 'defaultRequestToHandle', () => {


### PR DESCRIPTION
## What?

Adds `@wordpress/global-styles-engine` and `@wordpress/global-styles-ui` to the `BUNDLED_PACKAGES` list in `@wordpress/dependency-extraction-webpack-plugin`, so consumer builds inline them instead of externalizing them.

## Why?

Neither package ships as a WordPress script (no `wpScript` in `package.json`, no `wp-global-styles-*` handle registered anywhere). The plugin's default `requestToExternal` still maps them to `wp.globalStylesEngine` / `wp.globalStylesUi`, which do not exist at runtime, so any `@wordpress/scripts` or custom webpack build that imports either package is broken by default.
Consumers such as the WooCommerce admin and MailPoet currently carry a `requestToExternal` override just to bundle `@wordpress/global-styles-engine`.

Gutenberg's own build is unaffected: `@wordpress/build` derives externals from `wpScript`, not from this list.

## How?

- Two entries added to `BUNDLED_PACKAGES` in `packages/dependency-extraction-webpack-plugin/lib/util.js`.
- A unit test asserting `defaultRequestToExternal()` returns `undefined` for both packages. Nothing covered the bundled list before.
- Changelog entry.

## Testing Instructions

1. `npm run test:unit:vitest -- packages/dependency-extraction-webpack-plugin` passes.
2. In a plugin built with `@wordpress/scripts`, add `import { compileCSS } from '@wordpress/global-styles-engine';` to an entry point and run `wp-scripts build`.
   - Before: the `*.asset.php` file lists `wp-global-styles-engine` as a dependency and the bundle references `wp.globalStylesEngine`, which is `undefined` in the browser.
   - After: the package is inlined into the bundle and the asset file does not list it.

### Testing Instructions for Keyboard

N/A, build tooling only.

## Use of AI Tools

Investigation, the change, and this description were drafted with Claude Code and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rpy4AzABNhdUCYbWCnCJuz
