### PR TITLE
Modal: keep an accessible name when the header is hidden

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+-   `Modal`: Keep an accessible name on the dialog when `title` is combined with `__experimentalHideHeader`. The heading that `aria-labelledby` referenced is not rendered in that case, so the title is now applied as the dialog's `aria-label` instead ([#82645](https://github.com/WordPress/gutenberg/pull/82645)).
 -   `ProgressBar`: Remove determinate transitions and use a slower, stepped indeterminate animation when reduced motion is preferred. ([#82490](https://github.com/WordPress/gutenberg/pull/82490))
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))

--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -273,7 +273,7 @@ Titles are required for accessibility reasons, see `aria.labelledby` and `conten
 
 #### `__experimentalHideHeader`: `boolean`
 
-When set to `true`, the Modal's header (including the icon, title and close button) will not be rendered.
+When set to `true`, the Modal's header (including the icon, title and close button) will not be rendered. A `title` is then applied to the dialog as its `aria-label`, so the dialog keeps an accessible name.
 
 _Warning_: This property is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -72,7 +72,8 @@ function UnforwardedModal(
 	// The heading that `aria-labelledby` points at lives in the header, so when
 	// the header is hidden the title has to label the dialog directly instead.
 	const dialogLabel =
-		contentLabel ?? ( __experimentalHideHeader ? title : undefined );
+		contentLabel ??
+		( __experimentalHideHeader && title ? title : undefined );
 
 	// The focus hook does not support 'firstContentElement' but this is a valid
 	// value for the Modal's focusOnMount prop. The following code ensures the focus

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -69,6 +69,10 @@ function UnforwardedModal(
 	const headingId = title
 		? `components-modal-header-${ instanceId }`
 		: aria.labelledby;
+	// The heading that `aria-labelledby` points at lives in the header, so when
+	// the header is hidden the title has to label the dialog directly instead.
+	const dialogLabel =
+		contentLabel ?? ( __experimentalHideHeader ? title : undefined );
 
 	// The focus hook does not support 'firstContentElement' but this is a valid
 	// value for the Modal's focusOnMount prop. The following code ensures the focus
@@ -269,8 +273,8 @@ function UnforwardedModal(
 							: null,
 					] ) }
 					role={ role }
-					aria-label={ contentLabel }
-					aria-labelledby={ contentLabel ? undefined : headingId }
+					aria-label={ dialogLabel }
+					aria-labelledby={ dialogLabel ? undefined : headingId }
 					aria-describedby={ aria.describedby }
 					tabIndex={ -1 }
 					onKeyDown={ onKeyDown }

--- a/packages/components/src/modal/test/index.jsdom.test.tsx
+++ b/packages/components/src/modal/test/index.jsdom.test.tsx
@@ -59,6 +59,21 @@ describe( 'Modal', () => {
 		);
 	} );
 
+	it( 'keeps the title as the accessible name when the header is hidden', () => {
+		render(
+			<Modal
+				title="Test Title"
+				__experimentalHideHeader
+				onRequestClose={ noop }
+			>
+				<p>Modal content</p>
+			</Modal>
+		);
+		expect( screen.getByRole( 'dialog' ) ).toHaveAccessibleName(
+			'Test Title'
+		);
+	} );
+
 	it( 'hides the header when the `__experimentalHideHeader` prop is used', () => {
 		render(
 			<Modal

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -145,7 +145,8 @@ export type ModalProps = {
 	title?: string;
 	/**
 	 * When set to `true`, the Modal's header (including the icon, title and
-	 * close button) will not be rendered.
+	 * close button) will not be rendered. A `title` is then applied to the
+	 * dialog as its `aria-label`, so the dialog keeps an accessible name.
 	 *
 	 * _Warning_: This property is still experimental. “Experimental” means this
 	 * is an early implementation subject to drastic and breaking changes.


### PR DESCRIPTION
## What?

See #47885

`Modal` renders the dialog with `aria-labelledby` pointing at the `h1` that carries the `title`. That `h1` lives inside the header, and the header is not rendered at all when `__experimentalHideHeader` is set. So a caller that passes both `title` and `__experimentalHideHeader` gets a dialog whose `aria-labelledby` references an id that is not in the document, which means the dialog has no accessible name.

This PR makes the `title` label the dialog directly in that situation, by applying it as the dialog's `aria-label`.

## Why?

An unnamed dialog is a real accessibility defect. When the modal opens, assistive technology announces the dialog with no name, so the user has no idea what the dialog is for.

It is reachable from current code. `DataViews` renders action modals as:

```jsx
<Modal
	title={ modalHeader || label }
	__experimentalHideHeader={ !! action.hideModalHeader }
	...
