### PR TITLE
Editor: Describe the post title in the sidebar instead of "No block selected"

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -74,6 +74,7 @@ import {
 import { LinkPicker } from './components/link-picker';
 import useRemoteUrlData from './components/link-control/use-rich-url-data';
 import { PrivateBlockContext } from './components/block-list/private-block-context';
+import BlockCard from './components/block-card';
 import useListViewPanelState from './components/use-list-view-panel-state';
 import InnerContent from './components/inner-content';
 import { useNativeUndo, usesNativeUndo } from './utils/native-undo';
@@ -161,4 +162,5 @@ lock( privateApis, {
 	useNativeUndo,
 	usesNativeUndo,
 	isElementVisible,
+	BlockCard,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -75,6 +75,7 @@ import { LinkPicker } from './components/link-picker';
 import useRemoteUrlData from './components/link-control/use-rich-url-data';
 import { PrivateBlockContext } from './components/block-list/private-block-context';
 import BlockCard from './components/block-card';
+import { BlockInspectorPreTabsFill } from './components/block-inspector/inspector-pre-tabs-slot-fill';
 import useListViewPanelState from './components/use-list-view-panel-state';
 import InnerContent from './components/inner-content';
 import { useNativeUndo, usesNativeUndo } from './utils/native-undo';
@@ -163,4 +164,5 @@ lock( privateApis, {
 	usesNativeUndo,
 	isElementVisible,
 	BlockCard,
+	BlockInspectorPreTabsFill,
 } );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Enhancements
 
--   Sidebar: Describe the post title while it has focus, instead of reporting that no block is selected. The panel names the template its appearance comes from and offers to edit it ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
+-   Sidebar: Describe the post title in the Block tab, instead of reporting that no block is selected. The panel names the template its appearance comes from and offers to edit it ([#82673](https://github.com/WordPress/gutenberg/pull/82673)).
 -   Media Library modal: Pass the current post and its post type to the modal so its "Attached to" filter can offer media uploaded to that post, under the post type's own wording. Only a viewable post type is passed on: a template has no front end of its own, so media can't be uploaded to one ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
 -   Post actions: Append an ellipsis (`…`) to the "Set as homepage" and "Set as posts page" action labels, which open a confirmation dialog, following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 -   Show a "Privacy Policy Page" badge in the document bar and the post card panel for the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Enhancements
 
+-   Sidebar: Describe the post title while it has focus, instead of reporting that no block is selected. The panel names the template its appearance comes from and offers to edit it ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX)).
 -   Media Library modal: Pass the current post and its post type to the modal so its "Attached to" filter can offer media uploaded to that post, under the post type's own wording. Only a viewable post type is passed on: a template has no front end of its own, so media can't be uploaded to one ([#81974](https://github.com/WordPress/gutenberg/pull/81974)).
 -   Post actions: Append an ellipsis (`…`) to the "Set as homepage" and "Set as posts page" action labels, which open a confirmation dialog, following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 -   Show a "Privacy Policy Page" badge in the document bar and the post card panel for the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).

--- a/packages/editor/src/components/post-title/index.jsx
+++ b/packages/editor/src/components/post-title/index.jsx
@@ -16,6 +16,7 @@ import { DEFAULT_CLASSNAMES, REGEXP_NEWLINES } from './constants';
 import usePostTitleFocus from './use-post-title-focus';
 import usePostTitle from './use-post-title';
 import PostTypeSupportCheck from '../post-type-support-check';
+import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { useRichText } = unlock( richTextPrivateApis );
@@ -47,6 +48,7 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 
 	const { clearSelectedBlock, insertBlocks, insertDefaultBlock } =
 		useDispatch( blockEditorStore );
+	const { setIsEditingPostTitle } = unlock( useDispatch( editorStore ) );
 
 	const decodedPlaceholder =
 		decodeEntities( placeholder ) || __( 'Add title' );
@@ -84,6 +86,16 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 
 	function onSelect() {
 		setIsSelected( true );
+		/*
+		 * Clearing the block selection leaves nothing for the sidebar to
+		 * describe, so record that the title is what is being edited.
+		 *
+		 * This is deliberately not cleared on blur. Opening the sidebar's Block
+		 * tab moves focus out of the title, so a blur would unset this before
+		 * the tab it feeds could render. Selecting a block is what supersedes
+		 * it, and the sidebar already checks for that.
+		 */
+		setIsEditingPostTitle( true );
 		clearSelectedBlock();
 	}
 

--- a/packages/editor/src/components/sidebar/index.jsx
+++ b/packages/editor/src/components/sidebar/index.jsx
@@ -15,6 +15,7 @@ import PostSummary from './post-summary';
 import DataFormPostSummary from './dataform-post-summary';
 import PostRevisionSummary from './post-revision-summary';
 import PostTitleInspector from './post-title-inspector';
+import TemplateBlockScope from './template-block-scope';
 import PostTaxonomiesPanel from '../post-taxonomies/panel';
 import PostTransformPanel from '../post-transform-panel';
 import SidebarHeader from './header';
@@ -130,7 +131,10 @@ function Sidebar( { extraPanels, onActionPerformed } ) {
 				{ isDescribingPostTitle ? (
 					<PostTitleInspector />
 				) : (
-					<BlockInspector />
+					<>
+						<BlockInspector />
+						<TemplateBlockScope />
+					</>
 				) }
 				{ isRevisionsMode && <RevisionBlockDiffPanel /> }
 			</Tabs.Panel>

--- a/packages/editor/src/components/sidebar/index.jsx
+++ b/packages/editor/src/components/sidebar/index.jsx
@@ -14,6 +14,7 @@ import PluginSidebar from '../plugin-sidebar';
 import PostSummary from './post-summary';
 import DataFormPostSummary from './dataform-post-summary';
 import PostRevisionSummary from './post-revision-summary';
+import PostTitleInspector from './post-title-inspector';
 import PostTaxonomiesPanel from '../post-taxonomies/panel';
 import PostTransformPanel from '../post-transform-panel';
 import SidebarHeader from './header';
@@ -31,35 +32,43 @@ const SIDEBAR_ACTIVE_BY_DEFAULT = true;
 function Sidebar( { extraPanels, onActionPerformed } ) {
 	useAutoSwitchEditorSidebars();
 
-	const { tabName, keyboardShortcut, isRevisionsMode } = useSelect(
-		( select ) => {
-			const shortcut = select(
-				keyboardShortcutsStore
-			).getShortcutRepresentation( 'core/editor/toggle-sidebar' );
+	const {
+		tabName,
+		keyboardShortcut,
+		isRevisionsMode,
+		isDescribingPostTitle,
+	} = useSelect( ( select ) => {
+		const shortcut = select(
+			keyboardShortcutsStore
+		).getShortcutRepresentation( 'core/editor/toggle-sidebar' );
 
-			const sidebar =
-				select( interfaceStore ).getActiveComplementaryArea( 'core' );
-			const _isEditorSidebarOpened = [
-				sidebars.block,
-				sidebars.document,
-			].includes( sidebar );
-			let _tabName = sidebar;
-			if ( ! _isEditorSidebarOpened ) {
-				_tabName = select( blockEditorStore ).getBlockSelectionStart()
-					? sidebars.block
-					: sidebars.document;
-			}
+		const sidebar =
+			select( interfaceStore ).getActiveComplementaryArea( 'core' );
+		const _isEditorSidebarOpened = [
+			sidebars.block,
+			sidebars.document,
+		].includes( sidebar );
+		let _tabName = sidebar;
+		if ( ! _isEditorSidebarOpened ) {
+			_tabName = select( blockEditorStore ).getBlockSelectionStart()
+				? sidebars.block
+				: sidebars.document;
+		}
 
-			return {
-				tabName: _tabName,
-				keyboardShortcut: shortcut,
-				isRevisionsMode: unlock(
-					select( editorStore )
-				).isRevisionsMode(),
-			};
-		},
-		[]
-	);
+		return {
+			tabName: _tabName,
+			keyboardShortcut: shortcut,
+			isRevisionsMode: unlock( select( editorStore ) ).isRevisionsMode(),
+			/*
+			 * The title is not a block, so it never reaches the block
+			 * inspector. While it has focus the block tab describes it
+			 * instead of reporting that nothing is selected.
+			 */
+			isDescribingPostTitle:
+				unlock( select( editorStore ) ).isEditingPostTitle() &&
+				! select( blockEditorStore ).getBlockSelectionStart(),
+		};
+	}, [] );
 
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
@@ -118,7 +127,11 @@ function Sidebar( { extraPanels, onActionPerformed } ) {
 				{ tabContent }
 			</Tabs.Panel>
 			<Tabs.Panel value={ sidebars.block } tabIndex={ -1 }>
-				<BlockInspector />
+				{ isDescribingPostTitle ? (
+					<PostTitleInspector />
+				) : (
+					<BlockInspector />
+				) }
 				{ isRevisionsMode && <RevisionBlockDiffPanel /> }
 			</Tabs.Panel>
 		</PluginSidebar>

--- a/packages/editor/src/components/sidebar/post-title-inspector.tsx
+++ b/packages/editor/src/components/sidebar/post-title-inspector.tsx
@@ -1,0 +1,127 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { getBlockType } from '@wordpress/blocks';
+import { Notice } from '@wordpress/components';
+import { Stack } from '@wordpress/ui';
+import { useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+// @ts-expect-error No exported types
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import { store as editorStore } from '../../store';
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
+import { unlock } from '../../lock-unlock';
+
+const { BlockCard } = unlock( blockEditorPrivateApis );
+
+const POST_TITLE_BLOCK = 'core/post-title';
+
+/**
+ * Describes the post title while it has focus.
+ *
+ * With the template hidden the title is editor chrome rather than a block, so
+ * there is nothing for the block inspector to select and it reports that
+ * nothing is. The text itself belongs to the post and is edited in place; only
+ * its appearance comes from the template, which is what this explains.
+ *
+ * @return The rendered panel.
+ */
+export default function PostTitleInspector() {
+	const { templateId, onNavigateToEntityRecord, canEditTemplate } = useSelect(
+		( select ) => {
+			const { getCurrentTemplateId, getEditorSettings } = select(
+				editorStore
+			) as {
+				getCurrentTemplateId: () => string | undefined;
+				getEditorSettings: () => {
+					onNavigateToEntityRecord?: ( args: {
+						postId: string;
+						postType: string;
+					} ) => void;
+				};
+			};
+			const { canUser } = select( coreStore );
+
+			return {
+				templateId: getCurrentTemplateId(),
+				onNavigateToEntityRecord:
+					getEditorSettings().onNavigateToEntityRecord,
+				canEditTemplate: !! canUser( 'create', {
+					kind: 'postType',
+					name: TEMPLATE_POST_TYPE,
+				} ),
+			};
+		},
+		[]
+	);
+
+	// Nothing to fetch until the post resolves which template it uses.
+	const { editedRecord: template } = useEntityRecord< { title?: string } >(
+		'postType',
+		TEMPLATE_POST_TYPE,
+		templateId ?? '',
+		{ enabled: !! templateId }
+	);
+
+	const blockType = getBlockType( POST_TITLE_BLOCK );
+
+	if ( ! blockType ) {
+		return null;
+	}
+
+	const templateTitle = template?.title
+		? decodeEntities( template.title )
+		: undefined;
+
+	/*
+	 * Without a template to name there is nothing useful to say about where the
+	 * title's appearance comes from, so only the card is shown.
+	 */
+	const canExplain = !! templateTitle && canEditTemplate;
+
+	return (
+		<Stack direction="column" gap="md">
+			<BlockCard
+				title={ blockType.title }
+				icon={ blockType.icon }
+				description={ blockType.description }
+			/>
+			{ canExplain && (
+				<Notice
+					status="info"
+					isDismissible={ false }
+					className="editor-post-title-inspector__notice"
+					actions={
+						onNavigateToEntityRecord
+							? [
+									{
+										label: sprintf(
+											// translators: %s: name of the template, e.g. "Pages".
+											__( 'Edit %s template' ),
+											templateTitle
+										),
+										onClick: () =>
+											onNavigateToEntityRecord( {
+												postId: templateId as string,
+												postType: TEMPLATE_POST_TYPE,
+											} ),
+										variant: 'secondary',
+									},
+							  ]
+							: []
+					}
+				>
+					<p>
+						<strong>
+							{ __( 'This block comes from the template' ) }
+						</strong>
+					</p>
+					<p>
+						{ __(
+							'Changes to its settings affect all posts and pages that use the template.'
+						) }
+					</p>
+				</Notice>
+			) }
+		</Stack>
+	);
+}

--- a/packages/editor/src/components/sidebar/post-title-inspector.tsx
+++ b/packages/editor/src/components/sidebar/post-title-inspector.tsx
@@ -6,12 +6,16 @@ import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 // @ts-expect-error No exported types
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import { unlock } from '../../lock-unlock';
 
 const { BlockCard } = unlock( blockEditorPrivateApis );
+const { getTemplateInfo } = unlock( coreDataPrivateApis );
 
 const POST_TITLE_BLOCK = 'core/post-title';
 
@@ -26,41 +30,60 @@ const POST_TITLE_BLOCK = 'core/post-title';
  * @return The rendered panel.
  */
 export default function PostTitleInspector() {
-	const { templateId, onNavigateToEntityRecord, canEditTemplate } = useSelect(
-		( select ) => {
-			const { getCurrentTemplateId, getEditorSettings } = select(
-				editorStore
-			) as {
-				getCurrentTemplateId: () => string | undefined;
-				getEditorSettings: () => {
-					onNavigateToEntityRecord?: ( args: {
-						postId: string;
-						postType: string;
-					} ) => void;
-				};
+	const {
+		templateId,
+		templateTitle,
+		onNavigateToEntityRecord,
+		canEditTemplate,
+	} = useSelect( ( select ) => {
+		const { getCurrentTemplateId, getEditorSettings } = select(
+			editorStore
+		) as {
+			getCurrentTemplateId: () => string | undefined;
+			getEditorSettings: () => {
+				onNavigateToEntityRecord?: ( args: {
+					postId: string;
+					postType: string;
+				} ) => void;
 			};
-			const { canUser } = select( coreStore );
+		};
+		const { canUser, getEntityRecord, getCurrentTheme } =
+			select( coreStore );
+		const currentTemplateId = getCurrentTemplateId();
 
-			return {
-				templateId: getCurrentTemplateId(),
-				onNavigateToEntityRecord:
-					getEditorSettings().onNavigateToEntityRecord,
-				canEditTemplate: !! canUser( 'create', {
-					kind: 'postType',
-					name: TEMPLATE_POST_TYPE,
-				} ),
-			};
-		},
-		[]
-	);
+		/*
+		 * A template's own title is empty, or just its slug, until someone
+		 * renames it. `getTemplateInfo` falls back to the name the theme
+		 * gives it — "Pages", "Single Posts" — which is what the rest of
+		 * the editor shows.
+		 */
+		const templateInfo = currentTemplateId
+			? getTemplateInfo( {
+					templateTypes:
+						(
+							getCurrentTheme() as
+								| { default_template_types?: unknown[] }
+								| undefined
+						 )?.default_template_types ?? [],
+					template: getEntityRecord(
+						'postType',
+						TEMPLATE_POST_TYPE,
+						currentTemplateId
+					),
+			  } )
+			: undefined;
 
-	// Nothing to fetch until the post resolves which template it uses.
-	const { editedRecord: template } = useEntityRecord< { title?: string } >(
-		'postType',
-		TEMPLATE_POST_TYPE,
-		templateId ?? '',
-		{ enabled: !! templateId }
-	);
+		return {
+			templateId: currentTemplateId,
+			templateTitle: templateInfo?.title as string | undefined,
+			onNavigateToEntityRecord:
+				getEditorSettings().onNavigateToEntityRecord,
+			canEditTemplate: !! canUser( 'create', {
+				kind: 'postType',
+				name: TEMPLATE_POST_TYPE,
+			} ),
+		};
+	}, [] );
 
 	const blockType = getBlockType( POST_TITLE_BLOCK );
 
@@ -68,15 +91,13 @@ export default function PostTitleInspector() {
 		return null;
 	}
 
-	const templateTitle = template?.title
-		? decodeEntities( template.title )
-		: undefined;
+	const title = templateTitle ? decodeEntities( templateTitle ) : undefined;
 
 	/*
-	 * Without a template to name there is nothing useful to say about where the
-	 * title's appearance comes from, so only the card is shown.
+	 * A template that cannot be named is no reason to withhold the
+	 * explanation; the button just says "Edit template" instead.
 	 */
-	const canExplain = !! templateTitle && canEditTemplate;
+	const canExplain = !! templateId && canEditTemplate;
 
 	return (
 		<Stack direction="column" gap="md">
@@ -94,11 +115,13 @@ export default function PostTitleInspector() {
 						onNavigateToEntityRecord
 							? [
 									{
-										label: sprintf(
-											// translators: %s: name of the template, e.g. "Pages".
-											__( 'Edit %s template' ),
-											templateTitle
-										),
+										label: title
+											? sprintf(
+													// translators: %s: name of the template, e.g. "Pages".
+													__( 'Edit %s template' ),
+													title
+											  )
+											: __( 'Edit template' ),
 										onClick: () =>
 											onNavigateToEntityRecord( {
 												postId: templateId as string,

--- a/packages/editor/src/components/sidebar/post-title-inspector.tsx
+++ b/packages/editor/src/components/sidebar/post-title-inspector.tsx
@@ -1,21 +1,11 @@
-import { __, sprintf } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
-import { Notice } from '@wordpress/components';
-import { Stack, Text } from '@wordpress/ui';
-import { useSelect } from '@wordpress/data';
-import { decodeEntities } from '@wordpress/html-entities';
+import { Stack } from '@wordpress/ui';
 // @ts-expect-error No exported types
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import {
-	store as coreStore,
-	privateApis as coreDataPrivateApis,
-} from '@wordpress/core-data';
-import { store as editorStore } from '../../store';
-import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import { unlock } from '../../lock-unlock';
+import TemplateScopeNotice from './template-scope-notice';
 
 const { BlockCard } = unlock( blockEditorPrivateApis );
-const { getTemplateInfo } = unlock( coreDataPrivateApis );
 
 const POST_TITLE_BLOCK = 'core/post-title';
 
@@ -30,74 +20,11 @@ const POST_TITLE_BLOCK = 'core/post-title';
  * @return The rendered panel.
  */
 export default function PostTitleInspector() {
-	const {
-		templateId,
-		templateTitle,
-		onNavigateToEntityRecord,
-		canEditTemplate,
-	} = useSelect( ( select ) => {
-		const { getCurrentTemplateId, getEditorSettings } = select(
-			editorStore
-		) as {
-			getCurrentTemplateId: () => string | undefined;
-			getEditorSettings: () => {
-				onNavigateToEntityRecord?: ( args: {
-					postId: string;
-					postType: string;
-				} ) => void;
-			};
-		};
-		const { canUser, getEntityRecord, getCurrentTheme } =
-			select( coreStore );
-		const currentTemplateId = getCurrentTemplateId();
-
-		/*
-		 * A template's own title is empty, or just its slug, until someone
-		 * renames it. `getTemplateInfo` falls back to the name the theme
-		 * gives it — "Pages", "Single Posts" — which is what the rest of
-		 * the editor shows.
-		 */
-		const templateInfo = currentTemplateId
-			? getTemplateInfo( {
-					templateTypes:
-						(
-							getCurrentTheme() as
-								| { default_template_types?: unknown[] }
-								| undefined
-						 )?.default_template_types ?? [],
-					template: getEntityRecord(
-						'postType',
-						TEMPLATE_POST_TYPE,
-						currentTemplateId
-					),
-			  } )
-			: undefined;
-
-		return {
-			templateId: currentTemplateId,
-			templateTitle: templateInfo?.title as string | undefined,
-			onNavigateToEntityRecord:
-				getEditorSettings().onNavigateToEntityRecord,
-			canEditTemplate: !! canUser( 'create', {
-				kind: 'postType',
-				name: TEMPLATE_POST_TYPE,
-			} ),
-		};
-	}, [] );
-
 	const blockType = getBlockType( POST_TITLE_BLOCK );
 
 	if ( ! blockType ) {
 		return null;
 	}
-
-	const title = templateTitle ? decodeEntities( templateTitle ) : undefined;
-
-	/*
-	 * A template that cannot be named is no reason to withhold the
-	 * explanation; the button just says "Edit template" instead.
-	 */
-	const canExplain = !! templateId && canEditTemplate;
 
 	return (
 		<Stack direction="column" gap="md">
@@ -106,47 +33,7 @@ export default function PostTitleInspector() {
 				icon={ blockType.icon }
 				description={ blockType.description }
 			/>
-			{ canExplain && (
-				<Notice
-					status="info"
-					isDismissible={ false }
-					className="editor-post-title-inspector__notice"
-					actions={
-						onNavigateToEntityRecord
-							? [
-									{
-										label: title
-											? sprintf(
-													// translators: %s: name of the template, e.g. "Pages".
-													__( 'Edit %s template' ),
-													title
-											  )
-											: __( 'Edit template' ),
-										onClick: () =>
-											onNavigateToEntityRecord( {
-												postId: templateId as string,
-												postType: TEMPLATE_POST_TYPE,
-											} ),
-										variant: 'secondary',
-									},
-							  ]
-							: []
-					}
-				>
-					<Stack direction="column" gap="sm">
-						<Text render={ <p /> }>
-							<strong>
-								{ __( 'This block comes from the template' ) }
-							</strong>
-						</Text>
-						<Text render={ <p /> }>
-							{ __(
-								'Changes to its settings affect all posts and pages that use the template.'
-							) }
-						</Text>
-					</Stack>
-				</Notice>
-			) }
+			<TemplateScopeNotice />
 		</Stack>
 	);
 }

--- a/packages/editor/src/components/sidebar/post-title-inspector.tsx
+++ b/packages/editor/src/components/sidebar/post-title-inspector.tsx
@@ -1,7 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 import { Notice } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
+import { Stack, Text } from '@wordpress/ui';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 // @ts-expect-error No exported types
@@ -110,16 +110,18 @@ export default function PostTitleInspector() {
 							: []
 					}
 				>
-					<p>
-						<strong>
-							{ __( 'This block comes from the template' ) }
-						</strong>
-					</p>
-					<p>
-						{ __(
-							'Changes to its settings affect all posts and pages that use the template.'
-						) }
-					</p>
+					<Stack direction="column" gap="sm">
+						<Text render={ <p /> }>
+							<strong>
+								{ __( 'This block comes from the template' ) }
+							</strong>
+						</Text>
+						<Text render={ <p /> }>
+							{ __(
+								'Changes to its settings affect all posts and pages that use the template.'
+							) }
+						</Text>
+					</Stack>
 				</Notice>
 			) }
 		</Stack>

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -39,6 +39,6 @@
 // The sidebar panel is unpadded so full-bleed items can sit flush against its
 // edges, leaving each child to inset itself. The block card above this one
 // carries its own padding; this matches it.
-.editor-post-title-inspector__notice {
+.editor-template-scope-notice {
 	margin: 0 $grid-unit-20;
 }

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -35,3 +35,10 @@
 	border-top: $border-width solid $gray-200;
 	padding-top: $grid-unit-20;
 }
+
+// The sidebar panel is unpadded so full-bleed items can sit flush against its
+// edges, leaving each child to inset itself. The block card above this one
+// carries its own padding; this matches it.
+.editor-post-title-inspector__notice {
+	margin: 0 $grid-unit-20;
+}

--- a/packages/editor/src/components/sidebar/template-block-scope.tsx
+++ b/packages/editor/src/components/sidebar/template-block-scope.tsx
@@ -1,0 +1,57 @@
+import { useSelect } from '@wordpress/data';
+// @ts-expect-error No exported types
+// prettier-ignore
+import { privateApis as blockEditorPrivateApis, store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '../../store';
+import usePostContentBlockTypes from '../provider/use-post-content-block-types';
+import TemplateScopeNotice from './template-scope-notice';
+import { unlock } from '../../lock-unlock';
+
+const { BlockInspectorPreTabsFill } = unlock( blockEditorPrivateApis );
+
+/**
+ * Explains, in the block inspector, that the selected block belongs to the
+ * template rather than to the post.
+ *
+ * With the template shown, most of it is inert and cannot be selected at all.
+ * The exceptions are the blocks that render post data — Title, Featured Image
+ * and Content — which stay selectable so their content can be edited from
+ * here. Their settings still belong to the template, and nothing said so.
+ *
+ * @return The rendered notice.
+ */
+export default function TemplateBlockScope() {
+	const postContentBlockTypes = usePostContentBlockTypes();
+
+	const isTemplateBlockSelected = useSelect(
+		( select ) => {
+			const { getRenderingMode } = select( editorStore ) as {
+				getRenderingMode: () => string;
+			};
+
+			if ( getRenderingMode() !== 'template-locked' ) {
+				return false;
+			}
+
+			const { getSelectedBlockClientId, getBlockName } =
+				select( blockEditorStore );
+			const clientId = getSelectedBlockClientId();
+
+			return (
+				!! clientId &&
+				postContentBlockTypes.includes( getBlockName( clientId ) )
+			);
+		},
+		[ postContentBlockTypes ]
+	);
+
+	if ( ! isTemplateBlockSelected ) {
+		return null;
+	}
+
+	return (
+		<BlockInspectorPreTabsFill>
+			<TemplateScopeNotice />
+		</BlockInspectorPreTabsFill>
+	);
+}

--- a/packages/editor/src/components/sidebar/template-scope-notice.tsx
+++ b/packages/editor/src/components/sidebar/template-scope-notice.tsx
@@ -1,0 +1,128 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { Stack, Text } from '@wordpress/ui';
+import { useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
+import { store as editorStore } from '../../store';
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
+import { unlock } from '../../lock-unlock';
+
+const { getTemplateInfo } = unlock( coreDataPrivateApis );
+
+/**
+ * Says that what is being described is defined by the template rather than by
+ * the post, and offers to go and edit it.
+ *
+ * Renders nothing when there is no template to point at, or when the user
+ * cannot edit it: there is nothing useful to say in either case.
+ *
+ * @return The rendered notice.
+ */
+export default function TemplateScopeNotice() {
+	const { templateId, templateTitle, onNavigateToEntityRecord, canEdit } =
+		useSelect( ( select ) => {
+			const { getCurrentTemplateId, getEditorSettings } = select(
+				editorStore
+			) as {
+				getCurrentTemplateId: () => string | undefined;
+				getEditorSettings: () => {
+					onNavigateToEntityRecord?: ( args: {
+						postId: string;
+						postType: string;
+					} ) => void;
+				};
+			};
+			const { canUser, getEntityRecord, getCurrentTheme } =
+				select( coreStore );
+			const currentTemplateId = getCurrentTemplateId();
+
+			/*
+			 * A template's own title is empty, or just its slug, until someone
+			 * renames it. `getTemplateInfo` falls back to the name the theme
+			 * gives it — "Pages", "Single Posts" — which is what the rest of
+			 * the editor shows.
+			 */
+			const templateInfo = currentTemplateId
+				? getTemplateInfo( {
+						templateTypes:
+							(
+								getCurrentTheme() as
+									| { default_template_types?: unknown[] }
+									| undefined
+							 )?.default_template_types ?? [],
+						template: getEntityRecord(
+							'postType',
+							TEMPLATE_POST_TYPE,
+							currentTemplateId
+						),
+				  } )
+				: undefined;
+
+			return {
+				templateId: currentTemplateId,
+				templateTitle: templateInfo?.title as string | undefined,
+				onNavigateToEntityRecord:
+					getEditorSettings().onNavigateToEntityRecord,
+				canEdit: !! canUser( 'create', {
+					kind: 'postType',
+					name: TEMPLATE_POST_TYPE,
+				} ),
+			};
+		}, [] );
+
+	if ( ! templateId || ! canEdit ) {
+		return null;
+	}
+
+	const title = templateTitle ? decodeEntities( templateTitle ) : undefined;
+
+	return (
+		<Notice
+			status="info"
+			isDismissible={ false }
+			className="editor-template-scope-notice"
+			actions={
+				onNavigateToEntityRecord
+					? [
+							{
+								/*
+								 * A template that cannot be named is no reason
+								 * to withhold the route to it.
+								 */
+								label: title
+									? sprintf(
+											// translators: %s: name of the template, e.g. "Pages".
+											__( 'Edit %s template' ),
+											title
+									  )
+									: __( 'Edit template' ),
+								onClick: () =>
+									onNavigateToEntityRecord( {
+										postId: templateId,
+										postType: TEMPLATE_POST_TYPE,
+									} ),
+								variant: 'secondary',
+							},
+					  ]
+					: []
+			}
+		>
+			<Stack direction="column" gap="sm">
+				<Text render={ <p /> }>
+					<strong>
+						{ __( 'This block comes from the template' ) }
+					</strong>
+				</Text>
+				<Text render={ <p /> }>
+					{ __(
+						'Changes to its settings affect all posts and pages that use the template.'
+					) }
+				</Text>
+			</Stack>
+		</Notice>
+	);
+}

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -761,3 +761,18 @@ export function selectNote( noteId, options = { focus: false } ) {
 		options,
 	};
 }
+
+/**
+ * Records whether the post title field has focus, so the sidebar can describe
+ * the title rather than reporting that nothing is selected.
+ *
+ * @param {boolean} isEditing Whether the title has focus.
+ *
+ * @return {Object} Action object.
+ */
+export function setIsEditingPostTitle( isEditing ) {
+	return {
+		type: 'SET_IS_EDITING_POST_TITLE',
+		isEditing,
+	};
+}

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -605,3 +605,14 @@ export const isCollaborationEnabledForCurrentPost = createRegistrySelector(
 		);
 	}
 );
+
+/**
+ * Returns whether the post title field has focus.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the title is being edited.
+ */
+export function isEditingPostTitle( state ) {
+	return state.isEditingPostTitle;
+}

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -479,6 +479,27 @@ export function selectedNote( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Tracks whether the post title field has focus.
+ *
+ * The title in post-only rendering mode is editor chrome rather than a block,
+ * so nothing in the block editor store changes when it is clicked. This is what
+ * lets the sidebar tell "the title is being edited" apart from "nothing is
+ * selected", which otherwise look identical.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function isEditingPostTitle( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_EDITING_POST_TITLE':
+			return action.isEditing;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	postId,
 	postType,
@@ -504,5 +525,6 @@ export default combineReducers( {
 	revisionPage,
 	showRevisionDiff,
 	selectedNote,
+	isEditingPostTitle,
 	dataviews: dataviewsReducer,
 } );


### PR DESCRIPTION
## What?

Aruably closes, but let's not yet, #79285, as there are some related followups still in https://github.com/WordPress/gutenberg/issues/79285#issuecomment-5585765480.

Clicking the post title and opening the Block tab no longer says "No block selected." It describes the title, and explains that its appearance comes from the template, with a way to go and edit it.

Before:

<img width="466" height="462" alt="image" src="https://github.com/user-attachments/assets/7b74eb9a-9f6c-41a3-8838-636d7a0a3c58" />

After:

<img width="436" height="576" alt="image" src="https://github.com/user-attachments/assets/0d8e0329-bd66-416b-b7ad-352ef0354385" />

## How?

Claude wrote this:

With the template hidden, the title is not a block at all: `PostTitle` is editor chrome rendered outside `<BlockList>`, and focusing it clears the block selection. So there is nothing for the block inspector to select, and no existing state that distinguishes "the title is being edited" from "nothing is selected" — both look identical to `getBlockSelectionStart()`.

`PostTitle` already tracked its own focus locally for styling. That now also records `isEditingPostTitle` in the editor store, following the pattern of the other small UI flags there (`blockInserterPanel`, `listViewPanel`). The sidebar renders the title panel in the Block tab when that flag is set and no block is selected.

Two details that are easy to get wrong:

**Focus is not cleared on blur.** Opening the sidebar's Block tab moves focus out of the title, so clearing on blur would unset the flag in the same gesture that opens the tab meant to read it — the panel would only ever appear on a second click. Selecting a block is what supersedes the title, and the sidebar checks for that directly. This mirrors how block selection already survives clicking into the sidebar.

**`BlockCard` is now exported from `block-editor`'s private APIs.** The card describes `core/post-title` even though no such block exists in the tree, so the information comes from `getBlockType()` rather than from a selection. `editor` already unlocks these APIs in several places.

The notice uses `status="info"` rather than a warning: nothing has gone wrong, and it appears every time the title takes focus, so a persistent amber would be a lot of alarm for a routine state.

## Testing Instructions

1. On a block theme, edit a post or page with **Show template off** (the default).
2. Click into the title, then open the **Block** tab in the sidebar.
3. **Expected:** a Title block card, and a notice naming the template with a button to edit it. Previously this said "No block selected."
4. Press the button. It should navigate to that template.
5. Click a block in the content. The panel should give way to that block's inspector.

Please also confirm:

- A classic theme, or any post with no template. Only the card shows — there is no template to name or offer.
- A user without template editing permission sees the card without the notice.
- **Show template on.** Unchanged: the template's own blocks are selectable and the block inspector behaves as before.
- The title still behaves normally — typing, selection, <kbd>Enter</kbd> to create the first block.

### Testing Instructions for Keyboard

1. Focus the title field.
2. Open the sidebar and move to the **Block** tab.
3. The card and notice should be reachable, and the button should be in the tab order and announce which template it opens.

## Use of AI Tools

Claude Opus 5.