### PR TITLE
Navigation Overlay Close: Underline text on hover

### DIFF
--- a/packages/block-library/src/navigation-overlay-close/style.scss
+++ b/packages/block-library/src/navigation-overlay-close/style.scss
@@ -23,6 +23,10 @@
 	cursor: pointer;
 	text-decoration: none;
 
+	&:hover .wp-block-navigation-overlay-close__text {
+		text-decoration: underline;
+	}
+
 	&:focus {
 		outline-offset: 2px;
 	}
@@ -40,4 +44,3 @@
 		align-items: center;
 	}
 }
-


### PR DESCRIPTION
## What?

Closes #82655

Adds hover feedback to the Navigation Overlay Close block by underlining its text label.

## Why?

The Navigation Overlay Close block removes the browser's default button styling but does not provide a hover state. As a result, the text label gives no visual feedback when a pointer is placed over the control.

## How?

Adds a scoped `:hover` rule to the Navigation Overlay Close block styles. The implementation follows the existing hover treatment used by the Accordion Heading block.

## Use of AI Tools

ChatGPT Codex using GPT-5.6 Sol with light reasoning was used to help identify the relevant code path.