### PR TITLE
Disabled: keep the consumer className when isDisabled is false

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug Fixes
 
+-   `Disabled`: Keep the `className` passed by the consumer on the wrapper when `isDisabled` is `false`. Only `components-disabled` and the disabled styling are conditional now, so the wrapper stays styleable and targetable in both states ([#82648](https://github.com/WordPress/gutenberg/pull/82648)).
 -   `ProgressBar`: Remove determinate transitions and use a slower, stepped indeterminate animation when reduced motion is preferred. ([#82490](https://github.com/WordPress/gutenberg/pull/82490))
 -   `ColorPalette`: Apply the computed contrast color to the selected checkmark now that the icon is stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))
 -   `CheckboxControl`: Color the checked and indeterminate icons with `color` rather than `fill`, so they stay visible now that those icons are stroke-based. ([#78812](https://github.com/WordPress/gutenberg/pull/78812))

--- a/packages/components/src/disabled/index.tsx
+++ b/packages/components/src/disabled/index.tsx
@@ -59,14 +59,14 @@ function Disabled( {
 			<div
 				// @ts-expect-error `inert` is not declared in React 18's HTML attribute types.
 				inert={ isDisabled ? 'true' : undefined }
+				// Only the disabled styling is conditional. The consumer's own
+				// className has to stick around so the wrapper stays targetable
+				// whether or not it is currently disabled.
 				className={
-					isDisabled
-						? clsx(
-								styles.disabled,
-								className,
-								'components-disabled'
-						  )
-						: undefined
+					clsx(
+						className,
+						isDisabled && [ styles.disabled, 'components-disabled' ]
+					) || undefined
 				}
 				{ ...props }
 			>

--- a/packages/components/src/disabled/test/index.jsdom.test.tsx
+++ b/packages/components/src/disabled/test/index.jsdom.test.tsx
@@ -68,6 +68,31 @@ describe( 'Disabled', () => {
 		);
 	} );
 
+	it( 'keeps the consumer className and toggles only the disabled classes', () => {
+		const MaybeDisable = ( { isDisabled = true } ) => (
+			<Disabled
+				isDisabled={ isDisabled }
+				className="my-wrapper"
+				data-testid="disabled-wrapper"
+			>
+				<Form />
+			</Disabled>
+		);
+
+		const { rerender } = render( <MaybeDisable /> );
+
+		const wrapper = screen.getByTestId( 'disabled-wrapper' );
+		expect( wrapper ).toHaveClass( 'my-wrapper' );
+		expect( wrapper ).toHaveClass( 'components-disabled' );
+		expect( wrapper ).toHaveClass( styles.disabled );
+
+		rerender( <MaybeDisable isDisabled={ false } /> );
+
+		expect( wrapper ).toHaveClass( 'my-wrapper' );
+		expect( wrapper ).not.toHaveClass( 'components-disabled' );
+		expect( wrapper ).not.toHaveClass( styles.disabled );
+	} );
+
 	it( 'should preserve input values when toggling the isDisabled prop', async () => {
 		const user = userEvent.setup();
 


### PR DESCRIPTION
## What?

`Disabled` gated its entire `className` expression on `isDisabled`:

```jsx
className={
	isDisabled
		? clsx( styles.disabled, className, 'components-disabled' )
		: undefined
}
```

So passing a `className` alongside `isDisabled={ false }` produced a wrapper `div` with no class attribute at all. The `className` the consumer handed in was simply discarded.

This PR keeps the consumer's `className` on the wrapper in both states, and makes only the disabled specific classes conditional.

## I did not find a matching issue

I searched the issue tracker for this and came up empty, and the instructions I was working from said not to open one, so there is no `Closes` reference here. Happy to file an issue if the project would rather have one on record.

## Why?

A wrapper component that throws away the class you gave it is surprising, and it makes `Disabled` unusable as a stable wrapper. Any CSS or test selector hung off that class silently stops matching the moment the component is enabled, so styling that has nothing to do with the disabled state disappears along with the disabled state.

The intent of the two conditional classes is clear from what they are. `styles.disabled` carries the `pointer-events` and opacity treatment, and `components-disabled` is the public hook consumers style against. Both describe the disabled state, so both belong behind `isDisabled`. The consumer's `className` describes the wrapper itself, so it does not.

I grepped the repo for consumers before changing this. The only in tree usages are `packages/block-library/src/playlist/edit.jsx`, the component's own stories and its own tests, and none of them pass a `className` or depend on the wrapper being classless when enabled. So nothing in tree relies on the current behaviour.

## How?

```js
clsx( className, isDisabled && [ styles.disabled, 'components-disabled' ] ) ||
	undefined;
```

`clsx` ignores the falsy second argument when the component is enabled. The `|| undefined` keeps the previous DOM exactly as it was in the case where there is nothing to apply, so an enabled `Disabled` with no `className` still renders without a class attribute rather than with an empty one.

Note that the class order for the disabled case changes slightly. It was `styles.disabled className components-disabled` and it is now `className styles.disabled components-disabled`. Class attribute order has no bearing on CSS specificity, so this is cosmetic.

## Testing Instructions

1. `npm run test:unit:vitest -- packages/components/src/disabled/test/index.jsdom.test.tsx`
2. The new case is `keeps the consumer className and toggles only the disabled classes`. On `trunk` it fails, because the wrapper's class list is empty once `isDisabled` becomes `false`. With this patch it passes.

To see it by hand:

1. `npm run storybook:dev` and open `Components / Disabled`.
2. Render a `Disabled` with a `className` of your choosing and `isDisabled` set to `true`. Inspect the wrapper `div` and note it carries your class along with `components-disabled` and the disabled style class.
3. Flip `isDisabled` to `false`. Before this patch the wrapper loses every class, your own included. After this patch your class is still there and only `components-disabled` and the disabled style class are gone.
4. Confirm the disabled behaviour itself is unchanged: with `isDisabled` set to `true` the wrapper still has `inert`, descendants are not focusable or clickable, and the greyed out styling still applies.

### Testing Instructions for Keyboard

1. Follow the manual steps above.
2. With `isDisabled` set to `true`, press `Tab` from before the wrapper. Focus skips over everything inside it.
3. Flip `isDisabled` to `false` and press `Tab` again. Focus now enters the wrapper and reaches the fields inside, in document order.
4. Nothing about focus handling changes in this PR, since `inert` was already independent of the class list. This is a regression check only.

## Use of AI Tools

Claude Code was used to investigate the issue and to draft the patch and its test. I reviewed the change, confirmed the failing and passing test runs locally, and take responsibility for the result.
