### PR TITLE
DataViews: Remove obsolete Node 20 timezone test gate

### DIFF
--- a/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
+++ b/packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx
@@ -31,22 +31,6 @@ const field = normalizeFields< TestItem >( [
 const getMonthGrid = ( monthLabel: string ) =>
 	screen.getByRole( 'grid', { name: monthLabel } );
 
-const supportsOffsetTimeZones = () => {
-	try {
-		new Intl.DateTimeFormat( 'en', { timeZone: '+05:30' } );
-		return true;
-	} catch {
-		return false;
-	}
-};
-
-// Raw offset identifiers are supported by the target browsers and Node 22+.
-// Node 20 cannot mount Calendar with them because its Intl implementation
-// rejects the identifier before the interaction can be tested.
-const describeWithOffsetTimeZones = supportsOffsetTimeZones()
-	? describe
-	: describe.skip;
-
 function DateTimeHarness( { initialValue }: { initialValue: string } ) {
 	const [ data, setData ] = useState< TestItem >( {
 		published: initialValue,
@@ -157,7 +141,7 @@ describe( 'DateTime control', () => {
 		} );
 	}
 
-	describeWithOffsetTimeZones( 'with a manual UTC offset', () => {
+	describe( 'with a manual UTC offset', () => {
 		it( 'should move to the site month after an external value change', () => {
 			setSiteOffset( 14 );
 			const { rerender } = render(
@@ -329,9 +313,7 @@ describe( 'DateTime control', () => {
 			);
 		} );
 
-		// The manual offset reaches Calendar as a raw offset identifier,
-		// which Node 20 rejects — see `supportsOffsetTimeZones`.
-		describeWithOffsetTimeZones( 'on a site with a manual offset', () => {
+		describe( 'on a site with a manual offset', () => {
 			it( 'falls back to the UTC offset', () => {
 				setSiteOffset( 14 );
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/81498.

Related: https://github.com/WordPress/gutenberg/pull/82370 and https://github.com/WordPress/gutenberg/pull/82618.

## What?

Runs the DataViews datetime tests for manual UTC offsets unconditionally.

## Why?

The compatibility check only skipped these tests on Node 20, which rejected raw UTC-offset timezone identifiers. Gutenberg now requires Node 24.18 or newer, where these identifiers are supported. Keeping the check could hide regressions in supported test environments.

## How?

Removes the `supportsOffsetTimeZones` check and uses the standard `describe` function for the manual-offset scenarios. The separate Node 26 compatibility changes from #82618 remain unchanged.

## Testing Instructions

1. Use Node 24.18 or newer.
2. Run `npm run test:unit:vitest -- packages/dataviews/src/components/dataform-controls/test/datetime.jsdom.test.tsx packages/ui/src/calendar/test/localization.jsdom.test.tsx`.
3. Confirm that all 59 tests pass, including the manual UTC-offset and legacy `Intl.Locale` cases.

### Testing Instructions for Keyboard

Not applicable. This is a test-only change.

## Use of AI Tools

Codex was used to investigate the earlier compatibility changes, implement this test cleanup, and run verification.
