### PR TITLE
Test that every step can be redone after undoing past a navigation block

### DIFF
--- a/test/e2e/specs/editor/various/undo.spec.js
+++ b/test/e2e/specs/editor/various/undo.spec.js
@@ -693,6 +693,82 @@ test.describe( 'undo', () => {
 		await pageUtils.pressKeys( 'primaryShift+z', { times: 4 } );
 		await expect( field ).toHaveValue( '<p>markup</p>EDIT' );
 	} );
+
+	// A navigation block syncs its inner blocks back to the menu entity
+	// whenever the block tree is replaced, which every undo does. That
+	// derived edit must not count as new history, or the next undo throws
+	// away every redo step recorded after it.
+	test( 'should redo every step after undoing past a navigation block', async ( {
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const menu = await requestUtils.createNavigationMenu( {
+			title: 'Menu',
+			content:
+				'<!-- wp:navigation-submenu {"label":"Sub","url":"#"} --><!-- wp:navigation-link {"label":"Child","url":"#"} /--><!-- /wp:navigation-submenu -->',
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await editor.insertBlock( {
+			name: 'core/navigation',
+			attributes: { ref: menu.id },
+		} );
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await page.keyboard.type( '3' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '4' );
+		const blocks = [
+			{ name: 'core/paragraph', attributes: { content: '1' } },
+			{ name: 'core/paragraph', attributes: { content: '2' } },
+			{ name: 'core/navigation', attributes: { ref: menu.id } },
+			{ name: 'core/paragraph', attributes: { content: '3' } },
+			{ name: 'core/paragraph', attributes: { content: '4' } },
+		];
+		await expect.poll( editor.getBlocks ).toMatchObject( blocks );
+
+		// Wait for each click to take effect before the next one: either the
+		// content changes, or the step only moved the history so the buttons
+		// change instead.
+		const undo = page.getByRole( 'button', { name: 'Undo' } );
+		const redo = page.getByRole( 'button', { name: 'Redo' } );
+		const getState = async () => ( {
+			content: await editor.getEditedPostContent(),
+			undo: await undo.isEnabled(),
+			redo: await redo.isEnabled(),
+		} );
+		let state = await getState();
+		const submenu = editor.canvas.locator(
+			'[data-type="core/navigation-submenu"]'
+		);
+		const click = async ( button ) => {
+			const before = state;
+			await button.click();
+			await expect
+				.poll( async () => ( state = await getState() ) )
+				.not.toEqual( before );
+			// The navigation block renders its menu after the step, and
+			// syncs it back to the menu entity at the same time.
+			await expect( submenu ).toBeVisible( {
+				visible: state.content.includes( 'wp:navigation' ),
+			} );
+		};
+		let steps = 0;
+		while ( state.undo ) {
+			await click( undo );
+			steps++;
+		}
+		await expect.poll( editor.getBlocks ).toEqual( [] );
+		for ( let step = 0; step < steps; step++ ) {
+			await expect( redo ).toBeEnabled();
+			await click( redo );
+		}
+		await expect.poll( editor.getBlocks ).toMatchObject( blocks );
+
+		await requestUtils.deleteAllMenus();
+	} );
 } );
 
 class UndoUtils {


### PR DESCRIPTION
## What?
Adds an end to end test that undoes past a Navigation block and then redoes every step. On this branch the test fails on purpose: it reproduces the WordPress 7.1 report where redo works for one or two steps and then stops.

## Why?
Every undo replaces the block tree. The Navigation block's inner block controller then writes its inner blocks back to the menu entity as a transient edit, and the undo manager stages it as if the user had typed. The next undo treats the staged edit as new history and drops every redo step recorded after it. #80503 fixed this on trunk by marking those write-backs as ignored by history, but that change is not on wp/7.1.

## How?
1. **Builds a post** with two typed paragraphs, a Navigation block with a submenu, and two more typed paragraphs.
2. **Undoes to an empty canvas and redoes the same number of steps**, asserting the Redo button stays enabled and the full content comes back.
3. **Waits for the submenu to render after each click**, because that render is the same effect that emits the write-back. Clicking as soon as the store updates never reproduces the problem.

## Testing Instructions
1. `npm run test:e2e -- test/e2e/specs/editor/various/undo.spec.js -g "should redo every step after undoing past a navigation block"`
2. On this branch the redo loop fails with the Redo button disabled. With the change from #80503 applied on top, the test passes.

Verified locally: fails 3/3 on WordPress 7.1 core, passes on trunk and on this branch plus #80503, and fails again on trunk with #80503 reverted.

## Use of AI Tools
Written with Claude Code; the investigation, test, and description were reviewed by the author.
