### PR TITLE
Fix the high-severity sharp audit failure in AI development tests

### DIFF
--- a/test/ai-development/package-lock.json
+++ b/test/ai-development/package-lock.json
@@ -1083,6 +1083,8 @@
 		},
 		"node_modules/@emnapi/runtime": {
 			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1610,163 +1612,6 @@
 				"sharp": "^0.34.5"
 			}
 		},
-		"node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-arm64": {
-			"version": "0.35.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
-			"integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-arm64": "1.3.3"
-			}
-		},
-		"node_modules/@huggingface/transformers/node_modules/@img/sharp-freebsd-wasm32": {
-			"version": "0.35.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
-			"integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"dependencies": {
-				"@img/sharp-wasm32": "0.35.4"
-			},
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-arm64": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
-			"integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@huggingface/transformers/node_modules/@img/sharp-wasm32": {
-			"version": "0.35.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
-			"integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
-			"dev": true,
-			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/runtime": "^1.11.3"
-			},
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@huggingface/transformers/node_modules/@img/sharp-webcontainers-wasm32": {
-			"version": "0.35.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
-			"integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"dependencies": {
-				"@img/sharp-wasm32": "0.35.4"
-			},
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@huggingface/transformers/node_modules/detect-libc": {
-			"version": "2.1.2",
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@huggingface/transformers/node_modules/sharp": {
-			"version": "0.35.4",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
-			"integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"dependencies": {
-				"@img/colour": "^1.1.0",
-				"detect-libc": "^2.1.2",
-				"semver": "^7.8.5"
-			},
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "0.35.4",
-				"@img/sharp-darwin-x64": "0.35.4",
-				"@img/sharp-freebsd-wasm32": "0.35.4",
-				"@img/sharp-libvips-darwin-arm64": "1.3.3",
-				"@img/sharp-libvips-darwin-x64": "1.3.3",
-				"@img/sharp-libvips-linux-arm": "1.3.3",
-				"@img/sharp-libvips-linux-arm64": "1.3.3",
-				"@img/sharp-libvips-linux-ppc64": "1.3.3",
-				"@img/sharp-libvips-linux-riscv64": "1.3.3",
-				"@img/sharp-libvips-linux-s390x": "1.3.3",
-				"@img/sharp-libvips-linux-x64": "1.3.3",
-				"@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
-				"@img/sharp-libvips-linuxmusl-x64": "1.3.3",
-				"@img/sharp-linux-arm": "0.35.4",
-				"@img/sharp-linux-arm64": "0.35.4",
-				"@img/sharp-linux-ppc64": "0.35.4",
-				"@img/sharp-linux-riscv64": "0.35.4",
-				"@img/sharp-linux-s390x": "0.35.4",
-				"@img/sharp-linux-x64": "0.35.4",
-				"@img/sharp-linuxmusl-arm64": "0.35.4",
-				"@img/sharp-linuxmusl-x64": "0.35.4",
-				"@img/sharp-webcontainers-wasm32": "0.35.4",
-				"@img/sharp-win32-arm64": "0.35.4",
-				"@img/sharp-win32-ia32": "0.35.4",
-				"@img/sharp-win32-x64": "0.35.4"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@ibm-cloud/watsonx-ai": {
 			"version": "1.7.16",
 			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.16.tgz",
@@ -1792,7 +1637,9 @@
 			}
 		},
 		"node_modules/@img/sharp-darwin-arm64": {
-			"version": "0.35.3",
+			"version": "0.35.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+			"integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1809,7 +1656,7 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-arm64": "1.3.2"
+				"@img/sharp-libvips-darwin-arm64": "1.3.3"
 			}
 		},
 		"node_modules/@img/sharp-darwin-x64": {
@@ -1836,9 +1683,9 @@
 			}
 		},
 		"node_modules/@img/sharp-freebsd-wasm32": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-			"integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+			"version": "0.35.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+			"integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1846,7 +1693,7 @@
 				"freebsd"
 			],
 			"dependencies": {
-				"@img/sharp-wasm32": "0.35.3"
+				"@img/sharp-wasm32": "0.35.4"
 			},
 			"engines": {
 				"node": ">=20.9.0"
@@ -1856,7 +1703,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-darwin-arm64": {
-			"version": "1.3.2",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+			"integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2208,12 +2057,14 @@
 			}
 		},
 		"node_modules/@img/sharp-wasm32": {
-			"version": "0.35.3",
+			"version": "0.35.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+			"integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
 			"dev": true,
 			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/runtime": "^1.11.1"
+				"@emnapi/runtime": "^1.11.3"
 			},
 			"engines": {
 				"node": ">=20.9.0"
@@ -2223,9 +2074,9 @@
 			}
 		},
 		"node_modules/@img/sharp-webcontainers-wasm32": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-			"integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+			"version": "0.35.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+			"integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
 			"cpu": [
 				"wasm32"
 			],
