### PR TITLE
UI: Test Calendar raw-offset timezones directly

### DIFF
--- a/packages/ui/src/calendar/test/calendar.jsdom.test.tsx
+++ b/packages/ui/src/calendar/test/calendar.jsdom.test.tsx
@@ -1113,8 +1113,7 @@ describe( 'Calendar', () => {
 			render(
 				<Calendar
 					defaultValue={ tomorrowAtMidnightInTokyo }
-					// Note: using "Etc/GMT+2" instead of "-02:00" because support for raw offsets was introduced in Node v22 (while currently the repository still targets Node v20).
-					timeZone="Etc/GMT+2"
+					timeZone="-02:00"
 				/>
 			);
 

--- a/packages/ui/src/calendar/test/range-calendar.jsdom.test.tsx
+++ b/packages/ui/src/calendar/test/range-calendar.jsdom.test.tsx
@@ -1598,8 +1598,7 @@ describe( 'RangeCalendar', () => {
 			render(
 				<RangeCalendar
 					defaultValue={ timezoneRange }
-					// Note: using "Etc/GMT+2" instead of "-02:00" because support for raw offsets was introduced in Node v22 (while currently the repository still targets Node v20).
-					timeZone="Etc/GMT+2"
+					timeZone="-02:00"
 				/>
 			);
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/82644.

## What?

Tests Calendar and RangeCalendar with a raw UTC offset.

## Why?

The tests still used the `Etc/GMT+2` alias because Node 20 did not support raw UTC-offset timezone identifiers. Gutenberg now requires Node 24, so the tests can cover the intended `-02:00` path directly.

## How?

Replaces `Etc/GMT+2` with `-02:00` in the two timezone-conversion tests and removes the obsolete Node 20 comments.

## Testing Instructions

1. Use Node 24.18 or newer.
2. Run `npm run test:unit:vitest -- packages/ui/src/calendar/test/calendar.jsdom.test.tsx packages/ui/src/calendar/test/range-calendar.jsdom.test.tsx --testNamePattern='should handle timezoned dates and convert them to the calendar timezone'`.
3. Confirm that both tests pass.

### Testing Instructions for Keyboard

Not applicable. This is a test-only change.

## Use of AI Tools

Codex was used to inspect the earlier Node 20 workaround, make this test cleanup, and run verification.
