### PR TITLE
Cover: add "Insert from URL" for the background media

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Math: Declare `interactivity.clientNavigation` support. The block's front end output is static markup, and without the declaration a Math block inside a Query block forced full page reloads on pagination ([#82248](https://github.com/WordPress/gutenberg/pull/82248)).
 -   Paragraph, List, Heading, Preformatted, Columns, Group, Template Part: Read the default padding these blocks add when they have a background color from the `--wp--style--block-background-padding` custom property, so themes can change or remove it ([#82024](https://github.com/WordPress/gutenberg/pull/82024)).
 -   Query: Show a snackbar notice instead of a blocking modal when "Reload full page" is turned on automatically because a block inside the Query block doesn't support client-side navigation ([#82246](https://github.com/WordPress/gutenberg/pull/82246)).
+-   Cover: Add "Insert from URL" for the background media, in the placeholder and in the toolbar's replace flow, so an image or video background can be added from a URL and edited once set. Whether the URL is an image or a video is read from its file extension, falling back to loading it in an image element ([#82688](https://github.com/WordPress/gutenberg/pull/82688)).
 
 ### Bug Fixes
 

--- a/packages/block-library/src/cover/edit/block-controls.jsx
+++ b/packages/block-library/src/cover/edit/block-controls.jsx
@@ -20,6 +20,7 @@ export default function CoverBlockControls( {
 	attributes,
 	setAttributes,
 	onSelectMedia,
+	onSelectURL,
 	currentSettings,
 	toggleUseFeaturedImage,
 	onClearMedia,
@@ -130,6 +131,7 @@ export default function CoverBlockControls( {
 					mediaURL={ url }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					onSelect={ onSelectMedia }
+					onSelectURL={ onSelectURL }
 					onToggleFeaturedImage={ toggleUseFeaturedImage }
 					useFeaturedImage={ useFeaturedImage }
 					name={ ! url ? __( 'Add media' ) : __( 'Replace' ) }

--- a/packages/block-library/src/cover/edit/cover-placeholder.jsx
+++ b/packages/block-library/src/cover/edit/cover-placeholder.jsx
@@ -8,6 +8,7 @@ export default function CoverPlaceholder( {
 	disableMediaButtons = false,
 	children,
 	onSelectMedia,
+	onSelectURL,
 	onError,
 	style,
 	toggleUseFeaturedImage,
@@ -25,6 +26,7 @@ export default function CoverPlaceholder( {
 				title: __( 'Cover' ),
 			} }
 			onSelect={ onSelectMedia }
+			onSelectURL={ onSelectURL }
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			disableMediaButtons={ disableMediaButtons }
 			onToggleFeaturedImage={ toggleUseFeaturedImage }

--- a/packages/block-library/src/cover/edit/get-media-type-from-url.js
+++ b/packages/block-library/src/cover/edit/get-media-type-from-url.js
@@ -1,0 +1,104 @@
+import { IMAGE_BACKGROUND_TYPE, VIDEO_BACKGROUND_TYPE } from '../shared';
+
+const IMAGE_EXTENSIONS = [
+	'avif',
+	'bmp',
+	'gif',
+	'heic',
+	'heif',
+	'ico',
+	'jpeg',
+	'jpg',
+	'png',
+	'svg',
+	'webp',
+];
+
+const VIDEO_EXTENSIONS = [
+	'avi',
+	'flv',
+	'm4v',
+	'mov',
+	'mp4',
+	'mpeg',
+	'mpg',
+	'ogv',
+	'webm',
+	'wmv',
+];
+
+/**
+ * Reads the lowercased file extension of a URL, ignoring any query string and
+ * fragment. Relative paths are supported, as the URL field accepts them.
+ *
+ * @param {string} url The URL to read.
+ *
+ * @return {string} The extension, or an empty string when the URL has none.
+ */
+function getExtension( url ) {
+	let pathname;
+
+	try {
+		( { pathname } = new URL( url, window.location.href ) );
+	} catch {
+		// Not parseable as a URL, so strip the query and fragment by hand.
+		pathname = url.split( /[?#]/ )[ 0 ];
+	}
+
+	const lastDot = pathname.lastIndexOf( '.' );
+	const lastSlash = pathname.lastIndexOf( '/' );
+
+	// The dot has to follow the last slash, and cannot be the character right
+	// after it, which would make it a dotfile rather than an extension.
+	return lastDot > lastSlash + 1
+		? pathname.slice( lastDot + 1 ).toLowerCase()
+		: '';
+}
+
+/**
+ * Resolves whether the URL can be displayed by an image element.
+ *
+ * @param {string} url The URL to load.
+ *
+ * @return {Promise<boolean>} Whether the image loaded.
+ */
+function canLoadAsImage( url ) {
+	return new Promise( ( resolve ) => {
+		const image = new window.Image();
+		image.onload = () => resolve( true );
+		image.onerror = () => resolve( false );
+		image.src = url;
+	} );
+}
+
+/**
+ * Determines whether a URL points at an image or a video, so that a background
+ * added from a URL gets the right `backgroundType`.
+ *
+ * The file extension answers this for most URLs. When it doesn't, the URL is
+ * loaded in an image element: that isn't subject to CORS — it is how the block
+ * renders the background anyway — so it also works for media served without
+ * CORS headers, and the browser caches the response for the render that
+ * follows. Anything that doesn't load as an image is treated as a video, which
+ * is the same assumption `attributesFromMedia` makes for media of an unknown
+ * type.
+ *
+ * @param {string} url The URL of the media.
+ *
+ * @return {Promise<string>} Either `image` or `video`.
+ */
+export default async function getMediaTypeFromUrl( url ) {
+	const extension = getExtension( url );
+
+	if ( IMAGE_EXTENSIONS.includes( extension ) ) {
+		return IMAGE_BACKGROUND_TYPE;
+	}
+
+	if ( VIDEO_EXTENSIONS.includes( extension ) ) {
+		return VIDEO_BACKGROUND_TYPE;
+	}
+
+	return ( await canLoadAsImage( url ) )
+		? IMAGE_BACKGROUND_TYPE
+		: VIDEO_BACKGROUND_TYPE;
+}

--- a/packages/block-library/src/cover/edit/index.jsx
+++ b/packages/block-library/src/cover/edit/index.jsx
@@ -35,6 +35,7 @@ import {
 	getPositionClassName,
 	mediaPosition,
 } from '../shared';
+import getMediaTypeFromUrl from './get-media-type-from-url';
 import CoverInspectorControls from './inspector-controls';
 import CoverBlockControls from './block-controls';
 import CoverPlaceholder from './cover-placeholder';
@@ -320,6 +321,17 @@ function CoverEdit( {
 			} );
 
 			scaffoldInnerBlocks();
+		} );
+	};
+
+	const onSelectURL = async ( newURL ) => {
+		if ( ! newURL || newURL === url ) {
+			return;
+		}
+
+		await onSelectMedia( {
+			url: newURL,
+			type: await getMediaTypeFromUrl( newURL ),
 		} );
 	};
 
@@ -683,6 +695,7 @@ function CoverEdit( {
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 			onSelectMedia={ onSelectMedia }
+			onSelectURL={ onSelectURL }
 			onSelectEmbedUrl={ onSelectEmbedUrl }
 			currentSettings={ currentSettings }
 			toggleUseFeaturedImage={ toggleUseFeaturedImage }
@@ -751,6 +764,7 @@ function CoverEdit( {
 					{ resizeListener }
 					<CoverPlaceholder
 						onSelectMedia={ onSelectMedia }
+						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
 						toggleUseFeaturedImage={ toggleUseFeaturedImage }
 					>

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -70,6 +70,10 @@ export function attributesFromMedia( media ) {
 		id: media.id,
 		alt: media?.alt,
 		backgroundType: mediaType,
+		// Media that isn't in the library, such as a background added from a
+		// URL, has no registered image sizes, so a size selected for an earlier
+		// background no longer applies.
+		...( media.id ? {} : { sizeSlug: undefined } ),
 		...( mediaType === VIDEO_BACKGROUND_TYPE
 			? { hasParallax: undefined }
 			: {} ),

--- a/packages/block-library/src/cover/test/edit.jsdom.test.js
+++ b/packages/block-library/src/cover/test/edit.jsdom.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest-dom/prefer-to-have-style -- This suite moves to Browser Mode in the next stacked PR. */
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { screen, fireEvent, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -10,6 +10,25 @@ globalThis.wpVitest.mockMatchMedia();
 globalThis.wpVitest.mockCSSSupports();
 globalThis.wpVitest.mockResizeObserver();
 globalThis.wpVitest.mockVisibleElements();
+
+// JSDOM never fetches image sources, so an image element's load never resolves.
+// The block awaits `getMediaColor` before it commits a new background, which
+// would otherwise leave every media selection pending forever.
+beforeEach( () => {
+	vi.stubGlobal(
+		'Image',
+		class StubImage {
+			set src( value ) {
+				this._src = value;
+				Promise.resolve().then( () => this.onerror?.() );
+			}
+
+			get src() {
+				return this._src;
+			}
+		}
+	);
+} );
 
 const defaultSettings = {
 	__experimentalFeatures: {
@@ -97,6 +116,19 @@ async function createAndSelectBlock() {
 	await selectBlock( 'Block: Cover' );
 }
 
+/**
+ * Adds media to the Cover placeholder through its "Insert from URL" popover.
+ *
+ * @param {string} url The media URL to insert.
+ */
+async function insertFromURL( url ) {
+	await userEvent.click(
+		screen.getByRole( 'button', { name: 'Insert from URL' } )
+	);
+	await userEvent.type( screen.getByRole( 'textbox', { name: 'URL' } ), url );
+	await userEvent.click( screen.getByRole( 'button', { name: 'Apply' } ) );
+}
+
 async function openStylesTabIfAvailable() {
 	const stylesTab = screen.queryByRole( 'tab', {
 		name: 'Styles',
@@ -113,10 +145,46 @@ describe( 'Cover block', () => {
 			await setup();
 
 			expect(
-				within( screen.getByLabelText( 'Block: Cover' ) ).getByText(
-					'To edit this block, you need permission to upload media.'
+				within( screen.getByLabelText( 'Block: Cover' ) ).getByRole(
+					'button',
+					{ name: 'Insert from URL' }
 				)
 			).toBeInTheDocument();
+		} );
+
+		test( 'sets an image background from a URL inserted in the placeholder', async () => {
+			await setup();
+
+			await insertFromURL( 'https://example.com/photo.jpg' );
+
+			const cover = screen.getByLabelText( 'Block: Cover' );
+			expect( cover ).toHaveAttribute(
+				'data-url',
+				'https://example.com/photo.jpg'
+			);
+			expect( within( cover ).getByRole( 'img' ) ).toHaveAttribute(
+				'src',
+				'https://example.com/photo.jpg'
+			);
+		} );
+
+		test( 'sets a video background from a URL inserted in the placeholder', async () => {
+			const { container } = await setup();
+
+			await insertFromURL( 'https://example.com/clip.mp4' );
+
+			expect( screen.getByLabelText( 'Block: Cover' ) ).toHaveAttribute(
+				'data-url',
+				'https://example.com/clip.mp4'
+			);
+			// eslint-disable-next-line testing-library/no-node-access
+			const video = container.getElementsByClassName(
+				'wp-block-cover__video-background'
+			);
+			expect( video[ 0 ] ).toHaveAttribute(
+				'src',
+				'https://example.com/clip.mp4'
+			);
 		} );
 
 		test( 'can set overlay color using color picker on block placeholder', async () => {
@@ -127,8 +195,8 @@ describe( 'Cover block', () => {
 			await userEvent.click( colorPicker );
 			const color = colorPicker.style.backgroundColor;
 			expect(
-				screen.queryByRole( 'group', {
-					name: 'To edit this block, you need permission to upload media.',
+				screen.queryByRole( 'button', {
+					name: 'Insert from URL',
 				} )
 			).not.toBeInTheDocument();
 
@@ -200,6 +268,36 @@ describe( 'Cover block', () => {
 			);
 			expect( screen.getByLabelText( 'Block: Cover' ) ).toHaveClass(
 				'is-position-top-left'
+			);
+		} );
+
+		test( 'replaces the background media with a URL from the replace flow', async () => {
+			await setup( {
+				url: 'http://localhost/my-image.jpg',
+				backgroundType: 'image',
+			} );
+
+			await selectBlock( 'Block: Cover' );
+
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Replace' } )
+			);
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Edit link' } )
+			);
+
+			const urlInput = screen.getByRole( 'combobox', {
+				name: 'Paste or type URL',
+			} );
+			await userEvent.clear( urlInput );
+			await userEvent.type( urlInput, 'https://example.com/photo.png' );
+			await userEvent.click(
+				screen.getByRole( 'button', { name: 'Apply' } )
+			);
+
+			expect( screen.getByLabelText( 'Block: Cover' ) ).toHaveAttribute(
+				'data-url',
+				'https://example.com/photo.png'
 			);
 		} );
 

--- a/packages/block-library/src/cover/test/get-media-type-from-url.jsdom.test.js
+++ b/packages/block-library/src/cover/test/get-media-type-from-url.jsdom.test.js
@@ -1,0 +1,116 @@
+import { describe, expect, test, vi } from 'vitest';
+import getMediaTypeFromUrl from '../edit/get-media-type-from-url';
+
+/**
+ * Replaces the global `Image` constructor with a stub that resolves the load of
+ * any `src` in the way the test requires. JSDOM never fetches image sources, so
+ * the probe has to be simulated.
+ *
+ * @param {Object}   options            Options.
+ * @param {boolean}  options.loads      Whether the stub fires `onload` (as
+ *                                      opposed to `onerror`).
+ * @param {Function} [options.onCreate] Called whenever a stub is constructed.
+ */
+function stubImage( { loads, onCreate } = { loads: true } ) {
+	vi.stubGlobal(
+		'Image',
+		class StubImage {
+			constructor() {
+				onCreate?.();
+			}
+
+			set src( value ) {
+				this._src = value;
+				// Resolve on a microtask so the assignment stays synchronous.
+				Promise.resolve().then( () => {
+					if ( loads ) {
+						this.onload?.();
+					} else {
+						this.onerror?.();
+					}
+				} );
+			}
+
+			get src() {
+				return this._src;
+			}
+		}
+	);
+}
+
+describe( 'getMediaTypeFromUrl', () => {
+	test.each( [
+		'https://example.com/photo.jpg',
+		'https://example.com/photo.jpeg',
+		'https://example.com/photo.png',
+		'https://example.com/photo.gif',
+		'https://example.com/photo.webp',
+		'https://example.com/photo.avif',
+		'https://example.com/photo.svg',
+		'/relative/photo.png',
+	] )( 'detects %s as an image from its extension', async ( url ) => {
+		await expect( getMediaTypeFromUrl( url ) ).resolves.toBe( 'image' );
+	} );
+
+	test.each( [
+		'https://example.com/clip.mp4',
+		'https://example.com/clip.webm',
+		'https://example.com/clip.ogv',
+		'https://example.com/clip.mov',
+		'https://example.com/clip.m4v',
+		'/relative/clip.mp4',
+	] )( 'detects %s as a video from its extension', async ( url ) => {
+		await expect( getMediaTypeFromUrl( url ) ).resolves.toBe( 'video' );
+	} );
+
+	test( 'ignores the query string and fragment when reading the extension', async () => {
+		await expect(
+			getMediaTypeFromUrl( 'https://example.com/photo.jpg?w=800&h=600' )
+		).resolves.toBe( 'image' );
+		await expect(
+			getMediaTypeFromUrl( 'https://example.com/clip.mp4#t=10' )
+		).resolves.toBe( 'video' );
+	} );
+
+	test( 'matches extensions case-insensitively', async () => {
+		await expect(
+			getMediaTypeFromUrl( 'https://example.com/PHOTO.JPG' )
+		).resolves.toBe( 'image' );
+		await expect(
+			getMediaTypeFromUrl( 'https://example.com/CLIP.MP4' )
+		).resolves.toBe( 'video' );
+	} );
+
+	test( 'does not probe the URL when the extension is recognized', async () => {
+		const onCreate = vi.fn();
+		stubImage( { loads: true, onCreate } );
+
+		await getMediaTypeFromUrl( 'https://example.com/clip.mp4' );
+
+		expect( onCreate ).not.toHaveBeenCalled();
+	} );
+
+	test( 'probes an extensionless URL and detects an image that loads', async () => {
+		stubImage( { loads: true } );
+
+		await expect(
+			getMediaTypeFromUrl( 'https://example.com/media/12345' )
+		).resolves.toBe( 'image' );
+	} );
+
+	test( 'treats an extensionless URL that fails to load as a video', async () => {
+		stubImage( { loads: false } );
+
+		await expect(
+			getMediaTypeFromUrl( 'https://example.com/media/12345' )
+		).resolves.toBe( 'video' );
+	} );
+
+	test( 'probes a URL whose extension is neither an image nor a video', async () => {
+		stubImage( { loads: false } );
+
+		await expect(
+			getMediaTypeFromUrl( 'https://example.com/stream.m3u8' )
+		).resolves.toBe( 'video' );
+	} );
+} );

--- a/packages/block-library/src/cover/test/shared.test.js
+++ b/packages/block-library/src/cover/test/shared.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+import { attributesFromMedia } from '../shared';
+
+describe( 'attributesFromMedia', () => {
+	test( 'keeps the selected size for media picked from the library', () => {
+		expect(
+			attributesFromMedia( {
+				id: 7,
+				url: 'https://example.com/photo.jpg',
+				alt: 'A photo',
+				type: 'image',
+			} )
+		).toStrictEqual( {
+			url: 'https://example.com/photo.jpg',
+			id: 7,
+			alt: 'A photo',
+			backgroundType: 'image',
+		} );
+	} );
+
+	test( 'clears the selected size for media that is not in the library', () => {
+		// An external URL has no registered image sizes, so a size slug left
+		// over from a previously selected library image no longer applies.
+		expect(
+			attributesFromMedia( {
+				url: 'https://example.com/photo.jpg',
+				type: 'image',
+			} )
+		).toStrictEqual( {
+			url: 'https://example.com/photo.jpg',
+			id: undefined,
+			alt: undefined,
+			backgroundType: 'image',
+			sizeSlug: undefined,
+		} );
+	} );
+
+	test( 'resets the parallax setting when the media is a video', () => {
+		expect(
+			attributesFromMedia( {
+				url: 'https://example.com/clip.mp4',
+				type: 'video',
+			} )
+		).toStrictEqual( {
+			url: 'https://example.com/clip.mp4',
+			id: undefined,
+			alt: undefined,
+			backgroundType: 'video',
+			sizeSlug: undefined,
+			hasParallax: undefined,
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #10853

Adds "Insert from URL" to the Cover block, so a background image or video can be added from a URL — both when the block is empty, and via the toolbar's **Replace** flow once a background is already set.

> [!NOTE]
> There is an existing open PR for this issue, #74303 by @jenish77, which takes a different approach to detecting the media type (see **How?** below). Opening this as an alternative rather than as a replacement — happy to close it if the other approach is preferred.

## Why?
The Image, Video and Audio blocks all accept a URL, but the Cover block only accepts an upload or a media library selection. Anyone wanting a CDN- or externally-hosted background has to download and re-upload the file first.

[The workaround people have landed on (noted in the issue thread) is to insert an Image block, hot-link the URL, and transform it to a Cover — but the resulting URL then can't be edited, only removed or replaced from the library. Wiring `onSelectURL` into `MediaReplaceFlow` as well as the placeholder fixes that half too.]

## How?
One complication is that the `MediaPlaceholder` and `MediaReplaceFlow` components just pass the URL, so the block has to work out whether it points at an image or a video in order to set `backgroundType`. This is handled bty the new `getMediaTypeFromUrl()` helper which:

1. Looks at the File extension. In the majority of cases this is all we need.
2. Load it in an image element. When there's no usable extension, the URL is loaded in an `Image` — if it loads it's an image, otherwise it's treated as a video.

We deliberately don't do a fetch in Step 2 - A cross-origin `HEAD`/`GET` from the editor is usually blocked by CORS, but loading an `<img>` is not subject to CORS so it works regardless, and is how the block will actually use it. An additional benefit of this approach is that the images is cached.

Falling back to "video" for anything that won't load as an image matches the assumption `attributesFromMedia()` already makes for media of an unknown type, and matches the Image/Video blocks, which accept any URL without validating it.

The handler itself reuses the existing `onSelectMedia()`, so URL-added media goes through exactly the same dim-ratio, overlay-colour, `isDark` and parallax handling as media picked from the library:

```js
const onSelectURL = async ( newURL ) => {
	if ( ! newURL || newURL === url ) {
		return;
	}

	await onSelectMedia( {
		url: newURL,
		type: await getMediaTypeFromUrl( newURL ),
	} );
};
```

One related fix: `attributesFromMedia()` now clears `sizeSlug` for media with no `id`. Media that isn't in the library has no registered image sizes, so a size chosen for a previous library background would otherwise leave a stale `size-large` class on the saved markup (`save.js`) of a background added from a URL. This might be better in a separate PR.

## Testing Instructions
1. Insert a Cover block.
2. Click **Insert from URL**, paste a direct image URL (e.g. `https://s.w.org/style/images/about/WordPress-logotype-standard.png`) and press <kbd>Enter</kbd>. The image should become the background, with the overlay colour derived from it.
3. With the block selected, open **Replace** in the toolbar. There should now be a **Current media URL:** field. Edit it to a different image URL and click **Apply** — the background should update.
4. Repeat step 3 with a URL that has no file extension (e.g. `https://picsum.photos/seed/gutenberg/1200/600`). It should still be detected as an image.
5. Repeat step 3 with a direct `.mp4` URL. The block should switch to a video background — check the sidebar shows **Poster image** and no longer shows the image-only *Fixed background* / *Repeated background* toggles.


## Screenshots or screencast

| Before | After |
|-|-|
|<img width="678" height="270" alt="Screenshot 2026-09-09 at 16 24 08" src="https://github.com/user-attachments/assets/9813fb23-d2b3-4176-9572-73f64a25a178" />|<img width="686" height="333" alt="Screenshot 2026-09-09 at 16 23 01" src="https://github.com/user-attachments/assets/33c32e6b-df0d-4a17-b545-d4e998f8e0a6" />|



## Use of AI Tools

This PR was authored with Claude Code (Claude Opus 5) under my direction and review. I chose the media-type detection strategy and the scope; the implementation, unit/integration tests and this description were drafted by the model and reviewed and verified by me. All changes were verified by running the block-library and block-editor media test suites and by manually exercising the feature in a WordPress Playground instance (image URL, extensionless URL, video URL, and the replace flow).
