### PR TITLE
UI: Reset completed calendar ranges by default

### DIFF
--- a/packages/dataviews/src/components/dataform-controls/test/date.jsdom.test.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/date.jsdom.test.tsx
@@ -359,9 +359,6 @@ describe( 'DateControl', () => {
 			name: /august 25, 2026/i,
 		} );
 		await user.click( august25 );
-		// The first click extends the existing range. Clicking its new end again
-		// starts the replacement range from that day.
-		await user.click( august25 );
 		await user.click(
 			screen.getByRole( 'button', { name: /august 27, 2026/i } )
 		);

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+-   `RangeCalendar`: Start a new range by default when selecting a date after the current range is complete. Set `resetOnSelect={ false }` to preserve the previous behavior. ([#82612](https://github.com/WordPress/gutenberg/pull/82612))
 -   `Menu`: `--wp-ui-menu-selection-indicator-size` now controls the selection indicator width only. Its height follows the item label line height. ([#82346](https://github.com/WordPress/gutenberg/pull/82346))
 -   `Autocomplete.Popup`, `Combobox.Popup`, `Select.Popup`, `SearchableChipSelect`, and `SearchableChipSelectControl`: The popup now defaults to a fixed anchor width. Use `width="content"` on Popups, or `popupWidth="content"` on composites, to restore content-sized width between the anchor and available viewport bounds ([#82087](https://github.com/WordPress/gutenberg/pull/82087), [#82193](https://github.com/WordPress/gutenberg/pull/82193)).
 -   Portaled overlays (`AlertDialog`, `Autocomplete`, `Combobox`, `Dialog`, `Drawer`, `Menu`, `Popover`, and `Select`) now inherit the theme from their portal destination instead of re-emitting the trigger's nearest contextual theme. Default portals use the document root theme; custom portal containers use their DOM ancestry ([#82038](https://github.com/WordPress/gutenberg/pull/82038)).

--- a/packages/ui/src/calendar/range-calendar.tsx
+++ b/packages/ui/src/calendar/range-calendar.tsx
@@ -136,6 +136,7 @@ export const RangeCalendar = forwardRef< HTMLDivElement, RangeCalendarProps >(
 			onValueChange,
 			numberOfMonths = 1,
 			excludeDisabled,
+			resetOnSelect = true,
 			min,
 			max,
 			disabled,
@@ -230,6 +231,7 @@ export const RangeCalendar = forwardRef< HTMLDivElement, RangeCalendarProps >(
 					numberOfMonths={ clampNumberOfMonths( numberOfMonths ) }
 					disabled={ disabled }
 					excludeDisabled={ excludeDisabled }
+					resetOnSelect={ resetOnSelect }
 					min={ min }
 					max={ max }
 					labels={ labels }

--- a/packages/ui/src/calendar/range-calendar.tsx
+++ b/packages/ui/src/calendar/range-calendar.tsx
@@ -17,18 +17,25 @@ export function usePreviewRange( {
 	value,
 	hoveredDate,
 	excludeDisabled,
+	resetOnSelect,
 	min,
 	max,
 	disabled,
 }: Pick<
 	RangeCalendarProps,
-	'value' | 'excludeDisabled' | 'min' | 'max' | 'disabled'
+	'value' | 'excludeDisabled' | 'resetOnSelect' | 'min' | 'max' | 'disabled'
 > & {
 	hoveredDate: Date | undefined;
 } ) {
 	return useMemo( () => {
 		if ( ! hoveredDate || ! value?.from ) {
 			return;
+		}
+		if ( resetOnSelect && value.to ) {
+			return {
+				from: hoveredDate,
+				to: hoveredDate,
+			};
 		}
 
 		let previewHighlight: DateRange | undefined;
@@ -117,7 +124,15 @@ export function usePreviewRange( {
 		}
 
 		return previewHighlight;
-	}, [ value, hoveredDate, excludeDisabled, min, max, disabled ] );
+	}, [
+		value,
+		hoveredDate,
+		excludeDisabled,
+		resetOnSelect,
+		min,
+		max,
+		disabled,
+	] );
 }
 
 /**
@@ -196,6 +211,7 @@ export const RangeCalendar = forwardRef< HTMLDivElement, RangeCalendarProps >(
 			value: selected,
 			hoveredDate,
 			excludeDisabled,
+			resetOnSelect,
 			min,
 			max,
 			disabled,

--- a/packages/ui/src/calendar/stories/usage-guidelines.mdx
+++ b/packages/ui/src/calendar/stories/usage-guidelines.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Calendar
 
-`Calendar` selects a **single date**. `RangeCalendar` selects a **date range**. Both share the same prop surface apart from the shape of `value` / `defaultValue` / `onValueChange`, and the range-only `min`, `max` and `excludeDisabled` props.
+`Calendar` selects a **single date**. `RangeCalendar` selects a **date range**. Both share the same prop surface apart from the shape of `value` / `defaultValue` / `onValueChange`, and the range-only `min`, `max`, `excludeDisabled`, and `resetOnSelect` props.
 
 Both are built for accessibility and follow ARIA best practices for calendar widgets: keyboard navigation, screen reader support, and customizable labels for internationalization.
 
@@ -64,6 +64,8 @@ const MyRangeCalendar = () => {
 ```
 
 Use `min` and `max` to constrain how many nights a range may span, and `excludeDisabled` to reset the range when a disabled day falls inside it.
+
+After a range is complete, selecting another date starts a new range. Set `resetOnSelect` to `false` to extend or shorten the completed range instead.
 
 ## Disabling Days
 

--- a/packages/ui/src/calendar/stories/usage-guidelines.mdx
+++ b/packages/ui/src/calendar/stories/usage-guidelines.mdx
@@ -65,7 +65,7 @@ const MyRangeCalendar = () => {
 
 Use `min` and `max` to constrain how many nights a range may span, and `excludeDisabled` to reset the range when a disabled day falls inside it.
 
-After a range is complete, selecting another date starts a new range. Set `resetOnSelect` to `false` to extend or shorten the completed range instead.
+After a range is complete, selecting another date starts a new range, and the hover preview shows only that new start date. Set `resetOnSelect` to `false` to preview and adjust the closest end of the completed range instead.
 
 ## Disabling Days
 

--- a/packages/ui/src/calendar/test/range-calendar.jsdom.test.tsx
+++ b/packages/ui/src/calendar/test/range-calendar.jsdom.test.tsx
@@ -292,7 +292,7 @@ describe( 'RangeCalendar', () => {
 
 				expect( onValueChange ).toHaveBeenCalledTimes( 1 );
 				expect( onValueChange ).toHaveBeenCalledWith(
-					{ from: today, to: today },
+					{ from: today, to: undefined },
 					today,
 					expect.objectContaining( { today: true } ),
 					expect.objectContaining( {
@@ -320,7 +320,7 @@ describe( 'RangeCalendar', () => {
 
 				expect( onValueChange ).toHaveBeenCalledTimes( 1 );
 				expect( onValueChange ).toHaveBeenLastCalledWith(
-					{ from: today, to: today },
+					{ from: today, to: undefined },
 					today,
 					expect.objectContaining( { today: true } ),
 					expect.objectContaining( {
@@ -363,7 +363,7 @@ describe( 'RangeCalendar', () => {
 
 				expect( onValueChange ).toHaveBeenCalledTimes( 1 );
 				expect( onValueChange ).toHaveBeenCalledWith(
-					{ from: tomorrow, to: tomorrow },
+					{ from: tomorrow, to: undefined },
 					tomorrow,
 					expect.objectContaining( { today: false } ),
 					expect.objectContaining( {
@@ -396,7 +396,7 @@ describe( 'RangeCalendar', () => {
 				).toBeVisible();
 			} );
 
-			it( 'should expand the current range when clicking a third date after the existing range end', async () => {
+			it( 'should start a new range when clicking a date after the existing range end', async () => {
 				const user = setupUserEvent();
 				const onValueChange = vi.fn();
 
@@ -408,7 +408,7 @@ describe( 'RangeCalendar', () => {
 
 				expect( onValueChange ).toHaveBeenCalledTimes( 1 );
 				expect( onValueChange ).toHaveBeenCalledWith(
-					{ from: today, to: today },
+					{ from: today, to: undefined },
 					today,
 					expect.objectContaining( { today: true } ),
 					expect.objectContaining( {
@@ -433,7 +433,7 @@ describe( 'RangeCalendar', () => {
 					} )
 				);
 
-				// Third click - expand range end
+				// Third click - start a new range
 				const dayAfterTomorrow = addDays( today, 2 );
 				const dayAfterTomorrowButton =
 					getDateButton( dayAfterTomorrow );
@@ -442,7 +442,7 @@ describe( 'RangeCalendar', () => {
 				expect( onValueChange ).toHaveBeenCalledTimes( 3 );
 				expect( onValueChange ).toHaveBeenNthCalledWith(
 					3,
-					{ from: today, to: dayAfterTomorrow },
+					{ from: dayAfterTomorrow, to: undefined },
 					dayAfterTomorrow,
 					expect.objectContaining( { today: false } ),
 					expect.objectContaining( {
@@ -452,11 +452,16 @@ describe( 'RangeCalendar', () => {
 				);
 			} );
 
-			it( 'should update the current range when clicking a third date in between the existing range start and end', async () => {
+			it( 'should update the current range when `resetOnSelect` is `false`', async () => {
 				const user = setupUserEvent();
 				const onValueChange = vi.fn();
 
-				render( <Component onValueChange={ onValueChange } /> );
+				render(
+					<Component
+						onValueChange={ onValueChange }
+						resetOnSelect={ false }
+					/>
+				);
 
 				// First click - start range
 				const yesterdayButton = getDateButton( yesterday );
@@ -508,11 +513,16 @@ describe( 'RangeCalendar', () => {
 				);
 			} );
 
-			it( 'should expand the current range when clicking a third date before the existing range start', async () => {
+			it( 'should expand the current range when `resetOnSelect` is `false`', async () => {
 				const user = setupUserEvent();
 				const onValueChange = vi.fn();
 
-				render( <Component onValueChange={ onValueChange } /> );
+				render(
+					<Component
+						onValueChange={ onValueChange }
+						resetOnSelect={ false }
+					/>
+				);
 
 				// First click - start range
 				const todayButton = getDateButton( today );
@@ -582,7 +592,7 @@ describe( 'RangeCalendar', () => {
 				).not.toBeInTheDocument();
 			} );
 
-			it( 'should clear the range when defining a one-day range and clicking on the same date again', async () => {
+			it( 'should clear the range when defining a one-day range and clicking on the same date again with `resetOnSelect` set to `false`', async () => {
 				const user = setupUserEvent();
 				const onValueChange = vi.fn();
 
@@ -591,6 +601,7 @@ describe( 'RangeCalendar', () => {
 				const { rerender } = render(
 					<Component
 						onValueChange={ onValueChange }
+						resetOnSelect={ false }
 						initialSelected={ {
 							from: yesterday,
 							to: dayAfterTomorrow,
@@ -633,6 +644,7 @@ describe( 'RangeCalendar', () => {
 				rerender(
 					<Component
 						onValueChange={ onValueChange }
+						resetOnSelect={ false }
 						initialSelected={ {
 							from: yesterday,
 							to: dayAfterTomorrow,
@@ -644,7 +656,7 @@ describe( 'RangeCalendar', () => {
 				).not.toBeInTheDocument();
 			} );
 
-			it( 'should not clear the range when clicking a selected date if the `required` prop is set to `true`', async () => {
+			it( 'should not clear the range when clicking a selected date if `required` is `true` and `resetOnSelect` is `false`', async () => {
 				const user = setupUserEvent();
 				const onValueChange = vi.fn();
 
@@ -653,6 +665,7 @@ describe( 'RangeCalendar', () => {
 				render(
 					<Component
 						onValueChange={ onValueChange }
+						resetOnSelect={ false }
 						initialSelected={ {
 							from: yesterday,
 							to: dayAfterTomorrow,
@@ -712,7 +725,7 @@ describe( 'RangeCalendar', () => {
 
 				expect( onValueChange ).toHaveBeenCalledTimes( 1 );
 				expect( onValueChange ).toHaveBeenLastCalledWith(
-					{ from: today, to: today },
+					{ from: today, to: undefined },
 					today,
 					expect.objectContaining( { today: true } ),
 					expect.objectContaining( {
@@ -759,7 +772,7 @@ describe( 'RangeCalendar', () => {
 
 				expect( onValueChange ).toHaveBeenCalledTimes( 1 );
 				expect( onValueChange ).toHaveBeenLastCalledWith(
-					{ from: today, to: today },
+					{ from: today, to: undefined },
 					today,
 					expect.objectContaining( { today: true } ),
 					expect.objectContaining( {
@@ -860,7 +873,7 @@ describe( 'RangeCalendar', () => {
 
 				expect( onValueChange ).toHaveBeenCalledTimes( 1 );
 				expect( onValueChange ).toHaveBeenLastCalledWith(
-					{ from: yesterday, to: yesterday },
+					{ from: yesterday, to: undefined },
 					yesterday,
 					expect.objectContaining( { today: false } ),
 					expect.objectContaining( {
@@ -1556,7 +1569,7 @@ describe( 'RangeCalendar', () => {
 			expect( onValueChange ).toHaveBeenCalledWith(
 				{
 					from: tomorrowFromTokyoTimezone,
-					to: tomorrowFromTokyoTimezone,
+					to: undefined,
 				},
 				tomorrowFromTokyoTimezone,
 				expect.objectContaining( { today: true } ),

--- a/packages/ui/src/calendar/test/range-calendar.jsdom.test.tsx
+++ b/packages/ui/src/calendar/test/range-calendar.jsdom.test.tsx
@@ -1649,11 +1649,27 @@ describe( 'RangeCalendar', () => {
 			expect( result.current ).toBeUndefined();
 		} );
 
-		it( 'should show preview when hovering before selected range', () => {
+		it( 'should preview only the hovered date when resetting a complete range', () => {
 			const { result } = renderHook( () =>
 				usePreviewRange( {
 					value: { from: previewToday, to: previewTomorrow },
 					hoveredDate: previewYesterday,
+					resetOnSelect: true,
+				} )
+			);
+
+			expect( result.current ).toEqual( {
+				from: previewYesterday,
+				to: previewYesterday,
+			} );
+		} );
+
+		it( 'should show the adjustment preview before a completed range when `resetOnSelect` is `false`', () => {
+			const { result } = renderHook( () =>
+				usePreviewRange( {
+					value: { from: previewToday, to: previewTomorrow },
+					hoveredDate: previewYesterday,
+					resetOnSelect: false,
 				} )
 			);
 
@@ -1668,6 +1684,7 @@ describe( 'RangeCalendar', () => {
 				usePreviewRange( {
 					value: { from: previewYesterday, to: previewTomorrow },
 					hoveredDate: previewToday,
+					resetOnSelect: false,
 				} )
 			);
 
@@ -1682,6 +1699,7 @@ describe( 'RangeCalendar', () => {
 				usePreviewRange( {
 					value: { from: previewYesterday, to: previewToday },
 					hoveredDate: previewTomorrow,
+					resetOnSelect: false,
 				} )
 			);
 

--- a/packages/ui/src/calendar/types.ts
+++ b/packages/ui/src/calendar/types.ts
@@ -360,9 +360,10 @@ export interface RangeProps {
 	 */
 	excludeDisabled?: boolean;
 	/**
-	 * When `true`, selecting a date starts a new range when there is no current
-	 * start date or when the current range is complete. The hover preview shows
-	 * the range that selecting the date would create.
+	 * When `true`, clicking a day starts a new range if there is no current start
+	 * date or if a range is already complete. In those cases, the clicked day
+	 * becomes the start of the new range. When `required` is `false`, clicking
+	 * the same day of a single-day range clears the selection.
 	 * @default true
 	 */
 	resetOnSelect?: boolean;

--- a/packages/ui/src/calendar/types.ts
+++ b/packages/ui/src/calendar/types.ts
@@ -361,7 +361,8 @@ export interface RangeProps {
 	excludeDisabled?: boolean;
 	/**
 	 * When `true`, selecting a date starts a new range when there is no current
-	 * start date or when the current range is complete.
+	 * start date or when the current range is complete. The hover preview shows
+	 * the range that selecting the date would create.
 	 * @default true
 	 */
 	resetOnSelect?: boolean;

--- a/packages/ui/src/calendar/types.ts
+++ b/packages/ui/src/calendar/types.ts
@@ -360,6 +360,12 @@ export interface RangeProps {
 	 */
 	excludeDisabled?: boolean;
 	/**
+	 * When `true`, selecting a date starts a new range when there is no current
+	 * start date or when the current range is complete.
+	 * @default true
+	 */
+	resetOnSelect?: boolean;
+	/**
 	 * The minimum number of nights to include in the range.
 	 */
 	min?: number;

--- a/storybook/components-manifest.yml
+++ b/storybook/components-manifest.yml
@@ -984,6 +984,7 @@
       - onValueChange
       - render
       - required
+      - resetOnSelect
       - role
       - showOutsideDays
       - startMonth


### PR DESCRIPTION
Closes #82609.

## What?

Makes `RangeCalendar` start a new range when a selection is already complete. Its hover preview now shows the range that the next selection will create. The new `resetOnSelect` prop defaults to `true`, while consumers can pass `false` to preserve the previous range-editing behavior.

## Why?

Starting a new range is the intended default after a user completes the current selection. React DayPicker supports this behavior but defaults it to `false`, and `RangeCalendar` did not expose the option.

## How?

Passes `resetOnSelect` to the range-mode `DayPicker` and uses the same value for the hover preview. It also updates the public type and usage guidance, with default and opt-out test coverage.

## Testing Instructions

1. Open the `Design System / Components / Calendar / RangeCalendar / Default` Storybook story.
2. Select a start date and an end date.
3. Hover a third date. Confirm that the preview outlines only that date.
4. Select the third date. Confirm that only it remains selected as the start of a new range.
5. Set `resetOnSelect` to `false`.
6. Repeat the selections. Confirm that the preview and selection extend or shorten the completed range.

### Testing Instructions for Keyboard

Repeat the steps with Tab to enter the calendar, arrow keys to move between dates, and Enter or Space to select each date. Confirm the same default and opt-out behavior.


### Screen captures

Before:

https://github.com/user-attachments/assets/77ea080d-eb02-4db7-b463-d3d623a9dbcb

After:

https://github.com/user-attachments/assets/3f7d7a41-dc2f-4016-9a1c-c046b5dfa35c

## Use of AI Tools

Codex was used to inspect the existing API and consumers, implement the change, update tests and documentation, and run verification. I reviewed the resulting diff and browser behavior.
