### PR TITLE
Rich text: restore contenteditable on pointercancel

### DIFF
--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Export the `RichTextFormat` type, describing a single format applied to a range of characters within a `RichTextValue` ([#79486](https://github.com/WordPress/gutenberg/pull/79486)).
 
+### Bug Fixes
+
+-   Restore a rich text element's `contenteditable` attribute when a pointer interaction ends with `pointercancel`, so that swipe scrolling on touch devices no longer leaves text blocks uneditable ([#82598](https://github.com/WordPress/gutenberg/pull/82598)).
+
 ## 7.54.0 (2026-08-26)
 
 ## 7.53.0 (2026-08-12)

--- a/packages/rich-text/src/hook/event-listeners/prevent-focus-capture.js
+++ b/packages/rich-text/src/hook/event-listeners/prevent-focus-capture.js
@@ -49,9 +49,15 @@ export function preventFocusCapture() {
 			'pointerup',
 			onPointerUp
 		);
+		const unsubscribePointerCancel = subscribeDelegatedListener(
+			defaultView,
+			'pointercancel',
+			onPointerUp
+		);
 		return () => {
 			unsubscribePointerDown();
 			unsubscribePointerUp();
+			unsubscribePointerCancel();
 		};
 	};
 }


### PR DESCRIPTION
## What?

Restore a rich text element's `contenteditable` attribute when a pointer interaction ends with `pointercancel` rather than `pointerup`.

Attempts to address #72230 and #67986.

## Why?

`preventFocusCapture` sets `contenteditable` to `false` on `pointerdown` and restores it on `pointerup`, to avoid focus being captured when clicking around a flex parent.

On touch devices, a touch that turns into a scroll fires `pointercancel` instead of `pointerup`. The restore never runs, and the text block stays uneditable until the editor re-renders.

This was found and fixed downstream in GutenbergKit as a patch over the published package ([wordpress-mobile/GutenbergKit#135](https://github.com/wordpress-mobile/GutenbergKit/pull/135)); this ports it upstream so the patch can be dropped.

## How?

Subscribe to `pointercancel` with the same `onPointerUp` handler, and unsubscribe it alongside the others on cleanup.

## Testing Instructions

On a touch device (or a browser with touch emulation):

1. Open a post with a few text blocks.
2. Scroll by swiping along the edge of the display, outside the block canvas that contains the blocks.
3. Repeat the previous step at least once more.
4. Try to focus a text block and edit its content.

The block should be editable. Before this change, it was not.

### Accessibility Testing Instructions

N/A, no navigation changes.

## Screenshots or screencast

N/A, no visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iXbFmYveRx2xsN3G6WfML
