### PR TITLE
Gallery: Shorten "Use images attached to the post" button, add description

### DIFF
--- a/packages/block-library/src/gallery/dynamic-gallery.jsx
+++ b/packages/block-library/src/gallery/dynamic-gallery.jsx
@@ -241,7 +241,7 @@ export function GallerySourcePanel( {
 					 * carrying the per-source explanation these strings do today.
 					 */ }
 					<p className="wp-block-gallery__source-description">
-						{ __( 'Use images already attached to this post.' ) }
+						{ __( 'Images added to the gallery.' ) }
 					</p>
 					<Button
 						__next40pxDefaultSize
@@ -255,7 +255,7 @@ export function GallerySourcePanel( {
 			{ isConfirming && (
 				<ConfirmDialog
 					isOpen
-					title={ __( 'Use attached images?' ) }
+					title={ __( 'Use images attached to the post?' ) }
 					__experimentalHideHeader={ false }
 					confirmButtonText={ __( 'Use attached images' ) }
 					onConfirm={ () => {

--- a/packages/block-library/src/gallery/dynamic-gallery.jsx
+++ b/packages/block-library/src/gallery/dynamic-gallery.jsx
@@ -238,21 +238,24 @@ export function GallerySourcePanel( {
 					 * its confirm dialog below) is temporary. Once more sources
 					 * exist it becomes a "Choose source" select whose options read
 					 * from each source descriptor's `title`, with help text
-					 * carrying the per-source explanation this string does today.
+					 * carrying the per-source explanation these strings do today.
 					 */ }
+					<p className="wp-block-gallery__source-description">
+						{ __( 'Use images already attached to this post.' ) }
+					</p>
 					<Button
 						__next40pxDefaultSize
 						variant="secondary"
 						onClick={ requestEnableDynamicMode }
 					>
-						{ __( 'Use images attached to the post' ) }
+						{ __( 'Use attached images' ) }
 					</Button>
 				</div>
 			</PanelBody>
 			{ isConfirming && (
 				<ConfirmDialog
 					isOpen
-					title={ __( 'Use images attached to the post?' ) }
+					title={ __( 'Use attached images?' ) }
 					__experimentalHideHeader={ false }
 					confirmButtonText={ __( 'Use attached images' ) }
 					onConfirm={ () => {


### PR DESCRIPTION
## What?
Closes #82603

Shortens the Gallery block's "Use images attached to the post" button to "Use attached images" and adds a short description above it.

## Why?
The button label was too long to translate well in many languages, causing it to overflow. There was also no description text to give the button context.

## How?
Reuses the existing `.wp-block-gallery__source-description` style (already used in dynamic mode) to add a description paragraph above the button. Shortens the button label to "Use attached images", matching the text already used on the confirm dialog's confirm button, and updates the confirm dialog title to match.

## Testing Instructions
1. Insert a Gallery block.
2. Open Block settings in the sidebar → Source panel.
3. Confirm the button reads "Use attached images" with a description above it.
4. Click the button (with images already in the gallery) and confirm the dialog title reads "Use attached images?".

### Testing Instructions for Keyboard
Tab to the "Use attached images" button and activate with Enter/Space; confirm the dialog and its buttons remain keyboard-operable as before.

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="1464" height="620" alt="image" src="https://github.com/user-attachments/assets/b8b8a179-9b52-4654-834b-d6b0bbf8853a" /> | <img width="1470" height="699" alt="image" src="https://github.com/user-attachments/assets/7331a64a-7255-49a8-97cd-cc37cbc0e8a7" /> |
| <img width="288" height="161" alt="image" src="https://github.com/user-attachments/assets/6c2c7603-e499-40ca-8a00-3a270fb89da8" /> | <img width="276" height="130" alt="image" src="https://github.com/user-attachments/assets/f0d5199c-a897-4650-beb5-53a512b74db2" /> |


## Use of AI Tools
Claude Sonnet 5 (Claude Code)
Purpose - Identified the affected string/component and implemented the fix.