### PR TITLE
Theme: Use Node.js native type-stripping for scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25119,22 +25119,6 @@
 				"@esbuild/win32-x64": "0.27.2"
 			}
 		},
-		"node_modules/esbuild-esm-loader": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/esbuild-esm-loader/-/esbuild-esm-loader-0.3.3.tgz",
-			"integrity": "sha512-txJYxTdvMN6kkANPfn/YyP5Y2wIW8R6DzYMmuN+1RBY9pyRvIwhjSdESGL80PJONCUrNJKVmUHiMtFKXiOoDFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve-file-extension": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=16.17.0"
-			},
-			"peerDependencies": {
-				"esbuild": "*"
-			}
-		},
 		"node_modules/esbuild-plugin-babel": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/esbuild-plugin-babel/-/esbuild-plugin-babel-0.2.3.tgz",
@@ -43055,16 +43039,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/resolve-file-extension": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-file-extension/-/resolve-file-extension-1.0.1.tgz",
-			"integrity": "sha512-kPdiRMUkit/vBoMqLQ1RWe4VttH8/h7sLcpB//G4pTyuQ8Gjcxw9cs6ry0KaJpDbbhfhFpDZEgRn/wgNvqvSlA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -54641,7 +54615,6 @@
 				"@types/node": "^24.13.3",
 				"@wordpress/validation-tools": "file:../../tools/validation",
 				"esbuild": "^0.27.2",
-				"esbuild-esm-loader": "^0.3.3",
 				"lightningcss": "^1.33.0",
 				"prettier": "npm:wp-prettier@^3.0.3",
 				"storybook": "^10.5.3",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Internal
 
 -   Update type-checking for script files to enforce NodeNext module resolution ([#82622](https://github.com/WordPress/gutenberg/pull/82622)).
+-   Remove `esbuild-esm-loader` dependency in favor of Node.js TypeScript native type-stripping.
 -   Migrate design token modes to the DTCG resolver and Terrazzo CSS permutations. ([#82537](https://github.com/WordPress/gutenberg/pull/82537))
 -   Generate the default ramps before derived token artifacts so one build uses the current ramp algorithm throughout. ([#82525](https://github.com/WordPress/gutenberg/pull/82525))
 -   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Internal
 
 -   Update type-checking for script files to enforce NodeNext module resolution ([#82622](https://github.com/WordPress/gutenberg/pull/82622)).
--   Remove `esbuild-esm-loader` dependency in favor of Node.js TypeScript native type-stripping.
+-   Remove `esbuild-esm-loader` dependency in favor of Node.js TypeScript native type-stripping ([#82680](https://github.com/WordPress/gutenberg/pull/82680)).
 -   Migrate design token modes to the DTCG resolver and Terrazzo CSS permutations. ([#82537](https://github.com/WordPress/gutenberg/pull/82537))
 -   Generate the default ramps before derived token artifacts so one build uses the current ramp algorithm throughout. ([#82525](https://github.com/WordPress/gutenberg/pull/82525))
 -   Cache relative luminance calculations used by color-ramp contrast checks. ([#82445](https://github.com/WordPress/gutenberg/pull/82445))

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -104,7 +104,6 @@
 		"@types/node": "^24.13.3",
 		"@wordpress/validation-tools": "file:../../tools/validation",
 		"esbuild": "^0.27.2",
-		"esbuild-esm-loader": "^0.3.3",
 		"lightningcss": "^1.33.0",
 		"prettier": "npm:wp-prettier@^3.0.3",
 		"storybook": "^10.5.3",
@@ -145,8 +144,8 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build:default-ramps": "node --import=esbuild-esm-loader/register bin/generate-default-ramps/index.ts",
-		"build:tokens": "node --import=esbuild-esm-loader/register bin/generate-primitive-tokens/index.ts && node --import=esbuild-esm-loader/register bin/build-design-tokens/index.ts",
+		"build:default-ramps": "node bin/generate-default-ramps/index.ts",
+		"build:tokens": "node bin/generate-primitive-tokens/index.ts && node bin/build-design-tokens/index.ts",
 		"build": "npm run build:default-ramps && npm run build:tokens",
 		"lint:package-contents": "wp-validate-package-contents . --disallow-path src",
 		"postbuild": "prettier --write tokens/color.json tokens/modes prebuilt src/prebuilt src/color-ramps/lib/default-ramps.ts docs ../base-styles/internal/_wpds-token-fallbacks.scss"


### PR DESCRIPTION
## What?

- Updates `@wordpress/theme` scripts to drop the `esbuild-esm-loader` loader, now unnecessary since upgrading to Node.js v24 in #82370
- Removes `esbuild-esm-loader` as a dependency

Builds on #82622, which resolves issues when running scripts with Node.js module resolution that were obfuscated by the user of the ESBuild loader.

## Why?

Node.js v24 includes [native type-stripping](https://nodejs.org/learn/typescript/run-natively), and the only reason we used this dependency was so that we could run TypeScript files with Node.js.

## Testing Instructions

`npm run --workspace=@wordpress/theme build` should build successfully and produce an identical result as in `trunk`, verifiable by checking that `git status` has no changes to commit.

## Use of AI Tools

No AI was used.