### PR TITLE
Framework: Update @types/node to v24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15707,12 +15707,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.39",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+			"version": "24.13.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+			"integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -47559,9 +47559,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"license": "MIT"
 		},
 		"node_modules/unherit": {
@@ -50571,7 +50571,7 @@
 			"devDependencies": {
 				"@testing-library/jest-dom": "^6.9.1",
 				"@types/jest": "^30.0.0",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -51240,7 +51240,7 @@
 			"devDependencies": {
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/react": "^16.3.2",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@wordpress/block-library": "file:../block-library",
 				"deep-freeze": "^0.0.1",
 				"vitest": "^4.1.11"
@@ -51516,7 +51516,7 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"esbuild": "^0.27.2",
 				"storybook": "^10.5.3",
 				"vitest": "^4.1.11"
@@ -51701,7 +51701,7 @@
 				"design-system-mcp": "bin/design-system-mcp.mjs"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -51783,7 +51783,7 @@
 			},
 			"devDependencies": {
 				"@types/mime": "^2.0.3",
-				"@types/node": "^20.19.39"
+				"@types/node": "^24.13.3"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -51791,7 +51791,7 @@
 			},
 			"peerDependencies": {
 				"@playwright/test": ">=1",
-				"@types/node": "^20.17.10"
+				"@types/node": "^24.0.0"
 			}
 		},
 		"packages/e2e-test-utils-playwright/node_modules/web-vitals": {
@@ -52913,7 +52913,7 @@
 			},
 			"devDependencies": {
 				"@types/jest": "^30.0.0",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -53145,7 +53145,7 @@
 				"semver": "^7.5.4"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@types/npm-package-arg": "^6.1.1",
 				"@types/semver": "^7.3.8"
 			},
@@ -53542,7 +53542,7 @@
 			"version": "4.54.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@types/prettier": "^2.4.4",
 				"prettier": "npm:wp-prettier@^3.0.3",
 				"vitest": "^4.1.11"
@@ -53618,7 +53618,7 @@
 				"@octokit/webhooks-types": "^5.8.0"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -53797,7 +53797,7 @@
 				"jest-message-util": "^30.5.0"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -54545,7 +54545,7 @@
 				"yjs": "^13.6.29"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -54576,7 +54576,7 @@
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@types/jest": "^30.0.0",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@wordpress/validation-tools": "file:../../tools/validation",
 				"esbuild": "^0.27.2",
 				"esbuild-esm-loader": "^0.3.3",
@@ -54749,7 +54749,7 @@
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
 				"@types/jest": "^30.0.0",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@wordpress/base-styles": "file:../base-styles",
 				"@wordpress/jest-console": "file:../jest-console",
 				"fast-glob": "^3.2.7",
@@ -54779,7 +54779,7 @@
 				"@wordpress/is-shallow-equal": "file:../is-shallow-equal"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -54804,7 +54804,7 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -54915,7 +54915,7 @@
 				"wasm-vips": "^0.0.18"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -55127,7 +55127,7 @@
 				"wp-build": "lib/build.mjs"
 			},
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {
@@ -55611,7 +55611,7 @@
 			"devDependencies": {
 				"@flakiness/playwright": "^2.0.1",
 				"@playwright/test": "^1.62.1",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"@wordpress/vips": "file:../../packages/vips",
@@ -55653,7 +55653,7 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@playwright/test": "^1.62.1",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 				"@wordpress/scripts": "file:../../packages/scripts",
 				"wasm-vips": "^0.0.18"
@@ -55667,7 +55667,7 @@
 				"@emotion/babel-plugin": "^11.13.5",
 				"@playwright/test": "^1.62.1",
 				"@storybook/react-vite": "^10.5.3",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@wordpress/element": "file:../../packages/element",
 				"@wordpress/storybook": "file:../../storybook",
 				"storybook": "^10.5.3"
@@ -55686,7 +55686,7 @@
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"@typescript-eslint/parser": "^8.68.0",
 				"@vitejs/plugin-react-swc": "^4.3.3",
 				"@vitest/browser-playwright": "^4.1.10",
@@ -56209,7 +56209,7 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@types/node": "^20.19.39",
+				"@types/node": "^24.13.3",
 				"vitest": "^4.1.11"
 			},
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51791,7 +51791,7 @@
 			},
 			"peerDependencies": {
 				"@playwright/test": ">=1",
-				"@types/node": "^24.0.0"
+				"@types/node": ">=20"
 			}
 		},
 		"packages/e2e-test-utils-playwright/node_modules/web-vitals": {

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -44,7 +44,7 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.9.1",
 		"@types/jest": "^30.0.0",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -78,7 +78,7 @@
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/react": "^16.3.2",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@wordpress/block-library": "file:../block-library",
 		"deep-freeze": "^0.0.1",
 		"vitest": "^4.1.11"

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -65,6 +65,7 @@
 -   Remove unused dependency `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
 -   Note in the `/wp` bundle build script that its singleton externals list must stay in sync with the transitive private API usage check ([#82027](https://github.com/WordPress/gutenberg/pull/82027)).
+-   Update the `@types/node` development dependency to v24, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
 
 ### Bug Fix
 

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -100,7 +100,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"esbuild": "^0.27.2",
 		"storybook": "^10.5.3",
 		"vitest": "^4.1.11"

--- a/packages/design-system-mcp/package.json
+++ b/packages/design-system-mcp/package.json
@@ -46,7 +46,7 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   The `@types/node` peer dependency now requires `^24.0.0`, matching the Node.js version the repository builds and tests against.
+-   The `@types/node` peer dependency now requires `^24.0.0`, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
 
 ### New Features
 

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `@types/node` peer dependency now requires `^24.0.0`, matching the Node.js version the repository builds and tests against.
+
 ### New Features
 
 -   `Admin.visitSiteEditor()`: When the `GUTENBERG_E2E_SITE_EDITOR_V2` environment variable is set, visit the extensible site editor (`admin.php?page=site-editor-v2`) instead of `site-editor.php`, translating the classic query args to the equivalent v2 route, and wait for the lazily loaded editor to finish initializing on edit routes. `RequestUtils.setGutenbergExperiments()` keeps the `gutenberg-extensible-site-editor` experiment enabled in that mode so specs that reset experiments do not turn the v2 editor off mid-run.

--- a/packages/e2e-test-utils-playwright/CHANGELOG.md
+++ b/packages/e2e-test-utils-playwright/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-### Breaking Changes
-
--   The `@types/node` peer dependency now requires `^24.0.0`, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
-
 ### New Features
 
 -   `Admin.visitSiteEditor()`: When the `GUTENBERG_E2E_SITE_EDITOR_V2` environment variable is set, visit the extensible site editor (`admin.php?page=site-editor-v2`) instead of `site-editor.php`, translating the classic query args to the equivalent v2 route, and wait for the lazily loaded editor to finish initializing on edit routes. `RequestUtils.setGutenbergExperiments()` keeps the `gutenberg-extensible-site-editor` experiment enabled in that mode so specs that reset experiments do not turn the v2 editor off mid-run.
+
+### Enhancements
+
+-   Widen the `@types/node` peer dependency to `>=20`, so consumers on Node 22 or 24 type definitions no longer hit a peer resolution conflict ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
 
 ### Bug Fixes
 

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -49,7 +49,7 @@
 	},
 	"peerDependencies": {
 		"@playwright/test": ">=1",
-		"@types/node": "^24.0.0"
+		"@types/node": ">=20"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/e2e-test-utils-playwright/package.json
+++ b/packages/e2e-test-utils-playwright/package.json
@@ -45,11 +45,11 @@
 	},
 	"devDependencies": {
 		"@types/mime": "^2.0.3",
-		"@types/node": "^20.19.39"
+		"@types/node": "^24.13.3"
 	},
 	"peerDependencies": {
 		"@playwright/test": ">=1",
-		"@types/node": "^20.17.10"
+		"@types/node": "^24.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@types/jest": "^30.0.0",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {

--- a/packages/lazy-import/package.json
+++ b/packages/lazy-import/package.json
@@ -34,7 +34,7 @@
 		"semver": "^7.5.4"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@types/npm-package-arg": "^6.1.1",
 		"@types/semver": "^7.3.8"
 	},

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -33,7 +33,7 @@
 	},
 	"types": "build-types",
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@types/prettier": "^2.4.4",
 		"prettier": "npm:wp-prettier@^3.0.3",
 		"vitest": "^4.1.11"

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -37,7 +37,7 @@
 		"@octokit/webhooks-types": "^5.8.0"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {

--- a/packages/report-flaky-tests/package.json
+++ b/packages/report-flaky-tests/package.json
@@ -40,7 +40,7 @@
 		"jest-message-util": "^30.5.0"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -54,7 +54,7 @@
 		"yjs": "^13.6.29"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -25,6 +25,7 @@
 -   Generate the default ramps before derived token artifacts so one build uses the current ramp algorithm throughout. ([#82525](https://github.com/WordPress/gutenberg/pull/82525))
 -   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))
 -   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
+-   Update the `@types/node` development dependency to v24, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
 
 ## 2.0.0 (2026-08-26)
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -100,7 +100,7 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/jest": "^30.0.0",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@wordpress/validation-tools": "file:../../tools/validation",
 		"esbuild": "^0.27.2",
 		"esbuild-esm-loader": "^0.3.3",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 -   `AlertDialog`: Move confirmation lifecycle state to a private external store so event handlers and React renders read the same synchronous snapshot. ([#82131](https://github.com/WordPress/gutenberg/pull/82131))
 -   Use stable event callbacks and remove the remaining `react-hooks/refs` ESLint suppressions. ([#82131](https://github.com/WordPress/gutenberg/pull/82131))
+-   Update the `@types/node` development dependency to v24, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
 
 ## 0.21.0 (2026-08-26)
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -68,7 +68,7 @@
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/jest": "^30.0.0",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@wordpress/base-styles": "file:../base-styles",
 		"@wordpress/jest-console": "file:../jest-console",
 		"fast-glob": "^3.2.7",

--- a/packages/undo-manager/CHANGELOG.md
+++ b/packages/undo-manager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Update the `@types/node` development dependency to v24, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
+
 ## 1.54.0 (2026-08-26)
 
 ## 1.53.0 (2026-08-12)

--- a/packages/undo-manager/package.json
+++ b/packages/undo-manager/package.json
@@ -47,7 +47,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -61,7 +61,7 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {

--- a/packages/vips/package.json
+++ b/packages/vips/package.json
@@ -59,7 +59,7 @@
 		"wasm-vips": "^0.0.18"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {

--- a/packages/wp-build/CHANGELOG.md
+++ b/packages/wp-build/CHANGELOG.md
@@ -17,6 +17,10 @@
 -   Widen the optional `@wordpress/theme` peer dependency range to allow 2.x releases. ([#82139](https://github.com/WordPress/gutenberg/pull/82139))
 -   Pages: preserve the Core Boot layout compatibility class in generated wp-admin page templates so short pages fill the viewport when using Core's bundled Boot module ([#82112](https://github.com/WordPress/gutenberg/pull/82112)).
 
+### Internal
+
+-   Update the `@types/node` development dependency to v24, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
+
 ## 0.22.0 (2026-08-26)
 
 ### Internal

--- a/packages/wp-build/package.json
+++ b/packages/wp-build/package.json
@@ -55,7 +55,7 @@
 		"sass-embedded": "^1.97.2"
 	},
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"peerDependencies": {

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@flakiness/playwright": "^2.0.1",
 		"@playwright/test": "^1.62.1",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"@wordpress/vips": "file:../../packages/vips",

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.62.1",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@wordpress/e2e-test-utils-playwright": "file:../../packages/e2e-test-utils-playwright",
 		"@wordpress/scripts": "file:../../packages/scripts",
 		"wasm-vips": "^0.0.18"

--- a/test/storybook-playwright/package.json
+++ b/test/storybook-playwright/package.json
@@ -24,7 +24,7 @@
 		"@emotion/babel-plugin": "^11.13.5",
 		"@playwright/test": "^1.62.1",
 		"@storybook/react-vite": "^10.5.3",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@wordpress/element": "file:../../packages/element",
 		"@wordpress/storybook": "file:../../storybook",
 		"storybook": "^10.5.3"

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -28,7 +28,7 @@
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"@typescript-eslint/parser": "^8.68.0",
 		"@vitejs/plugin-react-swc": "^4.3.3",
 		"@vitest/browser-playwright": "^4.1.10",

--- a/tools/pr-meta/package.json
+++ b/tools/pr-meta/package.json
@@ -26,7 +26,7 @@
 	"type": "module",
 	"main": "src/index.ts",
 	"devDependencies": {
-		"@types/node": "^20.19.39",
+		"@types/node": "^24.13.3",
 		"vitest": "^4.1.11"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## What?

Follow up to #82370. Updates `@types/node` from `^20.19.39` to `^24.13.3` across every workspace that declares it.

## Why?

The repository now builds, tests, and runs on Node.js 24 LTS, but the type definitions still described the Node 20 API surface.

## How?

Bumps the `@types/node` devDependency in each workspace and widens the `@wordpress/e2e-test-utils-playwright` `@types/node` peer range to `>=20`, so consumers on newer type definitions no longer hit a peer resolution conflict.

## Testing Instructions

1. `npm install`
2. `npm run clean:package-types && npm run typecheck`
3. Confirm `node_modules/@types/node/package.json` reports 24.13.3.

## Use of AI Tools

Authored with Claude Code: dependency bump, changelog entry, and verification runs. Reviewed by the PR author.
