### PR TITLE
Navigation: Allow hiding the submenu arrow when submenus open on click

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.jsx
+++ b/packages/block-library/src/navigation-submenu/edit.jsx
@@ -394,7 +394,7 @@ export default function NavigationSubmenuEdit( {
 						/>
 					) }
 				</ParentElement>
-				{ ( showSubmenuIcon || openSubmenusOnClick ) && (
+				{ showSubmenuIcon && (
 					<span className="wp-block-navigation__submenu-icon">
 						<ItemSubmenuIcon />
 					</span>

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -233,7 +233,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		$html .= '</button>';
 
-		if ( $has_submenu ) {
+		if ( $has_submenu && $show_submenu_indicators ) {
 			$html .= '<span class="wp-block-navigation__submenu-icon">';
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
 				$html .= gutenberg_block_core_shared_navigation_render_submenu_icon();

--- a/packages/block-library/src/navigation/edit/index.jsx
+++ b/packages/block-library/src/navigation/edit/index.jsx
@@ -764,14 +764,16 @@ function Navigation( {
 		{ open: overlayMenuPreview }
 	);
 
-	const submenuAccessibilityNotice =
-		! showSubmenuIcon &&
-		submenuVisibility !== 'click' &&
-		submenuVisibility !== 'always'
-			? __(
-					'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
-			  )
-			: '';
+	let submenuAccessibilityNotice = '';
+	if ( ! showSubmenuIcon && submenuVisibility === 'hover' ) {
+		submenuAccessibilityNotice = __(
+			'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
+		);
+	} else if ( ! showSubmenuIcon && submenuVisibility === 'click' ) {
+		submenuAccessibilityNotice = __(
+			'Hiding the arrow removes the only visual cue that a menu item opens a submenu. Add another indicator to the menu item text so visitors can tell submenus apart from links.'
+		);
+	}
 
 	const isFirstRender = useRef( true ); // Don't speak on first render.
 	useEffect( () => {
@@ -835,11 +837,10 @@ function Navigation( {
 											if ( value === 'always' ) {
 												newAttributes.showSubmenuIcon = false;
 											} else if (
-												value === 'click' ||
 												prevSubmenuVisibility ===
-													'always'
+												'always'
 											) {
-												// When switching to "click" or away from "always", show the arrow
+												// Restore the arrow when switching away from "always", which forces it off.
 												newAttributes.showSubmenuIcon = true;
 											}
 
@@ -873,7 +874,6 @@ function Navigation( {
 										} )
 									}
 									isDisabled={
-										submenuVisibility === 'click' ||
 										submenuVisibility === 'always'
 									}
 									isShownByDefault
@@ -886,7 +886,6 @@ function Navigation( {
 											} );
 										} }
 										disabled={
-											submenuVisibility === 'click' ||
 											submenuVisibility === 'always'
 										}
 										label={ __( 'Show arrow' ) }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -375,12 +375,16 @@ button.wp-block-navigation-item__content {
 }
 
 // When set to open on click, a button element is used.
-// We pad it to include the arrow icon in the clickable area.
-// The padding can be blanket for click, since you can't set click and hide the icon.
+// We pad it to include the arrow icon in the clickable area, but only when the
+// arrow is shown, since the arrow can be hidden while submenus open on click.
 // This is only applied to the submenu in the page list block.
 .wp-block-navigation-item.open-on-click .wp-block-navigation-submenu__toggle {
 	padding-left: 0; // Remove the browser default padding.
-	padding-right: 0.6em + 0.25em; // Same size as icon plus margin.
+	padding-right: 0; // Remove the browser default padding.
+
+	&:has(+ .wp-block-navigation__submenu-icon) {
+		padding-right: 0.6em + 0.25em;
+	}
 
 	+ .wp-block-navigation__submenu-icon {
 		margin-left: -0.6em;

--- a/packages/block-library/src/page-list-item/edit.jsx
+++ b/packages/block-library/src/page-list-item/edit.jsx
@@ -71,9 +71,11 @@ export default function PageListItemEdit( { context, attributes } ) {
 							__html: safeHTML( label ),
 						} }
 					/>
-					<span className="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon">
-						<ItemSubmenuIcon />
-					</span>
+					{ context.showSubmenuIcon && (
+						<span className="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon">
+							<ItemSubmenuIcon />
+						</span>
+					) }
 				</>
 			) : (
 				<a

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -200,8 +200,10 @@ function block_core_page_list_render_nested_page_list( $submenu_visibility, $sho
 		$markup .= '<li class="wp-block-pages-list__item' . esc_attr( $css_class ) . '"' . $style_attribute . '>';
 
 		if ( isset( $page['children'] ) && $is_navigation_child && $open_on_click ) {
-			$markup .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="' . esc_attr( $navigation_child_content_class ) . ' wp-block-navigation-submenu__toggle" aria-expanded="false">' . wp_kses_post( $title ) .
-			'</button><span class="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
+			$markup .= '<button aria-label="' . esc_attr( $aria_label ) . '" class="' . esc_attr( $navigation_child_content_class ) . ' wp-block-navigation-submenu__toggle" aria-expanded="false">' . wp_kses_post( $title ) . '</button>';
+			if ( $show_submenu_icons ) {
+				$markup .= '<span class="wp-block-page-list__submenu-icon wp-block-navigation__submenu-icon"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg></span>';
+			}
 		} else {
 			$markup .= '<a class="wp-block-pages-list__item__link' . esc_attr( $navigation_child_content_class ) . '" href="' . esc_url( $page['link'] ) . '"' . $aria_current . '>' . wp_kses_post( $title ) . '</a>';
 		}

--- a/phpunit/blocks/render-block-navigation-submenu-test.php
+++ b/phpunit/blocks/render-block-navigation-submenu-test.php
@@ -276,4 +276,44 @@ class Render_Block_Navigation_Submenu_Test extends WP_UnitTestCase {
 			'Submenu should not have "open-on-hover-click" class when legacy openSubmenusOnClick was true'
 		);
 	}
+
+	/**
+	 * Test that the submenu arrow follows the showSubmenuIcon attribute when
+	 * submenus open on click.
+	 *
+	 * @group submenu-icon
+	 * @covers ::gutenberg_render_block_core_navigation_submenu
+	 */
+	public function test_should_respect_show_submenu_icon_when_submenus_open_on_click() {
+		$page_id = self::$page->ID;
+
+		$markup = '<!-- wp:navigation {"submenuVisibility":"click","showSubmenuIcon":%s,"overlayMenu":"never"} -->
+<!-- wp:navigation-submenu {"label":"Submenu Label","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} -->
+<!-- wp:navigation-link {"label":"Submenu Item","type":"page","id":' . $page_id . ',"url":"http://localhost:8888/?page_id=' . $page_id . '","kind":"post-type"} /-->
+<!-- /wp:navigation-submenu -->
+<!-- /wp:navigation -->';
+
+		$with_icon = do_blocks( sprintf( $markup, 'true' ) );
+
+		$this->assertStringContainsString(
+			'wp-block-navigation__submenu-icon',
+			$with_icon,
+			'Submenu should render the arrow when opening on click with "showSubmenuIcon" enabled'
+		);
+
+		$without_icon = do_blocks( sprintf( $markup, 'false' ) );
+
+		$this->assertStringNotContainsString(
+			'wp-block-navigation__submenu-icon',
+			$without_icon,
+			'Submenu should not render the arrow when opening on click with "showSubmenuIcon" disabled'
+		);
+
+		// The submenu must remain openable on click without the arrow.
+		$this->assertStringContainsString(
+			'wp-block-navigation-submenu__toggle',
+			$without_icon,
+			'Submenu should still render the click toggle when the arrow is hidden'
+		);
+	}
 }


### PR DESCRIPTION
## What?
Closes #75701

Unlocks the "Show arrow" toggle when Submenu Visibility is set to **Click**, and shows an accessibility notice, styled and announced the same way as the existing Hover notice, when the arrow is turned off in that mode.

Nothing changes for **Hover**. The toggle stays disabled for **Always**, where the arrow is forced off because the formatting breaks with center alignment.

## Testing Instructions
1. In the Site Editor, edit a template containing a Navigation block (or insert one) and add a submenu with at least one child item.
2. Select the Navigation block and open the **Display** panel in the sidebar.
3. Set **Submenu Visibility** to **Click**.
4. Confirm **Show arrow** is now enabled rather than greyed out.
5. Turn **Show arrow** off. Confirm:
   - The arrow disappears from the submenu item in the canvas.
   - A warning notice appears below the controls, matching the styling of the notice shown for Hover + no arrow.
   - The menu item label has no leftover gap where the arrow used to be.
6. Click the submenu item in the canvas and on the front end, the submenu still opens.
7. Save and view the front end. Confirm the arrow is gone and the submenu still opens on click.
8. Set **Submenu Visibility** back to **Hover**. Confirm the Hover behaviour and its notice are unchanged, and that your "Show arrow" choice is preserved across the switch.
9. Set **Submenu Visibility** to **Always** (vertical orientation). Confirm **Show arrow** is still disabled and the arrow is off.
10. Repeat steps 3–7 with a **Page List** block inside the Navigation block that has child pages.
11. Open an existing site whose Navigation block already uses click-to-open. Confirm the arrow still shows the default for `showSubmenuIcon` is unchanged, so nothing regresses for existing content.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/85507cdc-855c-4f91-aded-608b7fb20ebf

## Use of AI Tools
This PR was helped with Claude Opus 5.