### PR TITLE
Automated Testing: Fix unit test compatibility with Node.js v26

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -70,10 +70,6 @@ jobs:
                 event: ['${{ github.event_name }}']
                 node: ['24', '26']
                 shard: ['1/4', '2/4', '3/4', '4/4']
-                exclude:
-                    # Only test Node 24 for pull requests.
-                    - event: 'pull_request'
-                      node: '26'
 
         steps:
             - name: Checkout repository
@@ -145,10 +141,6 @@ jobs:
             matrix:
                 event: ['${{ github.event_name }}']
                 node: ['24', '26']
-                exclude:
-                    # On PRs: Only test Node 24
-                    - event: 'pull_request'
-                      node: '26'
 
         steps:
             - name: Checkout repository

--- a/packages/ui/src/calendar/test/localization.jsdom.test.tsx
+++ b/packages/ui/src/calendar/test/localization.jsdom.test.tsx
@@ -364,28 +364,50 @@ describe( 'Calendar day labels', () => {
 } );
 
 describe( 'Calendar text direction fallback', () => {
-	const getTextInfoDescriptor = Object.getOwnPropertyDescriptor(
-		Intl.Locale.prototype,
-		'getTextInfo'
-	);
+	const original = {
+		getTextInfo: Object.getOwnPropertyDescriptor(
+			Intl.Locale.prototype,
+			'getTextInfo'
+		),
+		textInfo: Object.getOwnPropertyDescriptor(
+			Intl.Locale.prototype,
+			'textInfo'
+		),
+	};
 
+	// Engines that implement `getTextInfo()` have dropped the legacy `textInfo`
+	// getter, so serve its data through `textInfo` to emulate an engine that
+	// only has the legacy property.
 	beforeAll( () => {
+		const getTextInfo = original.getTextInfo!.value;
+
 		Object.defineProperty( Intl.Locale.prototype, 'getTextInfo', {
 			configurable: true,
 			value: undefined,
 		} );
+		Object.defineProperty( Intl.Locale.prototype, 'textInfo', {
+			configurable: true,
+			get() {
+				return getTextInfo.call( this );
+			},
+		} );
 	} );
 
 	afterAll( () => {
-		if ( getTextInfoDescriptor ) {
+		Object.defineProperty(
+			Intl.Locale.prototype,
+			'getTextInfo',
+			original.getTextInfo!
+		);
+
+		if ( original.textInfo ) {
 			Object.defineProperty(
 				Intl.Locale.prototype,
-				'getTextInfo',
-				getTextInfoDescriptor
+				'textInfo',
+				original.textInfo
 			);
 		} else {
-			delete ( Intl.Locale.prototype as { getTextInfo?: unknown } )
-				.getTextInfo;
+			delete ( Intl.Locale.prototype as { textInfo?: unknown } ).textInfo;
 		}
 	} );
 

--- a/test/unit/config/setup-globals.vitest.js
+++ b/test/unit/config/setup-globals.vitest.js
@@ -226,6 +226,17 @@ globalThis.wpVitest = {
 };
 
 if ( typeof globalThis.window !== 'undefined' ) {
+	// Node 26 has its own `localStorage` and `sessionStorage` globals, which are
+	// `undefined` unless Node runs with `--localstorage-file`. The Vitest jsdom
+	// environment does not copy a window property over a global that already
+	// exists, so point these back at the jsdom window.
+	for ( const key of [ 'localStorage', 'sessionStorage' ] ) {
+		Object.defineProperty( globalThis, key, {
+			configurable: true,
+			get: () => globalThis.jsdom.window[ key ],
+		} );
+	}
+
 	globalThis.window.tinyMCEPreInit = {
 		baseURL: 'about:blank',
 	};


### PR DESCRIPTION
## What?

- Resolves build failures on `trunk` caused by incompatibility of JavaScript unit tests when run under Node.js v26.
- Updates test matrix so that Node.js v26 is run in pull requests prior to merge

## Why?

- Tests on `trunk` should pass.
- Workflow updates allow us to catch these issues prior to merge

## How?

There are two issues caused by changes in Node.js v26 around `Intl` and `localStorage` APIs:

- Node.js v26 removes legacy `Intl.Locale#textInfo`, which our tests were exercising as a fallback behavior
   - Fix: Re-shim `textInfo` to simulate the environments we're targeting
- Node.js v26 provides globals for `localStorage` but these are set to `undefined` unless invoked with `--localstorage-file`, and our tests are such that the global won't be shimmed if assigned, even if assigned to `undefined`.
   - Fix: Explicitly set `localStorage` pointing to JSDOM value in JSDOM environments

## Testing Instructions

`npm test` should pass in both Node.js v24 and Node.js v26.

If you're using a tool like `nvm`, you can switch like so:

```
nvm install 26 && nvm use 26
nvm install 24 && nvm use 24
```

## Use of AI Tools

Used Claude Code + Opus 5 to research and implement fixes to code issues, simplified after manual review. Used Cursor IDE + Auto model to update workflow.