### PR TITLE
Popover storybook: add infotip with link example

### DIFF
--- a/packages/ui/src/popover/stories/index.story.tsx
+++ b/packages/ui/src/popover/stories/index.story.tsx
@@ -5,6 +5,7 @@ import * as Popover from '../';
 import { VisuallyHidden } from '../../visually-hidden';
 import { Icon } from '../../icon';
 import { IconButton } from '../../icon-button';
+import { Link } from '../../link';
 import { GenericIframe, useMeasure } from './utils';
 
 const meta: Meta< typeof Popover.Root > = {
@@ -1228,8 +1229,9 @@ export const HoverTrigger: Story = {
 
 /**
  * Popups that open when hovering an info icon should use Popover with the
- * `openOnHover` prop on the trigger instead of a tooltip. This way, touch
- * users and screen reader users can access the content.
+ * `openOnHover` prop on the trigger instead of a
+ * [tooltip](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-tooltip--docs).
+ * This way, touch users and screen reader users can access the content.
  *
  * To know when to reach for a popover instead of a tooltip, consider the
  * purpose of the trigger element: If the trigger's purpose is to open the
@@ -1275,6 +1277,63 @@ export const Infotip: Story = {
 							This is additional context about the label. Unlike
 							tooltips, this content is accessible to touch and
 							screen reader users.
+						</Popover.Description>
+					</Popover.Popup>
+				</Popover.Root>
+			</div>
+		);
+	},
+};
+
+/**
+ * An infotip popup can contain interactive content, such as a `Link`. The
+ * popup stays open while the pointer moves from the trigger onto the popup
+ * itself, so the link stays reachable — satisfying the "hoverable"
+ * requirement of
+ * [WCAG 1.4.13 Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html).
+ * The link is also reachable by tabbing to it, since the trigger opens on
+ * focus as well as hover.
+ */
+export const InfotipWithLink: Story = {
+	parameters: { controls: { disable: true } },
+	render: function Render( args ) {
+		return (
+			<div
+				style={ {
+					display: 'flex',
+					alignItems: 'center',
+					gap: 'var(--wpds-dimension-gap-xs)',
+				} }
+			>
+				<span>Label</span>
+				<Popover.Root { ...args }>
+					<Popover.Trigger
+						openOnHover
+						delay={ 200 }
+						closeDelay={ 200 }
+						aria-label="More information"
+						style={ {
+							background: 'none',
+							border: 'none',
+							padding: 0,
+							cursor: 'var(--wpds-cursor-control)',
+							display: 'inline-flex',
+							alignItems: 'center',
+							borderRadius: 'var(--wpds-border-radius-sm)',
+						} }
+					>
+						<Icon icon={ info } size={ 20 } />
+					</Popover.Trigger>
+					<Popover.Popup>
+						<Popover.Arrow />
+						<VisuallyHidden render={ <Popover.Title /> }>
+							More information
+						</VisuallyHidden>
+						<Popover.Description>
+							This is additional context about the label.{ ' ' }
+							<Link href="https://wordpress.org" openInNewTab>
+								Read more
+							</Link>
 						</Popover.Description>
 					</Popover.Popup>
 				</Popover.Root>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Infotip With Link: adds a new example showcasing how it's possible to add links, and elaborates on how it's important that it's possible to navigate to the link with the keyboard:

    <img width="982" height="298" alt="image" src="https://github.com/user-attachments/assets/acf99e4f-ccc5-498a-be4f-faa85a3e1aa6" />
- Infotip: link to the "tooltip" component article
- Infotip: explain why infotip triggers must be single-purpose

    Infotip before:

    <img width="1058" height="345" alt="image" src="https://github.com/user-attachments/assets/315a6ac0-5473-42e1-9a3b-cc5973bafe92" />

    Infotip after:

    <img width="974" height="397" alt="image" src="https://github.com/user-attachments/assets/dc5600ff-7736-4b1d-86f9-09d0d0d9bbbb" />



<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Showing to designers and developers what is possible with the componentry.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run `npm run storybook:dev` and see the Popover story.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
