### PR TITLE
Test: Update SWC dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14561,9 +14561,9 @@
 			}
 		},
 		"node_modules/@swc/core": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.1.tgz",
-			"integrity": "sha512-nUaeu91O5QZKrQdaDCHd402ogUIoNOOjpkZNq0UomWK0G6gDaGmLhvddF1/3BXf5O8aLyo6ZPY/aMDWvaJQ/hg==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.2.tgz",
+			"integrity": "sha512-95I4kiSMeveI/Mhi+tE4fiWcWLUMfzfKrk0jtr8LRMqHgOgq+xHS+zExkDqoO4b5OeeuXHMWVdD5MeP3X6sULw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -14579,18 +14579,18 @@
 				"url": "https://opencollective.com/swc"
 			},
 			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.16.1",
-				"@swc/core-darwin-x64": "1.16.1",
-				"@swc/core-linux-arm-gnueabihf": "1.16.1",
-				"@swc/core-linux-arm64-gnu": "1.16.1",
-				"@swc/core-linux-arm64-musl": "1.16.1",
-				"@swc/core-linux-ppc64-gnu": "1.16.1",
-				"@swc/core-linux-s390x-gnu": "1.16.1",
-				"@swc/core-linux-x64-gnu": "1.16.1",
-				"@swc/core-linux-x64-musl": "1.16.1",
-				"@swc/core-win32-arm64-msvc": "1.16.1",
-				"@swc/core-win32-ia32-msvc": "1.16.1",
-				"@swc/core-win32-x64-msvc": "1.16.1"
+				"@swc/core-darwin-arm64": "1.16.2",
+				"@swc/core-darwin-x64": "1.16.2",
+				"@swc/core-linux-arm-gnueabihf": "1.16.2",
+				"@swc/core-linux-arm64-gnu": "1.16.2",
+				"@swc/core-linux-arm64-musl": "1.16.2",
+				"@swc/core-linux-ppc64-gnu": "1.16.2",
+				"@swc/core-linux-s390x-gnu": "1.16.2",
+				"@swc/core-linux-x64-gnu": "1.16.2",
+				"@swc/core-linux-x64-musl": "1.16.2",
+				"@swc/core-win32-arm64-msvc": "1.16.2",
+				"@swc/core-win32-ia32-msvc": "1.16.2",
+				"@swc/core-win32-x64-msvc": "1.16.2"
 			},
 			"peerDependencies": {
 				"@swc/helpers": ">=0.5.17"
@@ -14602,9 +14602,9 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.16.1.tgz",
-			"integrity": "sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.16.2.tgz",
+			"integrity": "sha512-i/j0HNbnn79qnTVPicvay92Nark8fW8NQqn1e2mGERjUXNpBV0+SwQxlRpk2zBhn6laJ8PDI6Kn1nHZhnz3LCA==",
 			"cpu": [
 				"arm64"
 			],
@@ -14619,9 +14619,9 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.16.1.tgz",
-			"integrity": "sha512-IN0BmPWb0YAh/17mmlWB/HDBtTw2MfuW4hulf/tQAgTQBRH17l+z499bNJLK6LizSjqs0P7V+jU38Zj+vJC1DA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.16.2.tgz",
+			"integrity": "sha512-HrwqHyEyHVXO3qTk8EkNK7/b6sOZSEoNh+pot6RdE5x0LbNqfo8LtJUvi3UTXr+5ja/o5HbJdW80eCXo+NjbiA==",
 			"cpu": [
 				"x64"
 			],
@@ -14636,9 +14636,9 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.16.1.tgz",
-			"integrity": "sha512-EYgrx2YOCQ2Twz2S793kqNjPkpvYVUPzzR95bIb7by+VQcyaai4lZZ2iz/tZvcFVKSNcN3/JTKwx+aBn2ZL52A==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.16.2.tgz",
+			"integrity": "sha512-MdXi83Z/gGp1LIrg+h7HKxiul/z/Bty/ZJSvYAFqDl9zteC1XLSAZdScquKtXPp50rdyXqritTDCqQBhwVfZKA==",
 			"cpu": [
 				"arm"
 			],
@@ -14653,13 +14653,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.16.1.tgz",
-			"integrity": "sha512-moyKm0YZlHdHohzm1YwgAyesqnE853rO0REMfJLFAova51wF9BNi+3ZW2PeS7Vqvn6HeJuepLpAHbBdZctxpHA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.16.2.tgz",
+			"integrity": "sha512-/jcTmK6Ktz3owM3YtiKvjofV6p3VpHnYzTIrOGwDIOsDigRAAVuZ8east33wYO/7UTdKYFlyHNnJNT0WJqOA3Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14670,13 +14673,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.16.1.tgz",
-			"integrity": "sha512-kKGBO9wdapiSzuf5ZzZ2fYtlu1BNSYtIIUxvH1ir/gcelTOREEHGDCLTDFx/2Knf878nU11A40z7LxwasEFxqA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.16.2.tgz",
+			"integrity": "sha512-4gFarKaFnlJTSlJYKmMhV4u+3YE4uYfiydpBoYjmgQhCf9lAieOq+WilZaK9vVSHeqLuQpTEiGULZqAdsRX5Dw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14687,13 +14693,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-ppc64-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.16.1.tgz",
-			"integrity": "sha512-nZ6qahtLxC3PM54cWOQZHxt4lTCF/3J4LIoWWzz6v7A+rLs8Dx54anYQf7mH3eIi8KlNpgKci/ie8ZSqFN8O7A==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.16.2.tgz",
+			"integrity": "sha512-syqSLGd6KlZ1PciNzs6bIUlhOuFztZufebOHaERjc4N4SqNZxyqYd4I+jj/EfOYnpe0kNjccn9HJLN1p5dz3+w==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14704,13 +14713,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-s390x-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.16.1.tgz",
-			"integrity": "sha512-4ji5PNzhYq193Z4/4xUaSoNJza6iCkDJSzhetrbB6KOYxsr+kxtQr8ePWhMJUiMt6JUWtXaZ1PYT8FhtED+nGA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.16.2.tgz",
+			"integrity": "sha512-ZBBLK+ewGyXLzWeMS7wbKtWBdnif6etn7xvPY/iOfbdsjX/+bgkp1pQt2lWF2wlu2hXYZuhJ/tHZE/QR8/apzg==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14721,13 +14733,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.16.1.tgz",
-			"integrity": "sha512-VJQxqrisHV+B394IgrOu8YsIIXZgffnf5tO+yc9Z/hoUpuZEvuQTjWwlnpZdpyD+0nx6LTD1/3k646JYm43yJA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.16.2.tgz",
+			"integrity": "sha512-LyHJgxCA4Tje0ysBMbEb0tt/ie8kgUKoFE3JAKFhpevmTmhYEoC0H9s47WuDsqiFckF1ITUguZIXJG6K5e0dvg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14738,13 +14753,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.16.1.tgz",
-			"integrity": "sha512-r9oV1mwxxsIGcLV1IQ/tw76MW3doatKze1QFWuC+a7QqJUkhY/bKTSVk6NpKKUGm2LDsE33Va8VqSClfA7vSiQ==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.16.2.tgz",
+			"integrity": "sha512-PghXJlVM1cgtLfNUR1vxFo1z+PDRAe8cWAJlZZ7spmeiN7BospGXg/MHUg7oNSgwSX7Zo//YKv9P5yD9apsFJQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14755,9 +14773,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.16.1.tgz",
-			"integrity": "sha512-6huNRessoBLxWEqBm5zJXyCQ27TO7anvkdiuQ5MDO4CJni0nOXEqKtV9RllQ2TdyENKKsUMXVnIfW2hIXx/R5Q==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.16.2.tgz",
+			"integrity": "sha512-StTOSefYBxemvNYYUI3UmO1a8y+hSPjjfHogC2TEHL+Z1PlEBim/XtLas5rS04jAzT9RrNmbtX911SZ42H9jSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -14772,9 +14790,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.16.1.tgz",
-			"integrity": "sha512-OVKJFUzphrGmsh+BGtcZDesx0YryV7/Yvy5XGgTqnrZfjnyfcr5uaqYQugCckdIlupc5Vs3XtDjRAj12z4ZPlw==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.16.2.tgz",
+			"integrity": "sha512-fycER209DYIzsibpTMC+chND05OfOjgztWL9U8OE6/uUlsOUZH3eh98isBLEnOymYUhlJLEt5++W1+KL/FOh5Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -14789,9 +14807,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.16.1.tgz",
-			"integrity": "sha512-Bt+VIhWYCGk4urklnkkteLUOeLv1VxigwTCeB/xC6rBZxY6IIKdDwCJf6on3E3SUGsIqmQS6QqtuJQc1VxF4Aw==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.16.2.tgz",
+			"integrity": "sha512-cSd1z6ivSrJPVr+moVwOHWjeKy6TpO4/Shwcv5KCrKYXCccxwh4pRy1C3fDioNx2PF1jPZWHKZjtXt+Be9VbaQ==",
 			"cpu": [
 				"x64"
 			],
@@ -14811,6 +14829,16 @@
 			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/@swc/plugin-emotion": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@swc/plugin-emotion/-/plugin-emotion-16.0.0.tgz",
+			"integrity": "sha512-1W9za9u6MidXiVy4a8jiy27RouSRTyhDsn+RSrULQlDXAagbg4z07oOEDmUAJCwCRhlzKSr8AJKYVRn+N0mTLw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@swc/counter": "^0.1.3"
+			}
 		},
 		"node_modules/@swc/types": {
 			"version": "0.1.28",
@@ -55682,7 +55710,7 @@
 				"@emotion/styled": "^11.14.1",
 				"@flakiness/jest": "^1.3.1",
 				"@flakiness/vitest": "^1.9.0",
-				"@swc/plugin-emotion": "^15.0.0",
+				"@swc/plugin-emotion": "^16.0.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@testing-library/user-event": "^14.6.1",
@@ -55713,16 +55741,6 @@
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.11",
 				"yargs": "^17.3.0"
-			}
-		},
-		"test/unit/node_modules/@swc/plugin-emotion": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/@swc/plugin-emotion/-/plugin-emotion-15.0.0.tgz",
-			"integrity": "sha512-B0L0KuItii5XatOskjeFW4kNPXYEDo5JYm+k5Lze3LEY46q4L7foVkXiUFbNn0GjbKJCOv+nU2nM57k4LYLbHw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@swc/counter": "^0.1.3"
 			}
 		},
 		"test/unit/node_modules/@typescript-eslint/parser": {

--- a/test/ai-development/package-lock.json
+++ b/test/ai-development/package-lock.json
@@ -3879,9 +3879,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@swc/core": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.1.tgz",
-			"integrity": "sha512-nUaeu91O5QZKrQdaDCHd402ogUIoNOOjpkZNq0UomWK0G6gDaGmLhvddF1/3BXf5O8aLyo6ZPY/aMDWvaJQ/hg==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.2.tgz",
+			"integrity": "sha512-95I4kiSMeveI/Mhi+tE4fiWcWLUMfzfKrk0jtr8LRMqHgOgq+xHS+zExkDqoO4b5OeeuXHMWVdD5MeP3X6sULw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -3898,18 +3898,18 @@
 				"url": "https://opencollective.com/swc"
 			},
 			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.16.1",
