### PR TITLE
View config: remove stale fields from the wp_template default view

### DIFF
--- a/backport-changelog/7.2/13443.md
+++ b/backport-changelog/7.2/13443.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13443
+
+* https://github.com/WordPress/gutenberg/pull/82602

--- a/lib/compat/wordpress-7.2/view-config-api.php
+++ b/lib/compat/wordpress-7.2/view-config-api.php
@@ -66,6 +66,27 @@ function _gutenberg_add_reading_settings_to_wp_template_view_config( $data ) {
 }
 
 /**
+ * Removes the `active`, `slug`, and `theme` fields from the `wp_template`
+ * default view.
+ *
+ * They were rendered by the template activation experiment, which has been
+ * removed. No field with those ids is registered for templates anymore.
+ *
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
+ */
+function _gutenberg_remove_stale_fields_from_wp_template_view_config( $data ) {
+	return $data->remove(
+		array(
+			'default_view' => array(
+				'fields' => array( 'active', 'slug', 'theme' ),
+			),
+		),
+		1
+	);
+}
+
+/**
  * Provides the view configuration for the `wp_navigation` post type.
  *
  * Core has no callback for this post type, so this is a base definition
@@ -192,6 +213,12 @@ function gutenberg_register_entity_view_config_filters_7_2() {
 	add_filter(
 		gutenberg_get_entity_view_config_hook_name( 'postType', 'wp_template' ),
 		'_gutenberg_add_reading_settings_to_wp_template_view_config',
+		6,
+		1
+	);
+	add_filter(
+		gutenberg_get_entity_view_config_hook_name( 'postType', 'wp_template' ),
+		'_gutenberg_remove_stale_fields_from_wp_template_view_config',
 		6,
 		1
 	);


### PR DESCRIPTION
## What?

Follow up to #82241.
Found while reviewing #82456.

Removes the `active`, `slug`, and `theme` fields from the default view of the `wp_template` entity in the view config API.

Core backport: https://github.com/WordPress/wordpress-develop/pull/13443

## Why?

Those three fields were rendered by the template activation experiment. #82241 removed the experiment and deleted the field definitions on the JavaScript side, but the server-side view config still lists them. No field with those ids is registered for templates anymore, so the entries do nothing. DataViews silently drops unknown ids from `view.fields`, which is why nothing broke, but the config should describe fields that exist.

## How?

The base `wp_template` configuration lives in `lib/compat/wordpress-7.1/view-config-api.php` and mirrors what already shipped in WordPress 7.1, so it is left untouched. Instead, `lib/compat/wordpress-7.2/view-config-api.php` registers a new callback on the `wp_template` hook that calls `remove()` on the three field ids, layered at the same priority as the existing reading settings addition. The result is a default view whose `fields` list is `author`, which is the one remaining registered field for templates and matches the default view of the extensible site editor route.

## Testing Instructions

1. Open the site editor and go to Templates.
2. Reset the view to its default if you had customized it, then switch to the table layout.
3. Confirm the columns are the same as on trunk: title, description, and author. There should be no change in behavior.
4. Optionally, request `/wp-json/wp/v2/view-config/postType/wp_template` and confirm `default_view.fields` is `["author"]`.

### Testing Instructions for Keyboard

Not applicable. This change does not alter the UI.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Claude Code was used to trace the history of the fields and to draft this PR. The change and description were reviewed by me.
