### PR TITLE
FormTokenField: wrap to the last suggestion when pressing ArrowUp with nothing selected

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+-   `FormTokenField`: Wrap to the last suggestion when pressing the up arrow with no suggestion selected, instead of leaving the selection on an invalid index ([#82646](https://github.com/WordPress/gutenberg/pull/82646)).
 -   `ProgressBar`: Remove determinate transitions and use a slower, stepped indeterminate animation when reduced motion is preferred. ([#82490](https://github.com/WordPress/gutenberg/pull/82490))
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -399,7 +399,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	function handleUpArrowKey() {
 		setSelectedSuggestionIndex( ( index ) => {
 			return (
-				( index === 0
+				( index <= 0
 					? getMatchingSuggestions(
 							incompleteTokenValue,
 							suggestions,

--- a/packages/components/src/form-token-field/test/index.jsdom.test.tsx
+++ b/packages/components/src/form-token-field/test/index.jsdom.test.tsx
@@ -1031,6 +1031,44 @@ describe( 'FormTokenField', () => {
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
 
+		it( 'should select the last suggestion when pressing the up arrow with no suggestion selected', async () => {
+			const user = userEvent.setup();
+
+			const suggestions = [ 'Pink', 'Salmon', 'Carnation', 'Neon' ];
+
+			render( <FormTokenFieldWithState suggestions={ suggestions } /> );
+
+			const input = screen.getByRole( 'combobox' );
+
+			// Typing "on" will show the "Salmon", "Carnation" and "Neon" suggestions
+			await user.type( input, 'on' );
+
+			const suggestionList = screen.getByRole( 'listbox' );
+
+			expectVisibleSuggestionsToBe( suggestionList, [
+				'Salmon',
+				'Carnation',
+				'Neon',
+			] );
+
+			// Currently, none of the suggestions are selected
+			expect(
+				within( suggestionList ).queryByRole( 'option', {
+					selected: true,
+				} )
+			).not.toBeInTheDocument();
+
+			// Pressing the up arrow from an empty selection wraps to the end of
+			// the list and selects "Neon"
+			await user.keyboard( '[ArrowUp]' );
+
+			expect(
+				within( suggestionList ).getByRole( 'option', {
+					selected: true,
+				} )
+			).toHaveAccessibleName( 'Neon' );
+		} );
+
 		it( 'should allow the user to use the mouse to navigate and select suggestions (which are marked with the `aria-selected` attribute)', async () => {
 			const user = userEvent.setup();
 


### PR DESCRIPTION
## What?

Makes ArrowUp select the last suggestion when the suggestion list is open and nothing is selected yet, instead of moving the selection to an index that does not exist.

## Why?

`selectedSuggestionIndex` starts at `-1` and is reset to `-1` whenever the list collapses. `getSelectedSuggestion` treats `-1` as "nothing is selected":

```js
function getSelectedSuggestion() {
	if ( selectedSuggestionIndex !== -1 ) {
		return getMatchingSuggestions()[ selectedSuggestionIndex ];
	}
	return undefined;
}
```

`handleUpArrowKey` only wrapped to the end of the list when the index was exactly `0`:

```js
( index === 0 ? matchingSuggestions.length : index ) - 1
```

So with nothing selected the up arrow computed `-1 - 1`, which is `-2`. Nothing gets selected, so from the user's point of view the key does nothing. It also leaves the state in a worse place than it started: `-2` is not the `-1` that means "no selection", and because `handleDownArrowKey` uses a modulo, `( -2 + 1 ) % 3` is `-1`, so the next down arrow press also selects nothing and the user has to press it twice to reach the first suggestion.

Reaching the end of a list by pressing up from the start is the normal expectation for this kind of combobox, and it is what the field already does once any suggestion is selected. `handleDownArrowKey` wraps at the other end for free through its modulo, so only the up arrow needed fixing. I searched the tracker and did not find an existing issue for this, so I have not linked one.

## How?

Changed the wrap condition from `index === 0` to `index <= 0`, so both the "first suggestion selected" case and the "nothing selected" case wrap to the last suggestion.

The comparison also makes the no suggestions case slightly better rather than worse: with an empty list the up arrow now leaves the index at `-1` instead of pushing it to `-2`.

Added a unit test for the no selection case, next to the existing keyboard navigation test and using the same `aria-selected` query helper.

## Testing Instructions

1. Open the post editor and expand the Tags panel in the post sidebar, or use any other `FormTokenField`, for example Storybook's Components / FormTokenField / Default with a few suggestions.
2. Click into the field and type enough characters to show at least two suggestions.
3. Without pressing the down arrow first, press the up arrow once.
4. The last suggestion in the list should now be highlighted, and pressing Enter should add it as a token.
5. On trunk, step 3 highlights nothing, and you then have to press the down arrow twice before the first suggestion is highlighted.
6. Check the existing behaviour still holds: down arrow from no selection selects the first suggestion, up arrow from the first suggestion wraps to the last, and down arrow from the last wraps to the first.

Unit test:

```
cd test/unit && ../../node_modules/.bin/vitest run --config vitest.config.mjs --project jsdom packages/components/src/form-token-field
```

The new case fails on trunk with `Unable to find an accessible element with the role "option"` for a selected option, and passes with this patch. The other 76 cases in the file pass either way.

### Testing Instructions for Keyboard

This is a keyboard only fix, so the whole check is keyboard driven.

1. Tab to the tags or token field. Do not click it.
2. Type a search string that matches at least two suggestions and wait for the list to appear.
3. Press ArrowUp once. Focus stays in the text input, and the last suggestion in the list becomes the active option. With a screen reader running you should hear that option announced, and `aria-activedescendant` on the input should point at the last option's id.
4. Press Enter. The last suggestion is added as a token and the list closes.
5. Press ArrowUp again on a fresh empty selection, then Escape. The list closes and the selection resets, and reopening the list starts again with nothing selected.
6. Repeat with ArrowDown as the first key to confirm that path is unchanged: it selects the first suggestion.

## Use of AI Tools

Claude Code was used to investigate the issue and draft the patch and its test. I reviewed the change, confirmed the failing and passing test runs locally, and take responsibility for the result.
