### PR TITLE
Theme, Widget dashboard: Declare the @storybook/addon-docs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54603,6 +54603,7 @@
 				"memize": "^2.1.1"
 			},
 			"devDependencies": {
+				"@storybook/addon-docs": "^10.5.3",
 				"@storybook/react-vite": "^10.5.3",
 				"@terrazzo/parser": "^2.7.1",
 				"@terrazzo/plugin-css": "^2.7.1",
@@ -54996,6 +54997,7 @@
 				"uuid": "^14.0.0"
 			},
 			"devDependencies": {
+				"@storybook/addon-docs": "^10.5.3",
 				"@storybook/react-vite": "^10.5.3",
 				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^6.9.1",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -27,6 +27,7 @@
 -   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))
 -   Enforce NodeNext module resolution in the build project so future declaration imports are checked against the package's published ESM resolution rules. ([#82088](https://github.com/WordPress/gutenberg/pull/82088))
 -   Update the `@types/node` development dependency to v24, matching the Node.js version the repository builds and tests against ([#82616](https://github.com/WordPress/gutenberg/pull/82616)).
+-   Declare the `@storybook/addon-docs` development dependency used by the package's story documentation ([#82676](https://github.com/WordPress/gutenberg/pull/82676)).
 
 ## 2.0.0 (2026-08-26)
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -91,6 +91,7 @@
 		"memize": "^2.1.1"
 	},
 	"devDependencies": {
+		"@storybook/addon-docs": "^10.5.3",
 		"@storybook/react-vite": "^10.5.3",
 		"@terrazzo/parser": "^2.7.1",
 		"@terrazzo/plugin-css": "^2.7.1",

--- a/packages/widget-dashboard/CHANGELOG.md
+++ b/packages/widget-dashboard/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 -   Remove unused dependency `@wordpress/primitives` ([#82103](https://github.com/WordPress/gutenberg/pull/82103)).
 -   Remove tsconfig project references to packages that are not dependencies ([#82106](https://github.com/WordPress/gutenberg/pull/82106)).
+-   Declare the `@storybook/addon-docs` development dependency used by the package's story documentation ([#82676](https://github.com/WordPress/gutenberg/pull/82676)).
 
 ### Bug Fixes
 

--- a/packages/widget-dashboard/package.json
+++ b/packages/widget-dashboard/package.json
@@ -66,6 +66,7 @@
 		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
+		"@storybook/addon-docs": "^10.5.3",
 		"@storybook/react-vite": "^10.5.3",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## What?

Caught by #75814

Adds the missing `@storybook/addon-docs` devDependency to `@wordpress/theme` and `@wordpress/widget-dashboard`.

## Why?

Both packages import `@storybook/addon-docs/blocks` in their story docs but never declared the dependency, so they resolve it from the hoisted root tree. This breaks under the isolated dependency layout explored in #75814.

## How?

Declares `@storybook/addon-docs` in `devDependencies` for both packages, matching the version already used by `@wordpress/components`, `@wordpress/ui`, `@wordpress/dataviews` and `@wordpress/widget-primitives`.

## Testing Instructions

1. Run `npm install`; the lockfile should stay unchanged beyond the two added entries.
2. Run `npm run storybook:dev` and confirm the Theme and Widget dashboard docs pages still render.

## Use of AI Tools

Claude Code was used to locate the undeclared imports and draft this description. All changes were reviewed by me.
