### PR TITLE
Grid: fix bottomLeft alignment mapping to the bottom left corner

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+-   `Grid`: Fix the `bottomLeft` alignment, which resolved to the top right corner instead of the bottom left one ([#82641](https://github.com/WordPress/gutenberg/pull/82641)).
 -   `ProgressBar`: Remove determinate transitions and use a slower, stepped indeterminate animation when reduced motion is preferred. ([#82490](https://github.com/WordPress/gutenberg/pull/82490))
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))

--- a/packages/components/src/grid/test/grid.jsdom.test.tsx
+++ b/packages/components/src/grid/test/grid.jsdom.test.tsx
@@ -96,6 +96,22 @@ describe( 'props', () => {
 		} );
 	} );
 
+	test( 'should render alignment bottomLeft', () => {
+		render(
+			<Grid alignment="bottomLeft" data-testid="grid">
+				<View />
+				<View />
+				<View />
+			</Grid>
+		);
+
+		expect( screen.getByTestId( 'grid' ) ).toHaveStyle( {
+			display: 'grid',
+			alignItems: 'flex-end',
+			justifyContent: 'flex-start',
+		} );
+	} );
+
 	test( 'should render justify', () => {
 		render(
 			<Grid justify="flex-start" data-testid="grid">

--- a/packages/components/src/grid/utils.ts
+++ b/packages/components/src/grid/utils.ts
@@ -2,7 +2,7 @@ import type { CSSProperties } from 'react';
 
 const ALIGNMENTS = {
 	bottom: { alignItems: 'flex-end', justifyContent: 'center' },
-	bottomLeft: { alignItems: 'flex-start', justifyContent: 'flex-end' },
+	bottomLeft: { alignItems: 'flex-end', justifyContent: 'flex-start' },
 	bottomRight: { alignItems: 'flex-end', justifyContent: 'flex-end' },
 	center: { alignItems: 'center', justifyContent: 'center' },
 	spaced: { alignItems: 'center', justifyContent: 'space-between' },


### PR DESCRIPTION
## What?

Fixes the `bottomLeft` value of `Grid`'s `alignment` prop, which currently aligns content to the top right corner.

## Why?

`packages/components/src/grid/utils.ts` maps each alignment name to `alignItems` and `justifyContent`. The `Grid` container is `display: grid`, so `alignItems` controls the block (vertical) axis and `justifyContent` controls the inline (horizontal) axis. There is no `flex-direction` involved, so the axes are never swapped.

Every other entry in the map follows that: `bottom` is `alignItems: flex-end`, `left` is `justifyContent: flex-start`, `bottomRight` is `alignItems: flex-end` plus `justifyContent: flex-end`, and `topLeft` is `alignItems: flex-start` plus `justifyContent: flex-start`.

`bottomLeft` was the odd one out:

```
bottomLeft: { alignItems: 'flex-start', justifyContent: 'flex-end' },
```

That is top and right. Passing `alignment="bottomLeft"` therefore pushed content to the opposite corner from the one the prop names. `HStack`'s equivalent row direction map already uses the correct pair (`align: 'flex-end', justify: 'flex-start'`), so this was just a typo in the `Grid` copy of the table. I did not find an existing issue for it.

## How?

One line change, swapping the two values so `bottomLeft` resolves to `alignItems: flex-end` and `justifyContent: flex-start`. Nothing else in the repo depended on the old behaviour: no test, story or consumer passes `alignment="bottomLeft"` to `Grid`.

Added a unit test asserting the resolved styles, following the existing `should render alignment spaced` test in the same file.

## Testing Instructions

1. `npm run storybook:dev`
2. Open Components / Grid / Default.
3. In the controls panel set `alignment` to `bottomLeft`. Give the grid some extra height if needed, for example by setting `rows` to 3, so the block axis has room to show the effect.
4. Content should sit in the bottom left of the grid area. Before this patch it sat in the top right.
5. Check `bottomRight`, `topLeft` and `topRight` still land in their named corners.

Unit test:

```
npx jest -c test/unit/jest.config.js packages/components/src/grid/test/grid.jsdom.test.tsx
```

It fails on trunk with the expected `alignItems: flex-end` and `justifyContent: flex-start` reported as missing, and passes with this patch.

### Testing Instructions for Keyboard

`Grid` is a layout primitive with no interactive behaviour, and this patch only changes two CSS property values, so there is nothing keyboard specific to exercise. Tabbing through focusable children inside a `Grid` still follows DOM order, which this patch does not touch.

## Use of AI Tools

Claude Code was used to investigate the issue and draft the patch and its test. I reviewed the change, confirmed the failing and passing test runs locally, and take responsibility for the result.