>
```

Any action that sets `hideModalHeader` therefore opens a dialog with no accessible name, even though a perfectly good `title` was supplied.

`ConfirmDialog` already works around this in the same package by forwarding `contentLabel={ __experimentalHideHeader ? title : undefined }`. That workaround is exactly the behaviour this PR moves into `Modal`, so every caller benefits instead of only the one that remembered to do it.

Issue #47885 tracks the broader goal of making sure a `Modal` dialog is always labelled, and it lists this specific case. It also asks for a way to require that one of `title` or `contentLabel` is always set, which this PR does not attempt, so I linked the issue with `See` rather than closing it.

## How?

In `packages/components/src/modal/index.tsx`, compute the dialog's `aria-label` from `contentLabel`, falling back to `title` when the header is hidden:

```js
const dialogLabel =
	contentLabel ?? ( __experimentalHideHeader ? title : undefined );
```

and use `dialogLabel` for both `aria-label` and the decision to suppress `aria-labelledby`.

The resulting priority order is `contentLabel`, then `title`, then `aria.labelledby`, which is the order the existing docs and tests already describe. Nothing changes when the header is visible: the `h1` is rendered and `aria-labelledby` still references it. Nothing changes for `ConfirmDialog` either, since `contentLabel` still wins.

I also documented the behaviour on the `__experimentalHideHeader` prop in the README and in `types.ts`.

An alternative fix would be to keep rendering the `h1` and hide it visually, which is what the issue suggests. I did not go that way because the existing unit test asserts that the title text is not in the document when the header is hidden, and because it changes the rendered DOM rather than only the labelling. Happy to switch if the accessibility team prefers that shape.

## Testing Instructions

Automated:

1. `npm run test:unit:vitest -- packages/components/src/modal/test/index.jsdom.test.tsx`
2. The new case is `keeps the title as the accessible name when the header is hidden`. On `trunk` it fails with an empty accessible name. With this patch it passes.

Manual, using Storybook:

1. `npm run storybook:dev`
2. Open `Components / Modal`, and in the controls set a `title` and turn on `__experimentalHideHeader`. Open the modal.
3. Open the browser accessibility inspector. In Chrome DevTools that is Elements, then the Accessibility pane, with the `div[role="dialog"]` selected. In Firefox it is the Accessibility panel.
4. Before this patch the dialog's computed name is empty and `aria-labelledby` points at an id that does not exist. After this patch the dialog's computed name is the `title` text, coming from `aria-label`.
5. Optionally repeat with a screen reader such as VoiceOver or NVDA. Before the patch the dialog is announced with no name. After the patch the title is announced.
6. Sanity check the unchanged paths: a modal with a visible header still takes its name from the visible heading, and `ConfirmDialog`, which hides its header by default, still announces its title.

### Testing Instructions for Keyboard

1. Follow the manual steps above to open a modal that has a `title` and `__experimentalHideHeader`.
2. Press `Tab` repeatedly. Focus stays inside the dialog and cycles through its focusable content, as before.
3. Press `Escape`. The modal closes and focus returns to the element that opened it.
4. With a screen reader running, move focus into the dialog and confirm the dialog name is announced. Keyboard behaviour itself is untouched by this PR, since only labelling attributes changed.

## Use of AI Tools

Claude Code was used to investigate the issue and to draft the patch and its test. I reviewed the change, confirmed the failing and passing test runs locally, and take responsibility for the result.
