### PR TITLE
UI: Defend anchor text-decoration against global CSS

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Bug Fixes
 
 -   `Fieldset`: Fix gap token to match spec ([#75479](https://github.com/WordPress/gutenberg/pull/75479)).
+-   `Link`: Defend `text-decoration` against unlayered global CSS, so the underline survives host rules such as `.some-admin-page a { text-decoration: none; }` ([#00000](https://github.com/WordPress/gutenberg/pull/00000)).
 -   `Field.Label`: Reset `variant="plain"` to the default font weight so it no longer inherits the uppercase label emphasis weight ([#82213](https://github.com/WordPress/gutenberg/pull/82213)).
 -   `Select` (`variant="minimal"`): Keep the trigger borderless and unfilled when disabled. InputLayout no longer applies disabled field chrome to `.is-borderless`. ([#82468](https://github.com/WordPress/gutenberg/pull/82468))
 -   `Link`: Show the new-tab indicator and accessible notice when `target` is an ASCII case-insensitive match for `"_blank"`. ([#82447](https://github.com/WordPress/gutenberg/pull/82447))

--- a/packages/ui/src/link/style.module.css
+++ b/packages/ui/src/link/style.module.css
@@ -3,6 +3,10 @@
 
 	@layer components {
 		.link {
+			/* Bridge the underline into the unlayered `.a` global CSS defense. */
+			--_gcd-a-text-decoration-line: underline;
+			--_gcd-a-text-decoration-thickness: from-font;
+
 			text-underline-offset: 0.2em;
 			text-decoration-thickness: from-font;
 		}
@@ -26,6 +30,7 @@
 		.is-neutral,
 		.is-neutral:visited {
 			--_gcd-a-color: var(--wpds-color-foreground-interactive-neutral);
+			--_gcd-a-text-decoration-color: var(--wpds-color-stroke-interactive-neutral);
 
 			color: var(--wpds-color-foreground-interactive-neutral);
 			text-decoration-color: var(--wpds-color-stroke-interactive-neutral);

--- a/packages/ui/src/utils/css/global-css-defense.module.css
+++ b/packages/ui/src/utils/css/global-css-defense.module.css
@@ -116,6 +116,16 @@ p.p {
 	transition: var(--_gcd-a-transition, none);
 }
 
+/* Scoped to `:any-link` to outrank the wrapper-scoped `.some-page a` rules hosts
+   use to strip underlines, which a lone class does not. All three longhands,
+   because a host `text-decoration` shorthand resets each of them. */
+.a:any-link,
+.a:any-link:is(:hover, :focus, :active) {
+	text-decoration-line: var(--_gcd-a-text-decoration-line, none);
+	text-decoration-color: var(--_gcd-a-text-decoration-color, currentColor);
+	text-decoration-thickness: var(--_gcd-a-text-decoration-thickness, auto);
+}
+
 .ol {
 	margin: var(--_gcd-ol-margin, 0);
 	padding-block: var(--_gcd-ol-padding-block, 0);


### PR DESCRIPTION
## What?

Adds a `text-decoration` bridge to `@wordpress/ui`'s global CSS defense, so a `Link`'s underline survives host pages that strip anchor underlines.

## Why?

`Link`'s `default` variant never declared an underline — it tunes offset, thickness and colour and relies on the UA underline. An unlayered host rule like `.some-admin-page a { text-decoration: none; }` therefore removes it outright and leaves the tuning styling nothing. `global-css-defense.module.css` already bridges `outline`, `color`, `box-shadow`, `border-radius` and `transition` for this reason; `text-decoration` was missing because wp-admin's own CSS never touches it.

The concrete case is the Jetpack plugin, which sets exactly that rule on every admin screen. It's the only one I can point to, but the shape is generic.

## How?

A new `.a:any-link` block defends the three `text-decoration` longhands, with the **initial values as fallbacks** — so the defense alone changes nothing, and components opt in through the custom properties. `Link` bridges its values in on `default` / `neutral`. `Link` `unstyled`, `LinkButton` and `Menu.LinkItem` need no override.

Two things worth flagging:

- **All three longhands**, because a host `text-decoration` shorthand resets colour and thickness too. Defending only the line restores an underline in the wrong colour and weight.
- **`:any-link` is a specificity increase**, `(0,1,0)` → `(0,2,0)`. The existing `.a` beats wp-admin's bare `a` selectors but loses to the wrapper-scoped `.some-page a` rules hosts actually write. The cost: a consumer styling a wp-ui link from outside at `(0,1,0)` will now lose and would need to set `--_gcd-a-text-decoration-line`. Keeping plain `.a` specificity avoids that but fixes nothing. Happy to take the other trade if preferred.

## Testing Instructions

1. Render a default `Link` on a page that also loads an unlayered `.wrap a { text-decoration: none; }`. On `trunk` the underline is gone; on this branch it's restored, with `from-font` thickness and the neutral stroke colour.
2. On a page **without** such a rule, confirm `Link` (both tones and variants), `LinkButton` and `Menu.LinkItem` are unchanged from `trunk`. This is the important check.
3. Confirm the external-link arrow stays un-underlined.

### Testing Instructions for Keyboard

No interaction change. Tab to a `Link` and confirm the focus ring behaves as on `trunk`.

## Screenshots or screencast

A `Notice.ActionLink` (a `Link`, `tone="neutral"`, `variant="default"`) on a page carrying `.jetpack-pagestyles a { text-decoration: none; }`.

|Before|After|
|-|-|
| <img width="660" height="78" alt="gb-link-before" src="https://github.com/user-attachments/assets/61ac4cfe-51cc-4e4a-9b54-cd55dcb4bbb2" /> | <img width="660" height="78" alt="gb-link-after" src="https://github.com/user-attachments/assets/3727cf3f-dad5-404d-8379-d97f974c9a88" /> |

Computed styles on that element:

| | Before | After |
|-|-|-|
| `text-decoration-line` | `none` | `underline` |
| `text-decoration-thickness` | `auto` | `from-font` |
| `text-decoration-color` | `rgb(30, 30, 30)` (`currentColor`) | `rgb(141, 141, 141)` (`--wpds-color-stroke-interactive-neutral`) |

The host page runs the published `@wordpress/ui`, so the "after" is this PR's CSS injected with the built module hashes substituted, declarations otherwise verbatim.

## Use of AI Tools

Researched and drafted with Claude Code, reviewed by me before submission. The cascade behaviour, specificity comparison and three-longhand requirement were each verified in a browser across trunk/branch × clean/hostile CSS, rather than reasoned about on paper.