-				"@swc/core-darwin-x64": "1.16.1",
-				"@swc/core-linux-arm-gnueabihf": "1.16.1",
-				"@swc/core-linux-arm64-gnu": "1.16.1",
-				"@swc/core-linux-arm64-musl": "1.16.1",
-				"@swc/core-linux-ppc64-gnu": "1.16.1",
-				"@swc/core-linux-s390x-gnu": "1.16.1",
-				"@swc/core-linux-x64-gnu": "1.16.1",
-				"@swc/core-linux-x64-musl": "1.16.1",
-				"@swc/core-win32-arm64-msvc": "1.16.1",
-				"@swc/core-win32-ia32-msvc": "1.16.1",
-				"@swc/core-win32-x64-msvc": "1.16.1"
+				"@swc/core-darwin-arm64": "1.16.2",
+				"@swc/core-darwin-x64": "1.16.2",
+				"@swc/core-linux-arm-gnueabihf": "1.16.2",
+				"@swc/core-linux-arm64-gnu": "1.16.2",
+				"@swc/core-linux-arm64-musl": "1.16.2",
+				"@swc/core-linux-ppc64-gnu": "1.16.2",
+				"@swc/core-linux-s390x-gnu": "1.16.2",
+				"@swc/core-linux-x64-gnu": "1.16.2",
+				"@swc/core-linux-x64-musl": "1.16.2",
+				"@swc/core-win32-arm64-msvc": "1.16.2",
+				"@swc/core-win32-ia32-msvc": "1.16.2",
+				"@swc/core-win32-x64-msvc": "1.16.2"
 			},
 			"peerDependencies": {
 				"@swc/helpers": ">=0.5.17"
@@ -3921,9 +3921,9 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.16.1.tgz",
-			"integrity": "sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.16.2.tgz",
+			"integrity": "sha512-i/j0HNbnn79qnTVPicvay92Nark8fW8NQqn1e2mGERjUXNpBV0+SwQxlRpk2zBhn6laJ8PDI6Kn1nHZhnz3LCA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3938,9 +3938,9 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.16.1.tgz",
-			"integrity": "sha512-IN0BmPWb0YAh/17mmlWB/HDBtTw2MfuW4hulf/tQAgTQBRH17l+z499bNJLK6LizSjqs0P7V+jU38Zj+vJC1DA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.16.2.tgz",
+			"integrity": "sha512-HrwqHyEyHVXO3qTk8EkNK7/b6sOZSEoNh+pot6RdE5x0LbNqfo8LtJUvi3UTXr+5ja/o5HbJdW80eCXo+NjbiA==",
 			"cpu": [
 				"x64"
 			],
@@ -3955,9 +3955,9 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.16.1.tgz",
-			"integrity": "sha512-EYgrx2YOCQ2Twz2S793kqNjPkpvYVUPzzR95bIb7by+VQcyaai4lZZ2iz/tZvcFVKSNcN3/JTKwx+aBn2ZL52A==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.16.2.tgz",
+			"integrity": "sha512-MdXi83Z/gGp1LIrg+h7HKxiul/z/Bty/ZJSvYAFqDl9zteC1XLSAZdScquKtXPp50rdyXqritTDCqQBhwVfZKA==",
 			"cpu": [
 				"arm"
 			],
@@ -3972,13 +3972,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.16.1.tgz",
-			"integrity": "sha512-moyKm0YZlHdHohzm1YwgAyesqnE853rO0REMfJLFAova51wF9BNi+3ZW2PeS7Vqvn6HeJuepLpAHbBdZctxpHA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.16.2.tgz",
+			"integrity": "sha512-/jcTmK6Ktz3owM3YtiKvjofV6p3VpHnYzTIrOGwDIOsDigRAAVuZ8east33wYO/7UTdKYFlyHNnJNT0WJqOA3Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -3989,13 +3992,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.16.1.tgz",
-			"integrity": "sha512-kKGBO9wdapiSzuf5ZzZ2fYtlu1BNSYtIIUxvH1ir/gcelTOREEHGDCLTDFx/2Knf878nU11A40z7LxwasEFxqA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.16.2.tgz",
+			"integrity": "sha512-4gFarKaFnlJTSlJYKmMhV4u+3YE4uYfiydpBoYjmgQhCf9lAieOq+WilZaK9vVSHeqLuQpTEiGULZqAdsRX5Dw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -4006,13 +4012,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-ppc64-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.16.1.tgz",
-			"integrity": "sha512-nZ6qahtLxC3PM54cWOQZHxt4lTCF/3J4LIoWWzz6v7A+rLs8Dx54anYQf7mH3eIi8KlNpgKci/ie8ZSqFN8O7A==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.16.2.tgz",
+			"integrity": "sha512-syqSLGd6KlZ1PciNzs6bIUlhOuFztZufebOHaERjc4N4SqNZxyqYd4I+jj/EfOYnpe0kNjccn9HJLN1p5dz3+w==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -4023,13 +4032,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-s390x-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.16.1.tgz",
-			"integrity": "sha512-4ji5PNzhYq193Z4/4xUaSoNJza6iCkDJSzhetrbB6KOYxsr+kxtQr8ePWhMJUiMt6JUWtXaZ1PYT8FhtED+nGA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.16.2.tgz",
+			"integrity": "sha512-ZBBLK+ewGyXLzWeMS7wbKtWBdnif6etn7xvPY/iOfbdsjX/+bgkp1pQt2lWF2wlu2hXYZuhJ/tHZE/QR8/apzg==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -4040,13 +4052,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.16.1.tgz",
-			"integrity": "sha512-VJQxqrisHV+B394IgrOu8YsIIXZgffnf5tO+yc9Z/hoUpuZEvuQTjWwlnpZdpyD+0nx6LTD1/3k646JYm43yJA==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.16.2.tgz",
+			"integrity": "sha512-LyHJgxCA4Tje0ysBMbEb0tt/ie8kgUKoFE3JAKFhpevmTmhYEoC0H9s47WuDsqiFckF1ITUguZIXJG6K5e0dvg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -4057,13 +4072,16 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.16.1.tgz",
-			"integrity": "sha512-r9oV1mwxxsIGcLV1IQ/tw76MW3doatKze1QFWuC+a7QqJUkhY/bKTSVk6NpKKUGm2LDsE33Va8VqSClfA7vSiQ==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.16.2.tgz",
+			"integrity": "sha512-PghXJlVM1cgtLfNUR1vxFo1z+PDRAe8cWAJlZZ7spmeiN7BospGXg/MHUg7oNSgwSX7Zo//YKv9P5yD9apsFJQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -4074,9 +4092,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.16.1.tgz",
-			"integrity": "sha512-6huNRessoBLxWEqBm5zJXyCQ27TO7anvkdiuQ5MDO4CJni0nOXEqKtV9RllQ2TdyENKKsUMXVnIfW2hIXx/R5Q==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.16.2.tgz",
+			"integrity": "sha512-StTOSefYBxemvNYYUI3UmO1a8y+hSPjjfHogC2TEHL+Z1PlEBim/XtLas5rS04jAzT9RrNmbtX911SZ42H9jSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4091,9 +4109,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.16.1.tgz",
-			"integrity": "sha512-OVKJFUzphrGmsh+BGtcZDesx0YryV7/Yvy5XGgTqnrZfjnyfcr5uaqYQugCckdIlupc5Vs3XtDjRAj12z4ZPlw==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.16.2.tgz",
+			"integrity": "sha512-fycER209DYIzsibpTMC+chND05OfOjgztWL9U8OE6/uUlsOUZH3eh98isBLEnOymYUhlJLEt5++W1+KL/FOh5Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -4108,9 +4126,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.16.1.tgz",
-			"integrity": "sha512-Bt+VIhWYCGk4urklnkkteLUOeLv1VxigwTCeB/xC6rBZxY6IIKdDwCJf6on3E3SUGsIqmQS6QqtuJQc1VxF4Aw==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.16.2.tgz",
+			"integrity": "sha512-cSd1z6ivSrJPVr+moVwOHWjeKy6TpO4/Shwcv5KCrKYXCccxwh4pRy1C3fDioNx2PF1jPZWHKZjtXt+Be9VbaQ==",
 			"cpu": [
 				"x64"
 			],

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -24,7 +24,7 @@
 		"@emotion/styled": "^11.14.1",
 		"@flakiness/jest": "^1.3.1",
 		"@flakiness/vitest": "^1.9.0",
-		"@swc/plugin-emotion": "^15.0.0",
+		"@swc/plugin-emotion": "^16.0.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## What?

Updates `@swc/core` from 1.16.1 to 1.16.2 in both repository lockfiles and `@swc/plugin-emotion` from 15.0.0 to 16.0.0 in the unit-test workspace.

## Why?

This keeps the Vitest SWC and Emotion compiler path, and the isolated AI-development dependency tree, on the latest stable SWC releases.

## How?

The manifest and lockfiles now resolve the latest stable versions. No code or compiler configuration changes are required.

<details>
<summary>Release review</summary>

### `@swc/core` 1.16.2

The [1.16.2 release notes](https://github.com/swc-project/swc/blob/main/CHANGELOG.md#1162---2026-09-04) contain no breaking changes or deprecations. The release fixes parser, transform, optimizer-cache, TypeScript, decorator, Flow, and minifier correctness issues. Gutenberg receives the applicable correctness fixes without configuration changes.

The new minifier folding is not used by this Vitest configuration. The opt-in TSRX parser feature is exposed through Rust crate features, not the JavaScript bindings used here.

### `@swc/plugin-emotion` 16.0.0

The [16.0.0 release notes](https://github.com/swc-project/plugins/commit/a9a7fe95563fa5f4879e80bd3820fb13075d1f0c) contain one change: rebuilding against `swc_core` 78.0.0. The existing `autoLabel` and `labelFormat` options remain valid.

The repository has no direct `@swc/core` API usage and no SWC patch, override, or local workaround to update or remove. The current Emotion compiler configuration stays unchanged.

</details>

## Testing Instructions

1. Run `npm run test:unit:vitest -- test/unit/config/emotion-compiler.vitest.jsdom.test.jsx`.
2. Confirm that the stable-label regression test passes.
3. Run `npm run build`.

## Use of AI Tools

Codex was used to audit the upstream releases, update the dependencies, and run verification. I reviewed the resulting diff and release conclusions.
