### PR TITLE
Add/block width constraint notice

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   `BlockAlignmentControl`: List Wide and Full width as unavailable when the parent layout withholds them, instead of removing them from the menu without explanation. Blocks whose only alignments are wide and full, such as Group and Columns, now keep an alignment control in layouts that offer neither ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   `BlockAlignmentControl`: List Wide and Full width as unavailable when the parent layout withholds them, instead of removing them from the menu without explanation. Blocks whose only alignments are wide and full, such as Group and Columns, now keep an alignment control in layouts that offer neither ([#82600](https://github.com/WordPress/gutenberg/pull/82600)).
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `ListView`: Updated to use `outset-ring__focus()` mixin for focus outline wherever applicable instead of the previous box-shadow implementation. ([#82129](https://github.com/WordPress/gutenberg/pull/82129))
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Enhancements
 
+-   `BlockAlignmentControl`: List Wide and Full width as unavailable when the parent layout withholds them, instead of removing them from the menu without explanation. Blocks whose only alignments are wide and full, such as Group and Columns, now keep an alignment control in layouts that offer neither ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `ListView`: Updated to use `outset-ring__focus()` mixin for focus outline wherever applicable instead of the previous box-shadow implementation. ([#82129](https://github.com/WordPress/gutenberg/pull/82129))
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   `BlockAlignmentControl`: List Wide and Full width as unavailable when a parent layout withholds them but the theme itself offers them, instead of removing them from the menu without explanation. A theme that offers neither keeps them hidden, since it is curating its own options. Blocks whose only alignments are wide and full, such as Group and Columns, now keep an alignment control in layouts that offer neither ([#82600](https://github.com/WordPress/gutenberg/pull/82600)).
+-   Block alignment: Name the containing block whose layout withholds wide and full alignments in the alignment menu itself, and offer to select it so the setting can be changed where it lives ([#82607](https://github.com/WordPress/gutenberg/pull/82607)).
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `ListView`: Updated to use `outset-ring__focus()` mixin for focus outline wherever applicable instead of the previous box-shadow implementation. ([#82129](https://github.com/WordPress/gutenberg/pull/82129))
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
--   `BlockAlignmentControl`: List Wide and Full width as unavailable when the parent layout withholds them, instead of removing them from the menu without explanation. Blocks whose only alignments are wide and full, such as Group and Columns, now keep an alignment control in layouts that offer neither ([#82600](https://github.com/WordPress/gutenberg/pull/82600)).
+-   `BlockAlignmentControl`: List Wide and Full width as unavailable when a parent layout withholds them but the theme itself offers them, instead of removing them from the menu without explanation. A theme that offers neither keeps them hidden, since it is curating its own options. Blocks whose only alignments are wide and full, such as Group and Columns, now keep an alignment control in layouts that offer neither ([#82600](https://github.com/WordPress/gutenberg/pull/82600)).
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `ListView`: Updated to use `outset-ring__focus()` mixin for focus outline wherever applicable instead of the previous box-shadow implementation. ([#82129](https://github.com/WordPress/gutenberg/pull/82129))
 

--- a/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
@@ -382,3 +382,69 @@ describe( 'BlockAlignmentUI on a theme without layout support', () => {
 		] );
 	} );
 } );
+
+describe( 'BlockAlignmentUI constraint', () => {
+	const controls = [ 'left', 'center', 'right', 'wide', 'full' ];
+	const onChange = vi.fn();
+	const onSelect = vi.fn();
+	const constraint = {
+		description: 'It limits this block\u2019s width.',
+		action: { label: 'Select Group', onClick: onSelect },
+	};
+
+	afterEach( () => {
+		onChange.mockClear();
+		onSelect.mockClear();
+	} );
+
+	async function openMenu() {
+		const user = userEvent.setup();
+		renderWithTheme(
+			<BlockAlignmentUI
+				onChange={ onChange }
+				controls={ controls }
+				constraint={ constraint }
+			/>
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Align block' } )
+		);
+		return user;
+	}
+
+	test( 'explains the constraint as the action description', async () => {
+		await openMenu();
+
+		// Hung off the item rather than a group heading, so it reads as one
+		// thing with the action that resolves it.
+		expect(
+			screen.getByRole( 'menuitem', {
+				name: `Select Group ${ constraint.description }`,
+			} )
+		).toBeInTheDocument();
+	} );
+
+	test( 'offers the action as a command, not an alignment choice', async () => {
+		await openMenu();
+
+		// `menuitem`, not `menuitemradio`, so it is not announced as an
+		// alignment option alongside the real ones.
+		expect(
+			screen.getByRole( 'menuitem', { name: /Select Group/ } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'menuitemradio', { name: /Select Group/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'runs the action without changing the alignment', async () => {
+		const user = await openMenu();
+
+		await user.click(
+			screen.getByRole( 'menuitem', { name: /Select Group/ } )
+		);
+
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import BlockAlignmentUI from '../ui';
+import { LayoutProvider } from '../../block-list/layout';
 
 describe( 'BlockAlignmentUI', () => {
 	const alignment = 'left';
@@ -113,5 +114,140 @@ describe( 'BlockAlignmentUI', () => {
 
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
 		expect( onChange ).toHaveBeenCalledWith( 'center' );
+	} );
+} );
+
+describe( 'BlockAlignmentUI unavailable alignments', () => {
+	// The block supports every alignment; the default flow layout offers only
+	// none/left/center/right, so wide and full are taken away by the parent.
+	const controls = [ 'left', 'center', 'right', 'wide', 'full' ];
+	const onChange = vi.fn();
+
+	afterEach( () => {
+		onChange.mockClear();
+	} );
+
+	async function openMenu() {
+		const user = userEvent.setup();
+		render(
+			<BlockAlignmentUI onChange={ onChange } controls={ controls } />
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Align block' } )
+		);
+		return user;
+	}
+
+	test( 'lists them rather than omitting them, in their usual position', async () => {
+		await openMenu();
+
+		expect(
+			screen
+				.getAllByRole( 'menuitemradio' )
+				.map( ( item ) => item.textContent )
+		).toEqual( [
+			'None',
+			'Wide widthNot available',
+			'Full widthNot available',
+			'Align left',
+			'Align center',
+			'Align right',
+		] );
+	} );
+
+	test( 'marks them as disabled while keeping them reachable', async () => {
+		await openMenu();
+
+		const wide = screen.getByRole( 'menuitemradio', {
+			name: /Wide width/,
+		} );
+
+		expect( wide ).toHaveAttribute( 'aria-disabled', 'true' );
+		// `disabled` would remove it from the accessibility tree entirely,
+		// taking the explanation with it.
+		expect( wide ).toBeEnabled();
+	} );
+
+	test( 'does not change the alignment when one is chosen', async () => {
+		const user = await openMenu();
+
+		await user.click(
+			screen.getByRole( 'menuitemradio', { name: /Full width/ } )
+		);
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
+	test( 'leaves the menu alone when the layout offers every alignment', async () => {
+		const user = userEvent.setup();
+		render(
+			<LayoutProvider
+				value={ {
+					type: 'constrained',
+					contentSize: '600px',
+					wideSize: '1200px',
+				} }
+			>
+				<BlockAlignmentUI onChange={ onChange } controls={ controls } />
+			</LayoutProvider>
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Align block' } )
+		);
+
+		expect( screen.queryAllByText( 'Not available' ) ).toHaveLength( 0 );
+		expect(
+			screen
+				.getAllByRole( 'menuitemradio' )
+				.map( ( item ) => item.textContent )
+		).toEqual( [
+			'NoneMax 600px wide',
+			'Wide widthMax 1200px wide',
+			'Full width',
+			'Align left',
+			'Align center',
+			'Align right',
+		] );
+	} );
+} );
+
+describe( 'BlockAlignmentUI with no available alignments', () => {
+	// Group supports only wide and full, so a flow layout leaves it nothing.
+	const controls = [ 'wide', 'full' ];
+	const onChange = vi.fn();
+
+	afterEach( () => {
+		onChange.mockClear();
+	} );
+
+	test( 'still offers None alongside what the layout withholds', async () => {
+		const user = userEvent.setup();
+		render(
+			<BlockAlignmentUI onChange={ onChange } controls={ controls } />
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Align block' } )
+		);
+
+		expect(
+			screen
+				.getAllByRole( 'menuitemradio' )
+				.map( ( item ) => item.textContent )
+		).toEqual( [
+			'None',
+			'Wide widthNot available',
+			'Full widthNot available',
+		] );
+	} );
+
+	test( 'renders nothing when the layout places children itself', () => {
+		const { container } = render(
+			<LayoutProvider value={ { type: 'flex' } }>
+				<BlockAlignmentUI onChange={ onChange } controls={ controls } />
+			</LayoutProvider>
+		);
+
+		expect( container ).toBeEmptyDOMElement();
 	} );
 } );

--- a/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
@@ -388,7 +388,7 @@ describe( 'BlockAlignmentUI constraint', () => {
 	const onChange = vi.fn();
 	const onSelect = vi.fn();
 	const constraint = {
-		description: 'It limits this block\u2019s width.',
+		description: 'Its layout limits widths',
 		action: { label: 'Select Group', onClick: onSelect },
 	};
 

--- a/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
@@ -124,11 +124,11 @@ describe( 'BlockAlignmentUI', () => {
  */
 const THEME_LAYOUT = { contentSize: '600px', wideSize: '1200px' };
 
-function renderWithTheme( ui, layout = THEME_LAYOUT ) {
+function renderWithTheme( ui, layout = THEME_LAYOUT, settings = {} ) {
 	return render(
 		<BlockEditorProvider
 			value={ [] }
-			settings={ { __experimentalFeatures: { layout } } }
+			settings={ { __experimentalFeatures: { layout }, ...settings } }
 		>
 			{ ui }
 		</BlockEditorProvider>
@@ -321,6 +321,61 @@ describe( 'BlockAlignmentUI when the theme withholds alignments', () => {
 		expect( menuItems() ).toEqual( [
 			'None',
 			'Full widthNot available',
+			'Align left',
+			'Align center',
+			'Align right',
+		] );
+	} );
+} );
+
+describe( 'BlockAlignmentUI on a theme without layout support', () => {
+	// Classic themes opt into wide alignments with `add_theme_support`, which
+	// arrives as the `alignWide` setting. There is no layout to withhold
+	// anything, so the menu either offers wide and full or leaves them out.
+	const controls = [ 'left', 'center', 'right', 'wide', 'full' ];
+	const onChange = vi.fn();
+
+	afterEach( () => {
+		onChange.mockClear();
+	} );
+
+	async function openMenuWithAlignWide( alignWide ) {
+		const user = userEvent.setup();
+		renderWithTheme(
+			<BlockAlignmentUI onChange={ onChange } controls={ controls } />,
+			undefined,
+			{ supportsLayout: false, alignWide }
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Align block' } )
+		);
+	}
+
+	function menuItems() {
+		return screen
+			.getAllByRole( 'menuitemradio' )
+			.map( ( item ) => item.textContent );
+	}
+
+	test( 'offers both when the theme supports wide alignments', async () => {
+		await openMenuWithAlignWide( true );
+
+		expect( screen.queryAllByText( 'Not available' ) ).toHaveLength( 0 );
+		expect( menuItems() ).toEqual( [
+			'None',
+			'Align left',
+			'Align center',
+			'Align right',
+			'Wide width',
+			'Full width',
+		] );
+	} );
+
+	test( 'hides both when the theme does not support wide alignments', async () => {
+		await openMenuWithAlignWide( false );
+
+		expect( menuItems() ).toEqual( [
+			'None',
 			'Align left',
 			'Align center',
 			'Align right',

--- a/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/test/index.jsdom.test.jsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import BlockAlignmentUI from '../ui';
 import { LayoutProvider } from '../../block-list/layout';
+import { BlockEditorProvider } from '../../provider';
 
 describe( 'BlockAlignmentUI', () => {
 	const alignment = 'left';
@@ -117,6 +118,23 @@ describe( 'BlockAlignmentUI', () => {
 	} );
 } );
 
+/**
+ * A theme offering both wide and full. Without one, those alignments were never
+ * on the table and are not reported as withheld.
+ */
+const THEME_LAYOUT = { contentSize: '600px', wideSize: '1200px' };
+
+function renderWithTheme( ui, layout = THEME_LAYOUT ) {
+	return render(
+		<BlockEditorProvider
+			value={ [] }
+			settings={ { __experimentalFeatures: { layout } } }
+		>
+			{ ui }
+		</BlockEditorProvider>
+	);
+}
+
 describe( 'BlockAlignmentUI unavailable alignments', () => {
 	// The block supports every alignment; the default flow layout offers only
 	// none/left/center/right, so wide and full are taken away by the parent.
@@ -129,7 +147,7 @@ describe( 'BlockAlignmentUI unavailable alignments', () => {
 
 	async function openMenu() {
 		const user = userEvent.setup();
-		render(
+		renderWithTheme(
 			<BlockAlignmentUI onChange={ onChange } controls={ controls } />
 		);
 		await user.click(
@@ -180,7 +198,7 @@ describe( 'BlockAlignmentUI unavailable alignments', () => {
 
 	test( 'leaves the menu alone when the layout offers every alignment', async () => {
 		const user = userEvent.setup();
-		render(
+		renderWithTheme(
 			<LayoutProvider
 				value={ {
 					type: 'constrained',
@@ -222,7 +240,7 @@ describe( 'BlockAlignmentUI with no available alignments', () => {
 
 	test( 'still offers None alongside what the layout withholds', async () => {
 		const user = userEvent.setup();
-		render(
+		renderWithTheme(
 			<BlockAlignmentUI onChange={ onChange } controls={ controls } />
 		);
 
@@ -242,12 +260,70 @@ describe( 'BlockAlignmentUI with no available alignments', () => {
 	} );
 
 	test( 'renders nothing when the layout places children itself', () => {
-		const { container } = render(
+		const { container } = renderWithTheme(
 			<LayoutProvider value={ { type: 'flex' } }>
 				<BlockAlignmentUI onChange={ onChange } controls={ controls } />
 			</LayoutProvider>
 		);
 
 		expect( container ).toBeEmptyDOMElement();
+	} );
+} );
+
+describe( 'BlockAlignmentUI when the theme withholds alignments', () => {
+	// A theme offering neither is curating its own options globally, so those
+	// alignments stay hidden rather than being reported as unavailable.
+	const controls = [ 'left', 'center', 'right', 'wide', 'full' ];
+	const onChange = vi.fn();
+
+	afterEach( () => {
+		onChange.mockClear();
+	} );
+
+	async function openMenuForTheme( layout ) {
+		const user = userEvent.setup();
+		renderWithTheme(
+			<BlockAlignmentUI onChange={ onChange } controls={ controls } />,
+			layout
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Align block' } )
+		);
+	}
+
+	function menuItems() {
+		return screen
+			.getAllByRole( 'menuitemradio' )
+			.map( ( item ) => item.textContent );
+	}
+
+	test( 'hides both when the theme sets no layout at all', async () => {
+		// No provider at all, so the store holds no global layout.
+		const user = userEvent.setup();
+		render(
+			<BlockAlignmentUI onChange={ onChange } controls={ controls } />
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Align block' } )
+		);
+
+		expect( menuItems() ).toEqual( [
+			'None',
+			'Align left',
+			'Align center',
+			'Align right',
+		] );
+	} );
+
+	test( 'hides Wide when the theme sets no wide size', async () => {
+		await openMenuForTheme( { contentSize: '600px' } );
+
+		expect( menuItems() ).toEqual( [
+			'None',
+			'Full widthNot available',
+			'Align left',
+			'Align center',
+			'Align right',
+		] );
 	} );
 } );

--- a/packages/block-editor/src/components/block-alignment-control/ui.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/ui.jsx
@@ -6,7 +6,7 @@ import {
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
-import useAvailableAlignments from './use-available-alignments';
+import { useAlignmentMenu } from './use-available-alignments';
 import { BLOCK_ALIGNMENTS_CONTROLS, DEFAULT_CONTROL } from './constants';
 
 function BlockAlignmentUI( {
@@ -18,12 +18,38 @@ function BlockAlignmentUI( {
 	label = __( 'Align block' ),
 	description,
 } ) {
-	const enabledControls = useAvailableAlignments( controls );
-	const hasEnabledControls = !! enabledControls.length;
+	/*
+	 * Wide and Full are the alignments users look for and fail to find. When a
+	 * parent layout does not offer them they disappear from this menu with no
+	 * explanation, which reads as the editor losing the setting. List them as
+	 * unavailable instead, so the menu says why it cannot do what was asked.
+	 */
+	const { enabled: enabledControls, unavailable: unavailableControls } =
+		useAlignmentMenu( controls );
 
-	if ( ! hasEnabledControls ) {
+	if ( ! enabledControls.length && ! unavailableControls.length ) {
 		return null;
 	}
+
+	/*
+	 * A block whose alignments are all unavailable still needs somewhere to
+	 * anchor them, and `None` is always a valid choice for it.
+	 */
+	const menuControls = enabledControls.length
+		? [ ...enabledControls ]
+		: [ { name: 'none' } ];
+	const enabledNames = menuControls.map( ( { name } ) => name );
+
+	// Unavailable alignments sit where they would have sat had they been
+	// offered, which is directly after `none`.
+	menuControls.splice(
+		enabledNames.indexOf( 'none' ) + 1,
+		0,
+		...unavailableControls.map( ( name ) => ( {
+			name,
+			isUnavailable: true,
+		} ) )
+	);
 
 	function onChangeAlignment( align ) {
 		onChange( [ value, 'none' ].includes( align ) ? undefined : align );
@@ -60,13 +86,20 @@ function BlockAlignmentUI( {
 					return (
 						<>
 							<MenuGroup className="block-editor-block-alignment-control__menu-group">
-								{ enabledControls.map(
-									( { name: controlName, info } ) => {
+								{ menuControls.map(
+									( {
+										name: controlName,
+										info,
+										isUnavailable,
+									} ) => {
 										const { icon, title } =
 											BLOCK_ALIGNMENTS_CONTROLS[
 												controlName
 											];
 										// If no value is provided, mark as selected the `none` option.
+										// An unavailable alignment can still be the saved value, and
+										// showing it as selected is how the menu says the setting
+										// exists but has no effect in this position.
 										const isSelected =
 											controlName === value ||
 											( ! value &&
@@ -83,6 +116,7 @@ function BlockAlignmentUI( {
 													}
 												) }
 												isSelected={ isSelected }
+												disabled={ isUnavailable }
 												onClick={ () => {
 													onChangeAlignment(
 														controlName
@@ -90,7 +124,11 @@ function BlockAlignmentUI( {
 													onClose();
 												} }
 												role="menuitemradio"
-												info={ info }
+												info={
+													isUnavailable
+														? __( 'Not available' )
+														: info
+												}
 											>
 												{ title }
 											</MenuItem>

--- a/packages/block-editor/src/components/block-alignment-control/ui.jsx
+++ b/packages/block-editor/src/components/block-alignment-control/ui.jsx
@@ -6,6 +6,7 @@ import {
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
+import BlockIcon from '../block-icon';
 import { useAlignmentMenu } from './use-available-alignments';
 import { BLOCK_ALIGNMENTS_CONTROLS, DEFAULT_CONTROL } from './constants';
 
@@ -17,6 +18,7 @@ function BlockAlignmentUI( {
 	isCollapsed = true,
 	label = __( 'Align block' ),
 	description,
+	constraint,
 } ) {
 	/*
 	 * Wide and Full are the alignments users look for and fail to find. When a
@@ -136,6 +138,33 @@ function BlockAlignmentUI( {
 									}
 								) }
 							</MenuGroup>
+							{ /*
+							 * The explanation is the action's description rather
+							 * than a group heading: headings here are one or two
+							 * words, and hanging it off the item keeps it tied to
+							 * the thing that resolves it. The separate group is
+							 * what stops the action being announced as another
+							 * alignment choice.
+							 */ }
+							{ !! constraint && (
+								<MenuGroup>
+									<MenuItem
+										icon={
+											<BlockIcon
+												icon={ constraint.action.icon }
+											/>
+										}
+										iconPosition="left"
+										info={ constraint.description }
+										onClick={ () => {
+											constraint.action.onClick();
+											onClose();
+										} }
+									>
+										{ constraint.action.label }
+									</MenuItem>
+								</MenuGroup>
+							) }
 						</>
 					);
 				},

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -1,5 +1,7 @@
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 import { useLayout } from '../block-list/layout';
+import { useSettings } from '../use-settings';
 import { store as blockEditorStore } from '../../store';
 import { getLayoutType } from '../../layouts';
 
@@ -7,7 +9,10 @@ const EMPTY_ARRAY = [];
 const DEFAULT_CONTROLS = [ 'none', 'left', 'center', 'right', 'wide', 'full' ];
 const WIDE_CONTROLS = [ 'wide', 'full' ];
 
-export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
+export default function useAvailableAlignments(
+	controls = DEFAULT_CONTROLS,
+	layoutOverride
+) {
 	// Always add the `none` option if not exists.
 	if ( ! controls.includes( 'none' ) ) {
 		controls = [ 'none', ...controls ];
@@ -34,7 +39,8 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 			},
 			[ isNoneOnly ]
 		);
-	const layout = useLayout();
+	const parentLayout = useLayout();
+	const layout = layoutOverride ?? parentLayout;
 
 	if ( isNoneOnly ) {
 		return EMPTY_ARRAY;
@@ -104,15 +110,33 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
  * @return {{enabled: Object[], unavailable: string[]}} The split alignments.
  */
 export function useAlignmentMenu( controls = DEFAULT_CONTROLS ) {
+	const [ globalLayout ] = useSettings( 'layout' );
+
 	const enabled = useAvailableAlignments( controls );
 	const layoutOffersAlignments =
 		!! useAvailableAlignments( DEFAULT_CONTROLS ).length;
+
+	/*
+	 * What the theme itself offers, measured against its global layout rather
+	 * than the parent's. A theme that offers no wide size, or no layout at all,
+	 * is curating its own options; those alignments were never on the table and
+	 * reporting them as withheld would be wrong.
+	 */
+	const themeLayout = useMemo(
+		() => ( { ...globalLayout, type: 'constrained' } ),
+		[ globalLayout ]
+	);
+	const themeNames = useAvailableAlignments(
+		DEFAULT_CONTROLS,
+		themeLayout
+	).map( ( { name } ) => name );
 
 	const enabledNames = enabled.map( ( { name } ) => name );
 	const unavailable = layoutOffersAlignments
 		? controls.filter(
 				( name ) =>
 					WIDE_CONTROLS.includes( name ) &&
+					themeNames.includes( name ) &&
 					! enabledNames.includes( name )
 		  )
 		: EMPTY_ARRAY;

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -1,5 +1,4 @@
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 import { useLayout } from '../block-list/layout';
 import { useSettings } from '../use-settings';
 import { store as blockEditorStore } from '../../store';
@@ -9,43 +8,58 @@ const EMPTY_ARRAY = [];
 const DEFAULT_CONTROLS = [ 'none', 'left', 'center', 'right', 'wide', 'full' ];
 const WIDE_CONTROLS = [ 'wide', 'full' ];
 
-export default function useAvailableAlignments(
-	controls = DEFAULT_CONTROLS,
-	layoutOverride
-) {
+function useAlignmentSettings( isNoneOnly ) {
+	return useSelect(
+		( select ) => {
+			// If `isNoneOnly` is true, we'll be returning early because there is
+			// nothing to filter on an empty array. We won't need the info from
+			// the `useSelect` but we must call it anyway because Rules of Hooks.
+			// So the callback returns early to avoid block editor subscription.
+			if ( isNoneOnly ) {
+				return [ false, false, false ];
+			}
+
+			const settings = select( blockEditorStore ).getSettings();
+			return [
+				settings.alignWide ?? false,
+				settings.supportsLayout,
+				settings.__unstableIsBlockBasedTheme,
+			];
+		},
+		[ isNoneOnly ]
+	);
+}
+
+export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	// Always add the `none` option if not exists.
 	if ( ! controls.includes( 'none' ) ) {
 		controls = [ 'none', ...controls ];
 	}
 	const isNoneOnly = controls.length === 1 && controls[ 0 ] === 'none';
 
-	const [ wideControlsEnabled, themeSupportsLayout, isBlockBasedTheme ] =
-		useSelect(
-			( select ) => {
-				// If `isNoneOnly` is true, we'll be returning early because there is
-				// nothing to filter on an empty array. We won't need the info from
-				// the `useSelect` but we must call it anyway because Rules of Hooks.
-				// So the callback returns early to avoid block editor subscription.
-				if ( isNoneOnly ) {
-					return [ false, false, false ];
-				}
-
-				const settings = select( blockEditorStore ).getSettings();
-				return [
-					settings.alignWide ?? false,
-					settings.supportsLayout,
-					settings.__unstableIsBlockBasedTheme,
-				];
-			},
-			[ isNoneOnly ]
-		);
-	const parentLayout = useLayout();
-	const layout = layoutOverride ?? parentLayout;
+	const settings = useAlignmentSettings( isNoneOnly );
+	const layout = useLayout();
 
 	if ( isNoneOnly ) {
 		return EMPTY_ARRAY;
 	}
 
+	return getAvailableAlignments( controls, layout, settings );
+}
+
+/**
+ * The store-free part of `useAvailableAlignments`, so the same rules can be
+ * evaluated against more than one layout without a subscription for each.
+ *
+ * @param {string[]} controls Alignments the block supports, including `none`.
+ * @param {Object}   layout   Layout to evaluate against.
+ * @param {Array}    settings The `[ wideControlsEnabled, themeSupportsLayout, isBlockBasedTheme ]` tuple from `useAlignmentSettings`.
+ *
+ * @return {Object[]} The alignments the layout offers.
+ */
+function getAvailableAlignments( controls, layout, settings ) {
+	const [ wideControlsEnabled, themeSupportsLayout, isBlockBasedTheme ] =
+		settings;
 	const layoutType = getLayoutType( layout?.type );
 
 	if ( themeSupportsLayout ) {
@@ -93,53 +107,58 @@ export default function useAvailableAlignments(
 }
 
 /**
- * Splits the alignments a block supports into the ones the parent layout
- * offers and the wide alignments it has taken away.
+ * Returns the alignments a block supports, split into the ones the parent
+ * layout offers (`enabled`) and the wide alignments it does not (`unavailable`).
  *
- * A block whose only alignments are wide and full — Group is the common case —
- * ends up with nothing offered at all in a layout that allows neither, and the
- * control disappears rather than saying so. Reporting the two sets separately
- * lets the menu render `None` alongside the alignments it cannot give.
- *
- * Flex and Grid parents place their children themselves and offer no alignments
- * to anything, so there is no constraint worth explaining there and both sets
- * come back empty.
+ * An alignment is only `unavailable` when the block supports it, the theme
+ * offers it at the root, and the parent layout does not. The theme check is
+ * measured against the global layout settings, so a theme that sets no wide
+ * size, or no layout at all, is curating its own options rather than
+ * withholding them. Flex and Grid parents never offer alignments to anything,
+ * so under those both lists are empty.
  *
  * @param {string[]} controls Alignments the block supports.
  *
  * @return {{enabled: Object[], unavailable: string[]}} The split alignments.
  */
 export function useAlignmentMenu( controls = DEFAULT_CONTROLS ) {
+	// Always add the `none` option if not exists.
+	if ( ! controls.includes( 'none' ) ) {
+		controls = [ 'none', ...controls ];
+	}
+	const isNoneOnly = controls.length === 1 && controls[ 0 ] === 'none';
+
+	const settings = useAlignmentSettings( isNoneOnly );
+	const layout = useLayout();
 	const [ globalLayout ] = useSettings( 'layout' );
 
-	const enabled = useAvailableAlignments( controls );
-	const layoutOffersAlignments =
-		!! useAvailableAlignments( DEFAULT_CONTROLS ).length;
+	if ( isNoneOnly ) {
+		return { enabled: EMPTY_ARRAY, unavailable: EMPTY_ARRAY };
+	}
 
-	/*
-	 * What the theme itself offers, measured against its global layout rather
-	 * than the parent's. A theme that offers no wide size, or no layout at all,
-	 * is curating its own options; those alignments were never on the table and
-	 * reporting them as withheld would be wrong.
-	 */
-	const themeLayout = useMemo(
-		() => ( { ...globalLayout, type: 'constrained' } ),
-		[ globalLayout ]
-	);
-	const themeNames = useAvailableAlignments(
+	const enabled = getAvailableAlignments( controls, layout, settings );
+	const layoutOffersAlignments = !! getAvailableAlignments(
 		DEFAULT_CONTROLS,
-		themeLayout
-	).map( ( { name } ) => name );
+		layout,
+		settings
+	).length;
 
+	if ( ! layoutOffersAlignments ) {
+		return { enabled, unavailable: EMPTY_ARRAY };
+	}
+
+	const themeNames = getAvailableAlignments(
+		DEFAULT_CONTROLS,
+		{ ...globalLayout, type: 'constrained' },
+		settings
+	).map( ( { name } ) => name );
 	const enabledNames = enabled.map( ( { name } ) => name );
-	const unavailable = layoutOffersAlignments
-		? controls.filter(
-				( name ) =>
-					WIDE_CONTROLS.includes( name ) &&
-					themeNames.includes( name ) &&
-					! enabledNames.includes( name )
-		  )
-		: EMPTY_ARRAY;
+	const unavailable = controls.filter(
+		( name ) =>
+			WIDE_CONTROLS.includes( name ) &&
+			themeNames.includes( name ) &&
+			! enabledNames.includes( name )
+	);
 
 	return { enabled, unavailable };
 }

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -85,3 +85,37 @@ export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 
 	return alignments;
 }
+
+/**
+ * Splits the alignments a block supports into the ones the parent layout
+ * offers and the wide alignments it has taken away.
+ *
+ * A block whose only alignments are wide and full — Group is the common case —
+ * ends up with nothing offered at all in a layout that allows neither, and the
+ * control disappears rather than saying so. Reporting the two sets separately
+ * lets the menu render `None` alongside the alignments it cannot give.
+ *
+ * Flex and Grid parents place their children themselves and offer no alignments
+ * to anything, so there is no constraint worth explaining there and both sets
+ * come back empty.
+ *
+ * @param {string[]} controls Alignments the block supports.
+ *
+ * @return {{enabled: Object[], unavailable: string[]}} The split alignments.
+ */
+export function useAlignmentMenu( controls = DEFAULT_CONTROLS ) {
+	const enabled = useAvailableAlignments( controls );
+	const layoutOffersAlignments =
+		!! useAvailableAlignments( DEFAULT_CONTROLS ).length;
+
+	const enabledNames = enabled.map( ( { name } ) => name );
+	const unavailable = layoutOffersAlignments
+		? controls.filter(
+				( name ) =>
+					WIDE_CONTROLS.includes( name ) &&
+					! enabledNames.includes( name )
+		  )
+		: EMPTY_ARRAY;
+
+	return { enabled, unavailable };
+}

--- a/packages/block-editor/src/hooks/align.jsx
+++ b/packages/block-editor/src/hooks/align.jsx
@@ -6,7 +6,9 @@ import {
 	hasBlockSupport,
 } from '@wordpress/blocks';
 import { BlockControls, BlockAlignmentControl } from '../components';
-import useAvailableAlignments from '../components/block-alignment-control/use-available-alignments';
+import useAvailableAlignments, {
+	useAlignmentMenu,
+} from '../components/block-alignment-control/use-available-alignments';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 
 /**
@@ -110,11 +112,18 @@ function BlockEditAlignmentToolbarControlsPure( {
 		hasBlockSupport( blockName, 'alignWide', true )
 	);
 
-	const validAlignments = useAvailableAlignments(
-		blockAllowedAlignments
-	).map( ( { name } ) => name );
+	const { enabled, unavailable } = useAlignmentMenu( blockAllowedAlignments );
 	const blockEditingMode = useBlockEditingMode();
-	if ( ! validAlignments.length || blockEditingMode !== 'default' ) {
+	/*
+	 * Render whenever there is something to say, which includes having only
+	 * unavailable alignments to report: a Group supports nothing but wide and
+	 * full, so in a layout offering neither the control would otherwise vanish
+	 * from the block most likely to want them.
+	 */
+	if (
+		( ! enabled.length && ! unavailable.length ) ||
+		blockEditingMode !== 'default'
+	) {
 		return null;
 	}
 
@@ -134,7 +143,14 @@ function BlockEditAlignmentToolbarControlsPure( {
 			<BlockAlignmentControl
 				value={ align }
 				onChange={ updateAlignment }
-				controls={ validAlignments }
+				/*
+				 * Pass the alignments the block itself supports rather than the
+				 * ones the current layout leaves available. The control filters
+				 * them again, but keeping the unfiltered list lets it tell the
+				 * difference between an alignment this block never had and one a
+				 * parent layout has taken away.
+				 */
+				controls={ blockAllowedAlignments }
 			/>
 		</BlockControls>
 	);

--- a/packages/block-editor/src/hooks/align.jsx
+++ b/packages/block-editor/src/hooks/align.jsx
@@ -1,5 +1,7 @@
 import clsx from 'clsx';
 import { addFilter } from '@wordpress/hooks';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	getBlockSupport,
 	getBlockType,
@@ -10,6 +12,8 @@ import useAvailableAlignments, {
 	useAlignmentMenu,
 } from '../components/block-alignment-control/use-available-alignments';
 import { useBlockEditingMode } from '../components/block-editing-mode';
+import { store as blockEditorStore } from '../store';
+import useBlockDisplayInformation from '../components/use-block-display-information';
 
 /**
  * An array which includes all possible valid alignments,
@@ -98,9 +102,76 @@ export function addAttribute( settings ) {
 	return settings;
 }
 
+/**
+ * Describes the block whose layout is withholding alignments, so the menu can
+ * name it and offer to select it.
+ *
+ * Only a block the user can reach from here is described. When the constraint
+ * comes from outside the post — the template wrapped around the content — there
+ * is no block on the page to send anyone to.
+ *
+ * @param {string} clientId The block whose alignments are withheld.
+ *
+ * @return {?{description: string, action: Object}} The constraint.
+ */
+function useAlignmentConstraint( clientId ) {
+	const parentClientId = useSelect(
+		( select ) => {
+			const { getBlockRootClientId, getBlockEditingMode } =
+				select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+
+			if (
+				! rootClientId ||
+				getBlockEditingMode( rootClientId ) !== 'default'
+			) {
+				return null;
+			}
+
+			return rootClientId;
+		},
+		[ clientId ]
+	);
+
+	const parentInfo = useBlockDisplayInformation( parentClientId );
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	if ( ! parentInfo ) {
+		return null;
+	}
+
+	/*
+	 * The block type rather than any name it has been given, matching how
+	 * `BlockParentSelector` labels the same action. The icon comes from the
+	 * type too, so the two can never describe different blocks — a custom name
+	 * can sit beside an icon that does not look like it.
+	 */
+	const parentTitle = parentInfo.title;
+
+	return {
+		// Short enough not to wrap: the label above it already names the block.
+		description: __( 'It limits this block’s width.' ),
+		action: {
+			label: sprintf(
+				// translators: %s: title of the containing block, e.g. "Group".
+				__( 'Select %s' ),
+				parentTitle
+			),
+			/*
+			 * The block's own icon, matching how `BlockParentSelector` renders
+			 * the same "go up a level" action in the toolbar. It also keeps the
+			 * item in the menu's icon column.
+			 */
+			icon: parentInfo.icon,
+			onClick: () => selectBlock( parentClientId ),
+		},
+	};
+}
+
 function BlockEditAlignmentToolbarControlsPure( {
 	name: blockName,
 	align,
+	clientId,
 	setAttributes,
 } ) {
 	// Compute the block valid alignments by taking into account,
@@ -113,6 +184,7 @@ function BlockEditAlignmentToolbarControlsPure( {
 	);
 
 	const { enabled, unavailable } = useAlignmentMenu( blockAllowedAlignments );
+	const constraint = useAlignmentConstraint( clientId );
 	const blockEditingMode = useBlockEditingMode();
 	/*
 	 * Render whenever there is something to say, which includes having only
@@ -151,6 +223,7 @@ function BlockEditAlignmentToolbarControlsPure( {
 				 * parent layout has taken away.
 				 */
 				controls={ blockAllowedAlignments }
+				constraint={ unavailable.length ? constraint : undefined }
 			/>
 		</BlockControls>
 	);

--- a/packages/block-editor/src/hooks/align.jsx
+++ b/packages/block-editor/src/hooks/align.jsx
@@ -149,8 +149,12 @@ function useAlignmentConstraint( clientId ) {
 	const parentTitle = parentInfo.title;
 
 	return {
-		// Short enough not to wrap: the label above it already names the block.
-		description: __( 'It limits this block’s width.' ),
+		/*
+		 * The label above already names the block, so this only has to say what
+		 * about it is doing the limiting. "Layout" is also where the setting
+		 * lives once they get there.
+		 */
+		description: __( 'Its layout limits widths' ),
 		action: {
 			label: sprintf(
 				// translators: %s: title of the containing block, e.g. "Group".


### PR DESCRIPTION
## What?

Builds on #82600, and [part of the width guidance discussed in #79285](https://github.com/WordPress/gutenberg/issues/79285#issuecomment-5585765480).

Adds a button in the alignment dropdown to select the block that affects a child block's width.

Before:

<img width="1271" height="594" alt="image" src="https://github.com/user-attachments/assets/f4049daa-9f96-4cf8-b4a7-5de2abe1b967" />

After:

<img width="649" height="439" alt="image" src="https://github.com/user-attachments/assets/809db86f-9456-4c0a-b9f8-3a8ca30091f3" />

<details><summary>Previous iteration</summary>

When a block's parent layout withholds wide and full alignments, the block inspector now says which block is responsible and offers to select it.

> **Wide and Full width unavailable**
> The Group around this block limits its width.
> [ Select Group ]

#82600 made the alignment menu admit that Wide and Full are unavailable. This says why.

**Note:** There appears to be something wrong with the [Notice](https://wordpress.github.io/gutenberg/?path=/docs/components-notice--docs): it's now showing a grey background in all variants. Not sure if this is intentional or not, but it seems wrong to me, as a single border feels insufficient to communicate the difference in notice type.

Also, added CSS for this one feels also wrong: it's not clear there's an alternative whe nusing the pre-tabs slot which renders flush against the inspector edges. `Spacer` is blocked by the same lint rule as planned for deprecation, and `Stack` from `@wordpress/ui` only exposes `gap`. Any recommendation on what we can do instead?

Before:

<img width="1271" height="594" alt="image" src="https://github.com/user-attachments/assets/f4049daa-9f96-4cf8-b4a7-5de2abe1b967" />

After:
<img width="1278" height="627" alt="image" src="https://github.com/user-attachments/assets/58f7545b-f2eb-45f2-9f75-1f9edc93224c" />

</details>


## Why?

"Not available" answers half the question. The other half of where to change it and why, is hard to work out. Because the block responsible is often several steps away and looks like ordinary page content.

## How?

Claude wrote this:

The block support already knows which alignments the layout withheld, from `useAlignmentMenu` in #82600. This adds the other half: the parent that withheld them.

- The parent comes from `getBlockRootClientId`, and the notice renders into the existing `BlockInspectorPreTabsSlot`, directly below the "Edit original" button.
- The notice is deliberately silent in two cases: when there is no parent block, and when the parent's editing mode is not `default`. In both, the constraint comes from outside the post — the template wrapped around the content — and there is no block on the page to select. Explaining *that* case needs the template's identity and an "Edit template" action, neither of which `block-editor` can reach. It is a separate PR against `packages/editor`.
- The heading adapts when only one of the two alignments is withheld.

## Testing Instructions

1. Add a Group block and switch off "Inner blocks use content width" in its Layout panel.
2. Insert an Image inside it and select it.
3. **Expected:** the block inspector shows "Wide and Full width unavailable", naming the Group, with a "Select Group" button. The alignment dropdown shows Wide and Full as "Not available", per #82600.
4. Press "Select Group". The Group should be selected, and its Layout panel is where the setting actually is.
5. Rename the Group in the list view — call it "Hero" — and reselect the Image. The notice and the button should both use the new name.

Please also confirm it stays quiet where it should:

- Switch "Inner blocks use content width" back on. The notice should disappear.
- Select a block at the top level of the post, with no Group around it. No notice: the constraint, if any, comes from the template and this PR does not speak to that.
- With "Show template" on in the post editor, select a block inside the Content block. No notice, for the same reason.
- A block inside a Row or Grid. No notice — those layouts offer no alignments to anything rather than withholding them.

### Testing Instructions for Keyboard

1. Select the Image inside the flow Group.
2. Open the block inspector and tab to the "Select Group" button.
3. Press <kbd>Enter</kbd>. Focus should move with the selection to the Group, and the notice should no longer be present.

## Use of AI Tools

Claude Opus 5.