### PR TITLE
Components: Clean up legacy focus/button overrides in Snackbar and Notice

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
 -   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `TabPanel`: Updated to show outline via design system's mixin for focus ring instead of legacy box-shadow implementation ([#82421](https://github.com/WordPress/gutenberg/pull/82421)).
+-   `Snackbar`: Show the action's focus ring with the design system's outline instead of a legacy dotted outline, and let `Button`/`ExternalLink` own the ring ([#82640](https://github.com/WordPress/gutenberg/pull/82640)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Enhancements
 
 -   `CheckboxControl`: Match the `@wordpress/ui` checkmark size and disabled fill ([#82555](https://github.com/WordPress/gutenberg/pull/82555)).
+-   `Snackbar`: Show the action's focus ring with the design system's outline instead of a legacy dotted outline, and let `Button`/`ExternalLink` own the ring ([#82640](https://github.com/WordPress/gutenberg/pull/82640)).
+
+### Internal
+
+-   `Notice`: Remove dismiss button style overrides that now duplicate `Button` defaults, and drop an unused Sass import ([#82640](https://github.com/WordPress/gutenberg/pull/82640)).
 
 ## 40.1.0 (2026-09-10)
 
@@ -17,7 +22,6 @@
 -   `ToolsPanelItem`: Add `defaultShown` to show an optional item that has no value, and an `onShownChange` callback that fires only when the user toggles the item in the panel's menu ([#78010](https://github.com/WordPress/gutenberg/pull/78010)).
 -   `BorderBoxControl`: render the linked/unlinked toggle in a row alongside the label when a visible label is present, so it lines up with the equivalent toggle on sibling controls. Without a visible label the toggle stays beside the inputs, as before. The visible label is now a `BaseControl.VisualLabel`, so it renders as a `span` rather than a `label` element; it was never associated with an input in either form ([#82163](https://github.com/WordPress/gutenberg/pull/82163)).
 -   `TabPanel`: Updated to show outline via design system's mixin for focus ring instead of legacy box-shadow implementation ([#82421](https://github.com/WordPress/gutenberg/pull/82421)).
--   `Snackbar`: Show the action's focus ring with the design system's outline instead of a legacy dotted outline, and let `Button`/`ExternalLink` own the ring ([#82640](https://github.com/WordPress/gutenberg/pull/82640)).
 
 ### Bug Fixes
 

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -1,5 +1,3 @@
-@use "@wordpress/base-styles/variables" as *;
-
 .components-notice {
 	--wp-components-notice-background-color: var(--wpds-color-background-surface-info-weak);
 	--wp-components-notice-border-color: var(--wpds-color-stroke-surface-info);
@@ -70,11 +68,6 @@
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):active,
 	&:not(:disabled):not([aria-disabled="true"]):focus {
 		color: var(--wpds-color-foreground-interactive-neutral-active);
-		background-color: transparent;
-	}
-
-	&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):hover {
-		box-shadow: none;
 	}
 }
 

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -56,11 +56,7 @@
 	margin-left: $grid-unit-40;
 	color: $white;
 	flex-shrink: 0;
-
-	&:focus {
-		box-shadow: none;
-		outline: 1px dotted $white;
-	}
+	--focus-color: #{$white};
 
 	&:hover {
 		text-decoration: none;


### PR DESCRIPTION
## What?
Part of #80138

Removes the custom focus outline on the Snackbar action so it uses the same design system focus ring as other buttons, drawn with the `outset-ring__focus()` mixin. Also removes now-redundant dismiss button overrides from `Notice`, spotted during review.


## Why?
The Snackbar action renders as a link-variant `Button` or an `ExternalLink`. Both already draw the focus ring with `outset-ring__focus()`. The Snackbar stylesheet overrode that with `outline: 1px dotted $white`, plus a `box-shadow: none` that is no longer needed, so the action showed a thin dotted outline instead of the standard ring. 

The `Notice` dismiss button carries dead code: `background-color: transparent` and a hover-only `box-shadow: none` that a variant-less `Button` already covers, plus an unused Sass import.

## How?
**Snackbar**
* Delete the `&:focus` block on `.components-snackbar__action`.
* Set `--focus-color` to white on the action. The Snackbar sits on a dark background where the default focus color does not have enough contrast, and `--focus-color` is the color hook built into the mixin.

**Notice**

* Remove `background-color: transparent` on the dismiss button: the base `.components-button` is `background: none` and adds no background on hover/active/focus for a variant-less button.
* Remove the hover-only `box-shadow: none`: `Button` sets no `box-shadow` on hover.
* Remove the unused `@wordpress/base-styles/variables` import.

## Testing Instructions

1. Run `npm run storybook:dev` and open Components > Feedback > Snackbar.
2. Open the "WithActions" story.
3. Click once inside the canvas, then press Tab until the "Open WP.org" action is focused.
4. Confirm it has a solid focus ring sitting just outside it, matching other buttons. Before this change it was a 1px dotted outline flush against the text.
5. Repeat on the "WithActionAndExplicitDismiss" story.
6. To check the `ExternalLink` variant, edit the `actions` control, add `"openInNewTab": true`, click "Update story", then focus the action again. The ring should look the same.
```
[
  {
    "label": "Open WP.org",
    "url": "https://wordpress.org",
    "openInNewTab": true
  }
]
```
<img width="1171" height="631" alt="Screenshot 2026-09-10 at 4 49 19 PM" src="https://github.com/user-attachments/assets/1f147f00-5c3a-46b7-996b-3e0898467fba" />
7. Turn on a forced-colors theme (DevTools > Rendering > "Emulate CSS media feature forced-colors", or macOS Increase Contrast) and confirm the ring is still visible.

### Testing Instructions for Keyboard
Tab to the Snackbar action and confirm the focus ring is visible and consistent with other focused buttons. Enter still activates the action.

## Screenshots or screencast 

| | Before | After |
|-|-|-|
| Normal |  <img width="613" height="109" alt="Before - Normal" src="https://github.com/user-attachments/assets/0845154a-2ea5-4189-acf4-38b4478d6c9c" /> | <img width="634" height="114" alt="After - Normal" src="https://github.com/user-attachments/assets/2a5e7325-941b-47f1-ab99-e6e4007c8465" /> |
| Windows High Contrast Mode |  <img width="604" height="103" alt="Before - High" src="https://github.com/user-attachments/assets/c8c2e256-09b3-4689-9db4-c2739d0c42c1" />  | <img width="571" height="112" alt="After - High" src="https://github.com/user-attachments/assets/a4f1aa96-c353-4913-ba98-d6087b1e8710" /> |

## Use of AI Tools
This PR was developed with the assistance of Claude Code.
