### PR TITLE
BlockPreview: Assert preview contents are inert

### DIFF
--- a/packages/block-editor/src/components/block-preview/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-preview/test/index.jsdom.test.jsx
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import {
 	registerBlockType,
 	unregisterBlockType,
@@ -76,6 +76,11 @@ describe( 'useBlockPreview', () => {
 			'test-container-classname',
 			{ exact: true }
 		);
+
+		// Ensure rendered blocks cannot be interacted with.
+		await waitFor( () => {
+			expect( previewedBlock ).toHaveAttribute( 'inert', 'true' );
+		} );
 
 		// Ensure there is no nesting between the parent component and rendered blocks.
 		expect( blockPreviewComponent ).toContainElement( previewedBlock );

--- a/packages/block-editor/src/components/block-preview/test/index.jsdom.test.jsx
+++ b/packages/block-editor/src/components/block-preview/test/index.jsdom.test.jsx
@@ -79,7 +79,7 @@ describe( 'useBlockPreview', () => {
 
 		// Ensure rendered blocks cannot be interacted with.
 		await waitFor( () => {
-			expect( previewedBlock ).toHaveAttribute( 'inert', 'true' );
+			expect( previewedBlock ).toHaveAttribute( 'inert' );
 		} );
 
 		// Ensure there is no nesting between the parent component and rendered blocks.


### PR DESCRIPTION
Follow-up to #82651 and [this review thread](https://github.com/WordPress/gutenberg/pull/82651#discussion_r3968561005).

## What?

Adds a regression assertion that blocks rendered by `useBlockPreview` have `inert="true"`.

## Why?

PR #82651 removed the `components-disabled` class assertion. That class did not prove interaction blocking, but its removal also removed the test's statement that preview contents must stay non-interactive.

## How?

Waits for `useDisabled` to apply its mutation, then checks the rendered block element for the `inert` attribute.

## Testing Instructions

No manual testing is needed. This PR only strengthens the existing automated coverage.

### Testing Instructions for Keyboard

No UI behavior changes.

## Use of AI Tools

Codex inspected the review thread, updated the assertion, ran focused verification, and drafted this description.
