### PR TITLE
Security: Opt in to the npm v12 supply-chain defaults

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@
 /packages/interactivity                         @luisherranz @darerodz
 
 # Tooling
+.npmrc                                          @manzoorwanijk
 /bin                                            @manzoorwanijk
 /tools                                          @manzoorwanijk
 /test/php/gutenberg-coding-standards            @anton-vlasenko

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,8 @@
 /packages/interactivity                         @luisherranz @darerodz
 
 # Tooling
-.npmrc                                          @manzoorwanijk
+/.npmrc                                         @manzoorwanijk
+/package.json                                   @manzoorwanijk
 /bin                                            @manzoorwanijk
 /tools                                          @manzoorwanijk
 /test/php/gutenberg-coding-standards            @anton-vlasenko

--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,11 @@ legacy-peer-deps = true
 prefer-dedupe = true
 lockfile-version = 3
 min-release-age = 1
+# error out on install scripts not covered by the allowScripts policy in package.json
+strict-allow-scripts = true
+# only allow dependencies resolved from the registry
+allow-git = none
+allow-remote = none
+allow-file = none
+# workspace links are directory deps; transitive ones are not
+allow-directory = root

--- a/docs/contributors/code/managing-packages.md
+++ b/docs/contributors/code/managing-packages.md
@@ -9,3 +9,16 @@ Publishing WordPress packages to npm is automated by synchronizing it with the b
 ## Internal workspaces (tools and tests)
 
 The repository also contains internal workspaces under `tools/` and `test/` for development tooling and test infrastructure. When you need to add a new tool, script, or dependency for repo-level work, create a workspace under `tools/` (or add to an existing one) instead of adding dependencies to the root `package.json`. See the [Workspace Development guide](/docs/contributors/code/workspace-development.md) for the conversion pattern, CI conventions, and reference examples.
+
+## Supply chain policy
+
+`.npmrc` opts in to the npm hardening that becomes the default in npm v12.
+
+Dependencies must resolve from the registry. Git references (`EALLOWGIT`), tarball URLs (`EALLOWREMOTE`) and local tarball files (`EALLOWFILE`) are refused. Local directories are allowed only where the root or a workspace `package.json` declares them, which covers the `file:` workspace links.
+
+Install scripts are denied by default: every dependency that ships one is listed in `allowScripts` in the root `package.json`, and anything missing from that list fails the install with `ESTRICTALLOWSCRIPTS`. When that happens, read the script, then record the decision and commit the `package.json` change:
+
+```bash
+npm install-scripts deny <pkg>     # the package works without its install script
+npm install-scripts approve <pkg>  # the script is required; approval is pinned to the reviewed version
+```

--- a/package.json
+++ b/package.json
@@ -216,5 +216,17 @@
 		"tools/*",
 		"widgets/*",
 		"!test/ai-development"
-	]
+	],
+	"allowScripts": {
+		"@parcel/watcher": false,
+		"@swc/core": false,
+		"core-js": false,
+		"core-js-pure": false,
+		"esbuild": false,
+		"fs-ext": false,
+		"fsevents": false,
+		"leveldown": false,
+		"nx": false,
+		"unrs-resolver": false
+	}
 }


### PR DESCRIPTION
## What?

Closes #74877. Follow up to #82370. Opts in to the npm supply chain protections that become the default in npm v12.

Partial and temporary: #82328 tracks installing npm 12, after which these become defaults.

## Why?

Revives #79614, reverted in #79667.

## How?

`.npmrc` refuses git references, tarball URLs and local tarballs, and limits directory dependencies to those the root or a workspace declares.

`allowScripts` denies all ten dependencies that ship an install script, and `strict-allow-scripts` fails the install on anything absent from that list. #74877 proposed `ignore-scripts`, which would also disable our own scripts; this blocks dependencies only.

## Testing Instructions

1. Remove every `node_modules`, then `npm ci`. `package-lock.json` should be unchanged.
2. `npm run build`, `npm run typecheck` and `npm run lint:js` should pass.
3. Confirm each gate fires (the third edits `package.json`):

```bash
npm install --dry-run --no-save github:sindresorhus/is-odd
npm install --dry-run --no-save https://registry.npmjs.org/is-odd/-/is-odd-3.0.1.tgz
npm pkg delete allowScripts.esbuild && npm install --dry-run
git checkout package.json
```

4. In a scratch directory run `npm init -y && npm link`, then from the repo:

```bash
npm install --dry-run --no-save <scratch directory>
npm link --dry-run <scratch package name>
```

### Testing Instructions for Keyboard

N/A, no user interface change.

## Use of AI Tools

Claude Code researched the npm settings and verified them against clean installs. I reviewed all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