@@ -2233,7 +2084,7 @@
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@img/sharp-wasm32": "0.35.3"
+				"@img/sharp-wasm32": "0.35.4"
 			},
 			"engines": {
 				"node": ">=20.9.0"
@@ -9683,7 +9534,9 @@
 			"license": "ISC"
 		},
 		"node_modules/sharp": {
-			"version": "0.35.3",
+			"version": "0.35.4",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+			"integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -9699,456 +9552,36 @@
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "0.35.3",
-				"@img/sharp-darwin-x64": "0.35.3",
-				"@img/sharp-freebsd-wasm32": "0.35.3",
-				"@img/sharp-libvips-darwin-arm64": "1.3.2",
-				"@img/sharp-libvips-darwin-x64": "1.3.2",
-				"@img/sharp-libvips-linux-arm": "1.3.2",
-				"@img/sharp-libvips-linux-arm64": "1.3.2",
-				"@img/sharp-libvips-linux-ppc64": "1.3.2",
-				"@img/sharp-libvips-linux-riscv64": "1.3.2",
-				"@img/sharp-libvips-linux-s390x": "1.3.2",
-				"@img/sharp-libvips-linux-x64": "1.3.2",
-				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-				"@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-				"@img/sharp-linux-arm": "0.35.3",
-				"@img/sharp-linux-arm64": "0.35.3",
-				"@img/sharp-linux-ppc64": "0.35.3",
-				"@img/sharp-linux-riscv64": "0.35.3",
-				"@img/sharp-linux-s390x": "0.35.3",
-				"@img/sharp-linux-x64": "0.35.3",
-				"@img/sharp-linuxmusl-arm64": "0.35.3",
-				"@img/sharp-linuxmusl-x64": "0.35.3",
-				"@img/sharp-webcontainers-wasm32": "0.35.3",
-				"@img/sharp-win32-arm64": "0.35.3",
-				"@img/sharp-win32-ia32": "0.35.3",
-				"@img/sharp-win32-x64": "0.35.3"
+				"@img/sharp-darwin-arm64": "0.35.4",
+				"@img/sharp-darwin-x64": "0.35.4",
+				"@img/sharp-freebsd-wasm32": "0.35.4",
+				"@img/sharp-libvips-darwin-arm64": "1.3.3",
+				"@img/sharp-libvips-darwin-x64": "1.3.3",
+				"@img/sharp-libvips-linux-arm": "1.3.3",
+				"@img/sharp-libvips-linux-arm64": "1.3.3",
+				"@img/sharp-libvips-linux-ppc64": "1.3.3",
+				"@img/sharp-libvips-linux-riscv64": "1.3.3",
+				"@img/sharp-libvips-linux-s390x": "1.3.3",
+				"@img/sharp-libvips-linux-x64": "1.3.3",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+				"@img/sharp-linux-arm": "0.35.4",
+				"@img/sharp-linux-arm64": "0.35.4",
+				"@img/sharp-linux-ppc64": "0.35.4",
+				"@img/sharp-linux-riscv64": "0.35.4",
+				"@img/sharp-linux-s390x": "0.35.4",
+				"@img/sharp-linux-x64": "0.35.4",
+				"@img/sharp-linuxmusl-arm64": "0.35.4",
+				"@img/sharp-linuxmusl-x64": "0.35.4",
+				"@img/sharp-webcontainers-wasm32": "0.35.4",
+				"@img/sharp-win32-arm64": "0.35.4",
+				"@img/sharp-win32-ia32": "0.35.4",
+				"@img/sharp-win32-x64": "0.35.4"
 			},
 			"peerDependenciesMeta": {
 				"@types/node": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-darwin-x64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-			"integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-			"integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-			"integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-			"integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linux-ppc64": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-			"integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linux-riscv64": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-			"integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linux-s390x": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-			"integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-			"integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-			"integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-			"integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linux-arm": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-			"integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linux-arm64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-			"integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linux-ppc64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-			"integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-ppc64": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linux-riscv64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-			"integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-riscv64": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linux-s390x": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-			"integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-s390x": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linux-x64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-			"integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linuxmusl-arm64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-			"integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-linuxmusl-x64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-			"integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-x64": "1.3.2"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-win32-arm64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-			"integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-win32-ia32": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-			"integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/sharp/node_modules/@img/sharp-win32-x64": {
-			"version": "0.35.3",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-			"integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 AND LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=20.9.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/sharp/node_modules/detect-libc": {

--- a/test/ai-development/package.json
+++ b/test/ai-development/package.json
@@ -29,9 +29,7 @@
 		"promptfoo": "0.122.1"
 	},
 	"overrides": {
-		"@huggingface/transformers": {
-			"sharp": "0.35.4"
-		},
+		"sharp": "0.35.4",
 		"onnxruntime-node": {
 			"adm-zip": "0.6.0"
 		}


### PR DESCRIPTION
## What

`npm --prefix test/ai-development audit --audit-level=high` fails, so the **AI development tests (Node.js 22 on Linux)** job is red on trunk. Example: [run 34295877003](https://github.com/WordPress/gutenberg/actions/runs/34295877003).

## Why

[GHSA-rgj7-g3m4-5g8c](https://github.com/advisories/GHSA-rgj7-g3m4-5g8c) was published on 8 September and widened the vulnerable `sharp` range to `< 0.35.4`. Nothing in this repository changed; a previously clean version became vulnerable.

`test/ai-development` reaches `sharp` twice:

```
promptfoo
  |
  +-- optionalDependencies: sharp ^0.35.3 --> node_modules/sharp                  0.35.3  <-- flagged
  |
  +-- @huggingface/transformers
        +-- dependencies: sharp ^0.34.5 ---> .../transformers/node_modules/sharp  0.35.4
```

The existing override only covers the second path. That was correct when it was written: the advisory then in force was [GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj) (`< 0.35.0`), which hit the `^0.34.5` copy and left promptfoo's 0.35.3 clean. The new range reaches the copy the override does not.

## How

Move the `sharp` override to the top level so every path resolves to 0.35.4, and regenerate the lockfile. The lockfile shrinks because the duplicated nested `sharp` tree collapses into a single hoisted copy; the only version changes are `sharp` and its platform binaries.

The remaining `adm-zip` and `csv-parse` findings are moderate and stay below the `--audit-level=high` gate. `csv-parse` is already covered by #82619.

## Testing Instructions

In `test/ai-development`, with Node 22.18.0 / npm 10.9.3:

- `npm audit --audit-level=high` — exit 0
- `npm run test:utils` — 28 tests, 0 failures
- `npm run validate` (on Node 24.18.1) — `Configuration is valid.`