### PR TITLE
DataViews: Label clickable grid media by the item title when the title is hidden

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ### Bug Fixes
 
--   Grid layout: when the title is hidden (`showTitle: false`) and items are clickable, label each item's clickable media area with its title instead of the generic "Navigate to item" ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+-   Grid layout: when the title is hidden (`showTitle: false`) and items are clickable, label each item's clickable media area with its title instead of the generic "Navigate to item" ([#82639](https://github.com/WordPress/gutenberg/pull/82639)).
 -   `DataViews` and `DataViewsPicker`: the `table` and `pickerTable` layouts no longer render an empty column for an id in `view.fields` that has no matching field definition, matching what the other layouts already did. The column header menu moves, inserts and hides columns relative to the rendered columns, so a skipped id no longer offsets those operations; such ids are dropped from `view.fields` the next time the menu changes the view ([#82601](https://github.com/WordPress/gutenberg/pull/82601)).
 -   Fix `Field.sort` TypeScript type definition to reflect that `sort` receives extracted field values rather than `Item` objects ([#82162](https://github.com/WordPress/gutenberg/pull/82162)).
 -   DataForm: Render read-only fields without requiring an edit control ([#82514](https://github.com/WordPress/gutenberg/pull/82514)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### Bug Fixes
 
+-   Grid layout: when the title is hidden (`showTitle: false`) and items are clickable, label each item's clickable media area with its title instead of the generic "Navigate to item" ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
 -   `DataViews` and `DataViewsPicker`: the `table` and `pickerTable` layouts no longer render an empty column for an id in `view.fields` that has no matching field definition, matching what the other layouts already did. The column header menu moves, inserts and hides columns relative to the rendered columns, so a skipped id no longer offsets those operations; such ids are dropped from `view.fields` the next time the menu changes the view ([#82601](https://github.com/WordPress/gutenberg/pull/82601)).
 -   Fix `Field.sort` TypeScript type definition to reflect that `sort` receives extracted field values rather than `Item` objects ([#82162](https://github.com/WordPress/gutenberg/pull/82162)).
 -   DataForm: Render read-only fields without requiring an edit control ([#82514](https://github.com/WordPress/gutenberg/pull/82514)).

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -152,8 +152,12 @@ const GridItem = forwardRef< HTMLDivElement, GridItemProps< any > >(
 					id: `dataviews-view-grid__title-field-${ instanceId }`,
 				};
 			} else {
+				// With no visible title to point at, label the clickable media
+				// area with the item's title so it isn't announced generically.
 				mediaA11yProps = {
-					'aria-label': __( 'Navigate to item' ),
+					'aria-label':
+						( titleField && titleField.getValue( { item } ) ) ||
+						__( 'Navigate to item' ),
 				};
 			}
 		}

--- a/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/grid/composite-grid.tsx
@@ -156,8 +156,10 @@ const GridItem = forwardRef< HTMLDivElement, GridItemProps< any > >(
 				// area with the item's title so it isn't announced generically.
 				mediaA11yProps = {
 					'aria-label':
-						( titleField && titleField.getValue( { item } ) ) ||
-						__( 'Navigate to item' ),
+						titleField?.getValueFormatted( {
+							item,
+							field: titleField,
+						} ) || __( 'Navigate to item' ),
 				};
 			}
 		}

--- a/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
+++ b/packages/dataviews/src/dataviews/test/dataviews.jsdom.test.tsx
@@ -892,6 +892,53 @@ describe( 'DataViews component', () => {
 			expect( mediaClickItemCallback ).toHaveBeenCalledWith( data[ 0 ] );
 		} );
 
+		it( 'labels the clickable media area with the title when the title is hidden', () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						type: 'grid',
+						titleField: 'title',
+						mediaField: 'image',
+						showTitle: false,
+					} }
+					isItemClickable={ () => true }
+					onClickItem={ () => {} }
+				/>
+			);
+			for ( const item of data ) {
+				expect(
+					screen.getByRole( 'button', { name: item.title } )
+				).toBeInTheDocument();
+			}
+			expect(
+				screen.queryByRole( 'button', { name: 'Navigate to item' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'labels the clickable media area by the visible title when the title is shown', () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						type: 'grid',
+						titleField: 'title',
+						mediaField: 'image',
+					} }
+					isItemClickable={ () => true }
+					onClickItem={ () => {} }
+				/>
+			);
+			// Both the media area and the title are clickable and share the
+			// name; the media area points at the rendered title
+			// (`aria-labelledby`) rather than carrying a label of its own.
+			const mediaButton = screen
+				.getAllByRole( 'button', { name: data[ 0 ].title } )
+				.find( ( button ) =>
+					button.classList.contains( 'dataviews-view-grid__media' )
+				);
+			expect( mediaButton ).toHaveAttribute( 'aria-labelledby' );
+			expect( mediaButton ).not.toHaveAttribute( 'aria-label' );
+		} );
+
 		it( 'accepts checkbox click for selection', async () => {
 			render(
 				<DataViewWrapper


### PR DESCRIPTION
## What?

In the DataViews Grid layout (when it is clickable), use the title field if available for the `aria-label` even if the title isn't currently rendered. Only fall back to the string `Navigate to item` if no title is available.

## Why?

I'm currently exploring a redesign for the media inserter (the issue https://github.com/WordPress/gutenberg/issues/79729) where I want to compose the DataViews Grid layout for this purpose. In that context, clicking an item doesn't navigate to it, but rather inserts the item, and I'll be rendering the item without the title visible. I think the right label to use will be the title of the image, rather than the fallback.

I've labelled this PR a bug, but it's arguably an enhancement. Happy to change it if need be.

## How?

* We already use the title field for the label when it's rendered, so in this PR, if the title field is available, use it for the `aria-label`. If not, fall back to the existing "'Navigate to item'" string.

## Testing Instructions

We don't actually have any live consumers of this path for now in Gutenberg (but hopefully will soon 😄). But here goes for testing steps:

Check that the tests pass. If you want to test manually you can apply this diff to allow the page title field to be hidden:

```diff
diff --git a/packages/fields/src/fields/page-title/index.ts b/packages/fields/src/fields/page-title/index.ts
index f3d8106698e..d7941492e3b 100644
--- a/packages/fields/src/fields/page-title/index.ts
+++ b/packages/fields/src/fields/page-title/index.ts
@@ -11,7 +11,7 @@ const pageTitleField: Field< BasePost > = {
 	placeholder: __( 'No title' ),
 	getValue: ( { item } ) => getItemTitle( item ),
 	render: PageTitleView,
-	enableHiding: false,
+	enableHiding: true,
 	enableGlobalSearch: true,
 	filterBy: false,
 };
```

Then in the existing (v1) site editor, go to the Pages view and select to show the Grid layout. Then, hide all the fields except for the Featured Image field. If you inspect the markup, you should see that the page title is now the `aria-label` for the clickable item:

## Screenshots or screencast <!-- if applicable -->

<img width="1273" height="845" alt="image" src="https://github.com/user-attachments/assets/89df6730-f515-4de7-a3a4-e77c481213c6" />

## Use of AI Tools

Claude Code (Fable 5.1)