### PR TITLE
Inner Blocks: Support legacy inherit-based layouts

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,6 +11,10 @@
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `ListView`: Updated to use `outset-ring__focus()` mixin for focus outline wherever applicable instead of the previous box-shadow implementation. ([#82129](https://github.com/WordPress/gutenberg/pull/82129))
 
+### Bug Fixes
+
+-   `InnerBlocks`: Resolve a container's legacy layout markup (`inherit: true`, or a bare `contentSize` / `wideSize` with no `type`) to a constrained layout for its inner blocks, so they are offered the wide and full alignments. Previously only the container's styles honoured the legacy form, and the inner blocks resolved to the flow layout ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+
 ### Internal
 
 -   Pattern Overrides Dropdown: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#77492](https://github.com/WordPress/gutenberg/pull/77492)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug Fixes
 
--   `InnerBlocks`: Resolve a container's legacy layout markup (`inherit: true`, or a bare `contentSize` / `wideSize` with no `type`) to a constrained layout for its inner blocks, so they are offered the wide and full alignments. Previously only the container's styles honoured the legacy form, and the inner blocks resolved to the flow layout ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+-   `InnerBlocks`: Resolve a container's legacy layout markup (`inherit: true`, or a bare `contentSize` / `wideSize` with no `type`) to a constrained layout for its inner blocks, so they are offered the wide and full alignments. Previously only the container's styles honoured the legacy form, and the inner blocks resolved to the flow layout ([#82637](https://github.com/WordPress/gutenberg/pull/82637)).
 
 ### Internal
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -11,10 +11,6 @@
 -   Borders: rename the "Border & Shadow" panel to "Borders", whichever of its controls are available, and always show the Border and Shadow controls' visible labels. A stable panel title is what lets the Border label render unconditionally, so its "Unlink sides" toggle lines up with the border radius one ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `ListView`: Updated to use `outset-ring__focus()` mixin for focus outline wherever applicable instead of the previous box-shadow implementation. ([#82129](https://github.com/WordPress/gutenberg/pull/82129))
 
-### Bug Fixes
-
--   `InnerBlocks`: Resolve a container's legacy layout markup (`inherit: true`, or a bare `contentSize` / `wideSize` with no `type`) to a constrained layout for its inner blocks, so they are offered the wide and full alignments. Previously only the container's styles honoured the legacy form, and the inner blocks resolved to the flow layout ([#82637](https://github.com/WordPress/gutenberg/pull/82637)).
-
 ### Internal
 
 -   Pattern Overrides Dropdown: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#77492](https://github.com/WordPress/gutenberg/pull/77492)).
@@ -35,6 +31,7 @@
 -   Client-side media processing: Refuse a batch of more than one file when the caller only takes one, such as a Cover block placeholder, matching what the server-side upload path already did. Every dropped file was uploaded instead, and the block kept whichever one finished last ([#82041](https://github.com/WordPress/gutenberg/issues/82041)).
 -   `BlockVariationPicker`: Set icon colors with `color` so stroke-based variation icons retain their intended unfilled appearance, while keeping a non-important `fill` fallback for third-party icons that do not use `currentColor`. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `BlockIcon`, List View: Remove the obsolete `fill: CanvasText` override for forced colors mode. ([#82481](https://github.com/WordPress/gutenberg/pull/82481))
+-   `InnerBlocks`: Resolve a container's legacy layout markup (`inherit: true`, or a bare `contentSize` / `wideSize` with no `type`) to a constrained layout for its inner blocks, so they are offered the wide and full alignments. Previously only the container's styles honoured the legacy form, and the inner blocks resolved to the flow layout ([#82637](https://github.com/WordPress/gutenberg/pull/82637)).
 
 ### Internal
 

--- a/packages/block-editor/src/components/inner-blocks/index.jsx
+++ b/packages/block-editor/src/components/inner-blocks/index.jsx
@@ -18,6 +18,7 @@ import { useBlockEditContext } from '../block-edit/context';
 import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import useBlockDropZone from '../use-block-drop-zone';
+import { normalizeLegacyLayout } from '../../layouts/utils';
 import { unlock } from '../../lock-unlock';
 
 const EMPTY_OBJECT = {};
@@ -94,11 +95,18 @@ function UncontrolledInnerBlocks( props ) {
 		EMPTY_OBJECT;
 
 	const { allowSizingOnChildren = false } = defaultLayoutBlockSupport;
+	// Legacy markup expresses a constrained layout as `inherit: true` or bare
+	// content/wide sizes with no `type`. Promote it the way the layout styling
+	// hooks do, so the inner blocks resolve to constrained rather than flow.
+	const normalizedLayout = useMemo(
+		() => normalizeLegacyLayout( layout ),
+		[ layout ]
+	);
 	// The support is a config object, e.g. `{ allowSwitching: false, default: { type: 'flex' } }`,
 	// so the layout itself lives under `default`. Passing the config through would leave the
 	// context without a `type`, and consumers would resolve it to the flow layout.
 	const usedLayout =
-		layout || defaultLayoutBlockSupport.default || EMPTY_OBJECT;
+		normalizedLayout || defaultLayoutBlockSupport.default || EMPTY_OBJECT;
 
 	const memoedLayout = useMemo(
 		() => ( {

--- a/packages/block-editor/src/layouts/test/utils.js
+++ b/packages/block-editor/src/layouts/test/utils.js
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { appendSelectors, getBlockGapCSS } from '../utils';
+import {
+	appendSelectors,
+	getBlockGapCSS,
+	normalizeLegacyLayout,
+} from '../utils';
 
 const layoutDefinitions = {
 	default: {
@@ -125,5 +129,48 @@ describe( 'appendSelectors', () => {
 		expect(
 			appendSelectors( '.first-selector,.second-selector', '.appended' )
 		).toBe( '.first-selector .appended,.second-selector .appended' );
+	} );
+} );
+
+describe( 'normalizeLegacyLayout', () => {
+	it( 'should promote a layout using the legacy inherit flag to constrained', () => {
+		expect( normalizeLegacyLayout( { inherit: true } ) ).toEqual( {
+			inherit: true,
+			type: 'constrained',
+		} );
+	} );
+
+	it( 'should promote a layout with only a content size to constrained', () => {
+		expect( normalizeLegacyLayout( { contentSize: '600px' } ) ).toEqual( {
+			contentSize: '600px',
+			type: 'constrained',
+		} );
+	} );
+
+	it( 'should promote a layout with only a wide size to constrained', () => {
+		expect( normalizeLegacyLayout( { wideSize: '1200px' } ) ).toEqual( {
+			wideSize: '1200px',
+			type: 'constrained',
+		} );
+	} );
+
+	it( 'should return a typed layout unchanged', () => {
+		const layout = { type: 'flex', orientation: 'vertical' };
+
+		expect( normalizeLegacyLayout( layout ) ).toBe( layout );
+	} );
+
+	it( 'should return an explicitly flow layout unchanged', () => {
+		const layout = { type: 'default' };
+
+		expect( normalizeLegacyLayout( layout ) ).toBe( layout );
+	} );
+
+	it( 'should return an empty or missing layout unchanged', () => {
+		const layout = {};
+
+		expect( normalizeLegacyLayout( layout ) ).toBe( layout );
+		expect( normalizeLegacyLayout( null ) ).toBeNull();
+		expect( normalizeLegacyLayout( undefined ) ).toBeUndefined();
 	} );
 } );

--- a/packages/block-editor/src/layouts/utils.js
+++ b/packages/block-editor/src/layouts/utils.js
@@ -87,3 +87,22 @@ export function getAlignmentsInfo( layout ) {
 	}
 	return alignmentInfo;
 }
+
+/**
+ * Resolves the legacy layout shape to a typed one.
+ *
+ * Before layout types existed, a constrained layout was expressed as
+ * `inherit: true` or as bare `contentSize` / `wideSize` values with no `type`.
+ * Markup saved that way, such as a theme template's Post Content block, is
+ * still around, and consumers that read `type` alone would resolve it to the
+ * flow layout.
+ *
+ * @param {Object} layout The layout object.
+ * @return {Object} The layout, with `type: 'constrained'` set when it was
+ *                  expressed in the legacy form; otherwise the same object.
+ */
+export function normalizeLegacyLayout( layout ) {
+	return layout?.inherit || layout?.contentSize || layout?.wideSize
+		? { ...layout, type: 'constrained' }
+		: layout;
+}


### PR DESCRIPTION
## What?

When inner blocks determines the layout in use, gracefully handle unmigrated old layout attributes that still refer to a constrained layout implicitly via `inherit: true` or the presence of a content or wide size.

This ensure that in older themes that might use legacy markup for the post content block, that alignments are available in the post editor when in template preview mode.

## Why and how

I found this bug while reviewing #82599 on a block theme ([Dark Pastel](https://wordpress.org/themes/dark-pastel/)) that still uses legacy markup for the post content block's layout.

Other options to the fix include: theme authors updating their markup (uhhh... that'd be me in this case 😓), or adding a deprecation to the post content block. However, a) we can't depend on theme authors updating their themes, and b) deprecations don't apply unless someone actually goes to edit the template, which isn't likely to happen all that often for end users just using a theme.

So, I went with what we're doing in other places, where we normalize the provided layout to a type if a type isn't explicitly provided. I've gone with a helper function in this case so that we can test it does the right thing.

## Testing Instructions

* Install and activate ([Dark Pastel](https://wordpress.org/themes/dark-pastel/)) theme, or add `<!-- wp:post-content {"layout":{"inherit":true}} /-->` to a `single.html` template in any block theme
* Go to edit a post and with template preview mode switched off you should be able to access the wide/full alignments on say, an image block at the root of a post
* Switch template preview mode on
* In `trunk` the wide/full alignments won't be available on the image block
* With this PR applied, they should be available

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="3084" height="1936" alt="image" src="https://github.com/user-attachments/assets/07d6bf5b-bab6-4132-a572-b235f55878db" /> | <img width="3080" height="2186" alt="image" src="https://github.com/user-attachments/assets/25a80c1e-9829-4739-b542-ea40a1850d2f" /> |

## Use of AI Tools

Claude Code (Fable 5.1)