### PR TITLE
Create Block: Test package at supported Node.js versions

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -52,3 +52,49 @@ jobs:
 
             - name: Create block
               run: npm run test:create-block
+
+    packed-package:
+        name: Packed package w/Node.js ${{ matrix.node }}
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        timeout-minutes: 10
+        strategy:
+            fail-fast: false
+            matrix:
+                node: ['minimum', '22.0.0']
+
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Resolve the Node.js version
+              id: node
+              env:
+                  NODE_VERSION: ${{ matrix.node }}
+              run: |
+                  if [ "$NODE_VERSION" = 'minimum' ]; then
+                      NODE_VERSION="$(node --print 'require("./packages/create-block/package.json").engines.node.replace(/^>=/, "")')"
+                  fi
+                  echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
+
+            - name: Use Node.js ${{ steps.node.outputs.version }}
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: ${{ steps.node.outputs.version }}
+
+            - name: Test the packed package
+              working-directory: ${{ runner.temp }}
+              run: |
+                  echo "Node version: $(node --version)"
+                  echo "npm version: $(npm --version)"
+                  npm pack "$GITHUB_WORKSPACE/packages/create-block" --pack-destination "$RUNNER_TEMP"
+                  mkdir create-block-consumer
+                  cd create-block-consumer
+                  npm init --yes
+                  npm install "$RUNNER_TEMP"/wordpress-create-block-*.tgz
+                  npm exec --no -- wp-create-block runtime-floor --no-wp-scripts
+                  test -f runtime-floor/src/runtime-floor/block.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -51378,8 +51378,7 @@
 				"wp-create-block": "index.js"
 			},
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=20.10.0"
 			}
 		},
 		"packages/create-block-interactive-template": {

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   Remove the npm version requirement and add consumer tests for Node.js 20 and 22 ([#82657](https://github.com/WordPress/gutenberg/pull/82657)).
 -   Point the scaffolding output at the generated `env` script (`npm run env start`) instead of `npx wp-env start` ([#82331](https://github.com/WordPress/gutenberg/pull/82331)).
 
 ### Internal

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -18,7 +18,7 @@ $ npm start
 
 The `slug` provided (`todo-list` in the example) defines the folder name for the scaffolded plugin and the internal block name. The WordPress plugin generated must [be installed manually](https://wordpress.org/documentation/article/manage-plugins/#manual-plugin-installation-1).
 
-_(requires `node` version `20.10.0` or above, and `npm` version `10.2.3` or above)_
+_(requires `node` version `20.10.0` or above)_
 
 > [Watch a video introduction to create-block on Learn.wordpress.org](https://learn.wordpress.org/tutorial/using-the-create-block-tool/)
 

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -20,8 +20,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"engines": {
-		"node": ">=20.10.0",
-		"npm": ">=10.2.3"
+		"node": ">=20.10.0"
 	},
 	"files": [
 		"lib"


### PR DESCRIPTION
## What?

Remove `@wordpress/create-block`'s npm engine requirement and test the packed package on Node.js 20.10.0 and 22.0.0. Gutenberg's existing checks continue to cover Node.js 24 and 26.

## Why?

The package still works on Node.js 20.10.0, so its Node.js floor does not need to change. An npm engine can reject valid installations that use pnpm or Yarn, even though Node.js is the runtime requirement.

Gutenberg's own Create Block checks start at Node.js 24. The package therefore needs consumer-level checks for the older Node.js versions it supports.

## How?

Keep the existing Node.js engine and remove the npm engine from the package metadata and documentation. Add a packed-package matrix for the declared minimum and Node.js 22. The minimum comes from `package.json`, Node.js 22 uses an exact version, and each row uses its bundled npm. Existing engine and runtime checks continue to handle versions below the floor.

## Testing Instructions

1. Run `npm run test:create-block`.
2. Confirm the packed-package jobs use Node.js 20.10.0/npm 10.2.3 and Node.js 22.0.0/npm 10.5.1.
3. Confirm both jobs create the `runtime-floor` plugin.

## Use of AI Tools

Codex helped implement and verify this change.
