### PR TITLE
Block editor, Components: Stop relying on Disabled class name

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Internal
 
+-   `BlockPreview`: Stop applying the private `Disabled` component class name to block previews ([#82651](https://github.com/WordPress/gutenberg/pull/82651)).
 -   Pattern Overrides Dropdown: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#77492](https://github.com/WordPress/gutenberg/pull/77492)).
 -   Allowed Blocks Modal: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#78119](https://github.com/WordPress/gutenberg/pull/78119)).
 -   Block Switcher: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` for the bindings hint ([#77366](https://github.com/WordPress/gutenberg/pull/77366)).

--- a/packages/block-editor/src/components/block-preview/index.jsx
+++ b/packages/block-editor/src/components/block-preview/index.jsx
@@ -142,8 +142,7 @@ export function useBlockPreview( { blocks, props = {}, layout } ) {
 		ref,
 		className: clsx(
 			props.className,
-			'block-editor-block-preview__live-content',
-			'components-disabled'
+			'block-editor-block-preview__live-content'
 		),
 		children: blocks?.length ? children : null,
 	};

--- a/packages/block-editor/src/components/block-preview/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-preview/test/index.jsdom.test.jsx
@@ -72,12 +72,10 @@ describe( 'useBlockPreview', () => {
 
 		// Ensure the block preview class names are merged with the component's class name.
 		expect( blockPreviewComponent ).toHaveClass(
-			'block-editor-block-preview__live-content'
+			'block-editor-block-preview__live-content',
+			'test-container-classname',
+			{ exact: true }
 		);
-		expect( blockPreviewComponent ).toHaveClass(
-			'test-container-classname'
-		);
-		expect( blockPreviewComponent ).toHaveClass( 'components-disabled' );
 
 		// Ensure there is no nesting between the parent component and rendered blocks.
 		expect( blockPreviewComponent ).toContainElement( previewedBlock );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Internal
 
+-   `FormToggle`: Use the standard `inert` state instead of the `Disabled` component's class name for inherited disabled styles ([#82651](https://github.com/WordPress/gutenberg/pull/82651)).
 -   Migrate JSX files to TypeScript and remove their ESLint filename suppressions ([#82132](https://github.com/WordPress/gutenberg/pull/82132)).
 -   Use the `.jsx` extension for JavaScript source files that contain JSX ([#80990](https://github.com/WordPress/gutenberg/pull/80990)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -103,7 +103,7 @@ $transition-duration: 0.2s;
 
 	// Disabled state:
 	&.is-disabled,
-	.components-disabled & {
+	[inert] & {
 		.components-form-toggle__track {
 			background-color: $components-color-gray-100;
 			border-color: var(--wpds-color-stroke-interactive-neutral-disabled);


### PR DESCRIPTION
## What?

Stops code outside `Disabled` from relying on its `components-disabled` class name.

## Why?

When `useBlockPreview` was introduced in [#36431](https://github.com/WordPress/gutenberg/pull/36431), it also applied `components-disabled`. Interaction blocking came from `useDisabled`; the class acted as a visual-state marker for selectors elsewhere, including `FormToggle`'s disabled styles and a now-removed block appender rule.

Today, `FormToggle` is the remaining external styling dependency. Keeping that class on `BlockPreview` turns `Disabled`'s internal markup into a cross-package contract.

## How?

Removes the class from `BlockPreview` and uses the standard `[inert]` state for inherited `FormToggle` styles. `Disabled` still emits its legacy class for backward compatibility.

## Testing Instructions

1. Open the `Components/FormToggle` Storybook story.
2. In the story iframe's console, run `document.querySelector( '.components-form-toggle' ).parentElement.setAttribute( 'inert', '' )`.
3. Confirm that the toggle uses its gray disabled styling.
4. Remove the attribute with `document.querySelector( '.components-form-toggle' ).parentElement.removeAttribute( 'inert' )` and confirm that the normal styling returns.
5. Open the editor inserter and hover a block to show its preview. Confirm that the preview remains non-interactive.

## Use of AI Tools

Codex inspected the affected consumers, implemented the change, ran the focused checks, and drafted this description.
