### PR TITLE
DataViews: Skip table columns for field ids without a field definition

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### Bug Fixes
 
+-   `DataViews` and `DataViewsPicker`: the `table` and `pickerTable` layouts no longer render an empty column for an id in `view.fields` that has no matching field definition, matching what the other layouts already did ([#82601](https://github.com/WordPress/gutenberg/pull/82601)).
 -   Fix `Field.sort` TypeScript type definition to reflect that `sort` receives extracted field values rather than `Item` objects ([#82162](https://github.com/WordPress/gutenberg/pull/82162)).
 -   DataForm: Render read-only fields without requiring an edit control ([#82514](https://github.com/WordPress/gutenberg/pull/82514)).
 -   Operators: Support the `isAny` and `isNone` filter operators for numeric field values, which previously matched nothing ([#77942](https://github.com/WordPress/gutenberg/pull/77942)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ### Bug Fixes
 
--   `DataViews` and `DataViewsPicker`: the `table` and `pickerTable` layouts no longer render an empty column for an id in `view.fields` that has no matching field definition, matching what the other layouts already did ([#82601](https://github.com/WordPress/gutenberg/pull/82601)).
+-   `DataViews` and `DataViewsPicker`: the `table` and `pickerTable` layouts no longer render an empty column for an id in `view.fields` that has no matching field definition, matching what the other layouts already did. The column header menu moves, inserts and hides columns relative to the rendered columns, so a skipped id no longer offsets those operations; such ids are dropped from `view.fields` the next time the menu changes the view ([#82601](https://github.com/WordPress/gutenberg/pull/82601)).
 -   Fix `Field.sort` TypeScript type definition to reflect that `sort` receives extracted field values rather than `Item` objects ([#82162](https://github.com/WordPress/gutenberg/pull/82162)).
 -   DataForm: Render read-only fields without requiring an edit control ([#82514](https://github.com/WordPress/gutenberg/pull/82514)).
 -   Operators: Support the `isAny` and `isNone` filter operators for numeric field values, which previously matched nothing ([#77942](https://github.com/WordPress/gutenberg/pull/77942)).

--- a/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/picker-table/index.tsx
@@ -22,6 +22,7 @@ import type { SetSelection } from '../../../types/private';
 import ColumnHeaderMenu from '../table/column-header-menu';
 import ColumnPrimary from '../table/column-primary';
 import getDataByGroup from '../utils/get-data-by-group';
+import getTableColumns from '../utils/get-table-columns';
 import useSelectionProps from '../utils/use-selection-props';
 import type { SelectionProps } from '../utils/use-selection-props';
 import { useIntersectionObserver } from '../utils/use-infinite-scroll';
@@ -107,7 +108,7 @@ function TableRow< Item >( {
 		setIsHovered( false );
 	};
 
-	const columns = view.fields ?? [];
+	const columns = getTableColumns( view, fields );
 	const hasPrimaryColumn =
 		( titleField && showTitle ) ||
 		( mediaField && showMedia ) ||
@@ -297,7 +298,7 @@ function ViewPickerTable< Item >( {
 		( titleField && showTitle ) ||
 		( mediaField && showMedia ) ||
 		( descriptionField && showDescription );
-	const columns = view.fields ?? [];
+	const columns = getTableColumns( view, fields );
 	const headerMenuRef =
 		( column: string, index: number ) => ( node: HTMLButtonElement ) => {
 			if ( node ) {

--- a/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/column-header-menu.tsx
@@ -15,6 +15,7 @@ import type {
 } from '../../../types';
 import DataViewsContext from '../../dataviews-context';
 import getHideableFields from '../../../utils/get-hideable-fields';
+import getTableColumns from '../utils/get-table-columns';
 
 interface HeaderMenuProps< Item > {
 	fieldId: string;
@@ -53,8 +54,6 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	}: HeaderMenuProps< Item >,
 	ref: Ref< HTMLButtonElement >
 ) {
-	const visibleFieldIds = view.fields ?? [];
-	const index = visibleFieldIds?.indexOf( fieldId ) as number;
 	const isSorted = view.sort?.field === fieldId;
 	let isHidable = false;
 	let isSortable = false;
@@ -91,6 +90,11 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		return header;
 	}
 
+	// Operate on the rendered columns rather than the raw `view.fields`, so an
+	// id without a field definition (which the table skips) can't offset the
+	// indexes that move and insert rely on.
+	const visibleFieldIds = getTableColumns( view, fields );
+	const index = visibleFieldIds.indexOf( fieldId );
 	const hiddenFields = getHideableFields( view, fields ).filter(
 		( f ) => ! visibleFieldIds.includes( f.id )
 	);

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -32,6 +32,7 @@ import ColumnHeaderMenu from './column-header-menu';
 import ColumnPrimary from './column-primary';
 import { useScrollState } from './use-scroll-state';
 import getDataByGroup from '../utils/get-data-by-group';
+import getTableColumns from '../utils/get-table-columns';
 import useSelectionProps from '../utils/use-selection-props';
 import { PropertiesSection } from '../../dataviews-view-config/properties-section';
 import { useDelayedLoading } from '../../../hooks/use-delayed-loading';
@@ -140,7 +141,7 @@ function TableRow< Item >( {
 		showDescription = true,
 		infiniteScrollEnabled,
 	} = view;
-	const columns = view.fields ?? [];
+	const columns = getTableColumns( view, fields );
 	const hasPrimaryColumn =
 		( titleField && showTitle ) ||
 		( mediaField && showMedia ) ||
@@ -369,7 +370,7 @@ function ViewTable< Item >( {
 		( titleField && showTitle ) ||
 		( mediaField && showMedia ) ||
 		( descriptionField && showDescription );
-	const columns = view.fields ?? [];
+	const columns = getTableColumns( view, fields );
 	const headerMenuRef =
 		( column: string, index: number ) => ( node: HTMLButtonElement ) => {
 			if ( node ) {

--- a/packages/dataviews/src/components/dataviews-layouts/utils/get-table-columns.ts
+++ b/packages/dataviews/src/components/dataviews-layouts/utils/get-table-columns.ts
@@ -1,0 +1,21 @@
+import type { NormalizedField, View } from '../../../types';
+
+/**
+ * Returns the ids in `view.fields` that have a field definition, in view
+ * order. The table layouts render one column per id, so an id with no
+ * definition (a stale persisted view, or a server-provided default that
+ * names a field the consumer never registered) would otherwise produce an
+ * empty column with no header, no cells and no menu.
+ *
+ * @param view   The view.
+ * @param fields The normalized fields.
+ * @return The ids of the columns to render.
+ */
+export default function getTableColumns< Item >(
+	view: View,
+	fields: NormalizedField< Item >[]
+): string[] {
+	return ( view.fields ?? [] ).filter( ( fieldId ) =>
+		fields.some( ( field ) => field.id === fieldId )
+	);
+}

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.jsdom.test.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.jsdom.test.tsx
@@ -677,6 +677,35 @@ describe( 'DataViews Picker', () => {
 		} );
 	} );
 
+	describe( 'Table layout', () => {
+		it( 'does not render a column for a field id without a field definition', () => {
+			const { container } = render(
+				<Picker
+					layout={ LAYOUT_PICKER_TABLE }
+					fields={ [
+						{ id: 'title', label: 'Title' },
+						{ id: 'order', label: 'Order' },
+					] }
+					view={ { fields: [ 'order', 'missing' ] } }
+				/>
+			);
+
+			// The picker table marks its rows and cells as presentational, so
+			// they have no queryable role.
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+			const headers = container.querySelectorAll( 'thead th' );
+			// The checkbox column, the primary (title) column and the order
+			// column.
+			expect( headers ).toHaveLength( 3 );
+			expect( headers[ 2 ] ).toHaveTextContent( 'Order' );
+
+			for ( const option of screen.getAllByRole( 'option' ) ) {
+				// eslint-disable-next-line testing-library/no-node-access
+				expect( option.querySelectorAll( 'td' ) ).toHaveLength( 3 );
+			}
+		} );
+	} );
+
 	describe( 'Default layouts', () => {
 		/**
 		 * A minimal Picker that intentionally omits the `defaultLayouts` prop so

--- a/packages/dataviews/src/dataviews-picker/test/dataviews-picker.jsdom.test.tsx
+++ b/packages/dataviews/src/dataviews-picker/test/dataviews-picker.jsdom.test.tsx
@@ -704,6 +704,28 @@ describe( 'DataViews Picker', () => {
 				expect( option.querySelectorAll( 'td' ) ).toHaveLength( 3 );
 			}
 		} );
+
+		it( 'disables moving right for the last column when a field id without a field definition follows it', async () => {
+			const user = userEvent.setup();
+			render(
+				<Picker
+					layout={ LAYOUT_PICKER_TABLE }
+					fields={ [
+						{ id: 'title', label: 'Title' },
+						{ id: 'order', label: 'Order' },
+					] }
+					view={ { fields: [ 'order', 'missing' ] } }
+				/>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Order' } ) );
+
+			// `order` is the last rendered column, so it can't move right even
+			// though a skipped id follows it in `view.fields`.
+			expect(
+				await screen.findByRole( 'menuitem', { name: 'Move right' } )
+			).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
 	} );
 
 	describe( 'Default layouts', () => {

--- a/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
@@ -425,6 +425,32 @@ describe( 'DataViews component', () => {
 			}
 		} );
 
+		it( 'should move a column past a field id without a field definition', async () => {
+			const user = userEvent.setup();
+			const onChangeView = vi.fn();
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'title', 'missing', 'order' ],
+					} }
+					onChangeView={ onChangeView }
+				/>
+			);
+
+			await user.click( screen.getByRole( 'button', { name: 'Title' } ) );
+			await user.click(
+				await screen.findByRole( 'menuitem', { name: 'Move right' } )
+			);
+
+			// The move is computed against the rendered columns, so the
+			// title lands after the order column rather than swapping places
+			// with the skipped id, which is dropped from the view.
+			expect( onChangeView ).toHaveBeenCalledWith(
+				expect.objectContaining( { fields: [ 'order', 'title' ] } )
+			);
+		} );
+
 		it( 'should display title column if defined using titleField', () => {
 			render(
 				<DataViewWrapper

--- a/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMemo, useState } from '@wordpress/element';
@@ -387,6 +393,35 @@ describe( 'DataViews component', () => {
 				expect(
 					screen.getAllByText( item.title )[ 0 ]
 				).toBeInTheDocument();
+			}
+		} );
+
+		it( 'should not render a column for a field id without a field definition', () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'title', 'missing', 'order' ],
+					} }
+				/>
+			);
+
+			const headers = screen.getAllByRole( 'columnheader' );
+			expect( headers ).toHaveLength( 2 );
+			expect(
+				within( headers[ 0 ] ).getByRole( 'button', { name: 'Title' } )
+			).toBeInTheDocument();
+			expect(
+				within( headers[ 1 ] ).getByRole( 'button', { name: 'Order' } )
+			).toBeInTheDocument();
+
+			// The header row plus one row per item.
+			const rows = screen.getAllByRole( 'row' );
+			expect( rows ).toHaveLength( data.length + 1 );
+			for ( const row of rows.slice( 1 ) ) {
+				expect( within( row ).getAllByRole( 'cell' ) ).toHaveLength(
+					2
+				);
 			}
 		} );
 


### PR DESCRIPTION
## What?

Makes the `table` and `pickerTable` layouts of DataViews skip the ids in `view.fields` that have no matching field definition, instead of rendering an empty column for them.

Found while reviewing #82456: the `wp_template` view config served by `GET /wp/v2/view-config` lists `active`, `slug` and `theme` in `default_view.fields`, but neither site editor registers fields with those ids.

## Why?

Every id in `view.fields` produced a `<col>`, a `<th>` and a `<td>` per row even when no field with that id existed. The cells stayed empty, because the column component bails out without a field, but each phantom column still took up its padding width, got counted in the grouped-rows `colSpan`, and shipped an empty header. The grid, picker grid and list layouts already drop those ids, so the table layouts were the odd ones out.

A view can reference an unknown id legitimately: a persisted view that outlives a field the consumer removed, or a server-provided default that names a field the screen never registered. Both are the consumer's data, so DataViews should tolerate them rather than render broken columns.

## How?

- Adds a `getTableColumns( view, fields )` helper under `dataviews-layouts/utils` that returns the ids in `view.fields` with a field definition, in view order.
- The `table` and `pickerTable` layouts use it wherever they read `view.fields`, for both the header row and the item rows, so the column count and the `colSpan` stay in sync.
- Adds a test per layout that renders a view with an unknown id and checks that no header or cell is rendered for it.

## Testing Instructions

1. Open the Storybook for DataViews (`npm run storybook:dev`) or any DataViews table in the app.
2. In the site editor v1 (or in #82456 for v2), go to **Templates** and switch to the table layout. On trunk, DevTools shows three empty `<th>` elements between the **Author** and **Actions** headers, matching `dataviews-view-table__col-active`, `-slug` and `-theme` in the `<colgroup>`. With this PR, those columns are gone.
3. Run the unit tests:

```
npm run test:unit:vitest -- packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx packages/dataviews/src/dataviews-picker/test/dataviews-picker.jsdom.test.tsx
```

### Testing Instructions for Keyboard

Tab through the table header of a DataViews table whose view references an unknown field id. Focus should move from the last real column header straight to the next control, with no empty stop in between.

## Use of AI Tools

Written with Claude Code, reviewed and tested by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
