### PR TITLE
Site editor v2: Identity takes its form from the view config endpoint

### DIFF
--- a/backport-changelog/7.2/13296.md
+++ b/backport-changelog/7.2/13296.md
@@ -1,4 +1,3 @@
 https://github.com/WordPress/wordpress-develop/pull/13296
 
 * https://github.com/WordPress/gutenberg/pull/82138
-* https://github.com/WordPress/gutenberg/pull/82692

--- a/backport-changelog/7.2/13296.md
+++ b/backport-changelog/7.2/13296.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/13296
 
 * https://github.com/WordPress/gutenberg/pull/82138
+* https://github.com/WordPress/gutenberg/pull/82692

--- a/backport-changelog/7.2/13462.md
+++ b/backport-changelog/7.2/13462.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/13462
+
+* https://github.com/WordPress/gutenberg/pull/82692

--- a/lib/compat/wordpress-7.2/view-config-api.php
+++ b/lib/compat/wordpress-7.2/view-config-api.php
@@ -126,6 +126,40 @@ function _gutenberg_get_entity_view_config_posttype_wp_navigation( $data ) {
 }
 
 /**
+ * Provides the view configuration for the `root`/`site` entity.
+ *
+ * The site settings are a singleton record edited through a form (the site
+ * editor's Identity screen) rather than listed in a view, so only the `form`
+ * is defined here. The generic `default_view`, `default_layouts`, and
+ * `view_list` built by gutenberg_get_entity_view_config() are left untouched.
+ *
+ * Core has no callback for this entity, so this is a base definition rather
+ * than a layer on top of one.
+ *
+ * @param Gutenberg_View_Config_Data $data The view configuration container for the entity.
+ * @return Gutenberg_View_Config_Data The updated view configuration container.
+ */
+function _gutenberg_get_entity_view_config_root_site( $data ) {
+	return $data->set(
+		array(
+			'form' => array(
+				'layout' => array(
+					'type'          => 'regular',
+					'labelPosition' => 'top',
+				),
+				'fields' => array(
+					'title',
+					'description',
+					'site_logo',
+					'site_icon',
+				),
+			),
+		),
+		1
+	);
+}
+
+/**
  * Post types whose base definition provides its own `form`, without the
  * `status` and `discussion` groups of the default post type form.
  *
@@ -207,6 +241,12 @@ function gutenberg_register_entity_view_config_filters_7_2() {
 	add_filter(
 		gutenberg_get_entity_view_config_hook_name( 'postType', 'wp_navigation' ),
 		'_gutenberg_get_entity_view_config_posttype_wp_navigation',
+		5,
+		1
+	);
+	add_filter(
+		gutenberg_get_entity_view_config_hook_name( 'root', 'site' ),
+		'_gutenberg_get_entity_view_config_root_site',
 		5,
 		1
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -55346,7 +55346,9 @@
 				"@wordpress/fields": "file:../../packages/fields",
 				"@wordpress/html-entities": "file:../../packages/html-entities",
 				"@wordpress/i18n": "file:../../packages/i18n",
-				"@wordpress/lazy-editor": "file:../../packages/lazy-editor"
+				"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+				"@wordpress/routes-lock-unlock": "file:../lock-unlock",
+				"@wordpress/views": "file:../../packages/views"
 			}
 		},
 		"routes/lock-unlock": {

--- a/packages/edit-site/src/components/sidebar-identity/index.jsx
+++ b/packages/edit-site/src/components/sidebar-identity/index.jsx
@@ -5,6 +5,11 @@ import { store as coreStore } from '@wordpress/core-data';
 import { DataForm } from '@wordpress/dataviews';
 import { MediaEdit } from '@wordpress/fields';
 import { decodeEntities } from '@wordpress/html-entities';
+import { useViewConfig } from '@wordpress/views';
+
+// The screen only renders a form, so it requests the `form` of the entity
+// view configuration alone.
+const VIEW_CONFIG_FIELDS = [ 'form' ];
 
 const fields = [
 	{
@@ -53,14 +58,6 @@ const fields = [
 	},
 ];
 
-const form = {
-	layout: {
-		type: 'regular',
-		labelPosition: 'top',
-	},
-	fields: [ 'title', 'description', 'site_logo', 'site_icon' ],
-};
-
 export default function SidebarIdentity() {
 	const data = useSelect(
 		( select ) =>
@@ -68,10 +65,19 @@ export default function SidebarIdentity() {
 		[]
 	);
 	const { editEntityRecord } = useDispatch( coreStore );
+	const { form } = useViewConfig( {
+		kind: 'root',
+		name: 'site',
+		fields: VIEW_CONFIG_FIELDS,
+	} );
 
 	const onChange = ( edits ) => {
 		editEntityRecord( 'root', 'site', undefined, edits );
 	};
+
+	if ( ! form ) {
+		return null;
+	}
 
 	return (
 		<Page title={ _x( 'Identity', 'site identity' ) } headingLevel={ 2 }>

--- a/phpunit/class-gutenberg-rest-view-config-controller-test.php
+++ b/phpunit/class-gutenberg-rest-view-config-controller-test.php
@@ -327,6 +327,33 @@ class Tests_REST_View_Config_Controller extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * The `root`/`site` entity provides the form of the site identity screen.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items_root_site_form() {
+		// Admin: reading root config requires `manage_options`.
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->dispatch_request( 'root', 'site' );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = json_decode( wp_json_encode( $response->get_data() ), true );
+
+		$this->assertSame(
+			array(
+				'type'          => 'regular',
+				'labelPosition' => 'top',
+			),
+			$data['form']['layout']
+		);
+		$this->assertSame(
+			array( 'title', 'description', 'site_logo', 'site_icon' ),
+			$data['form']['fields']
+		);
+	}
+
+	/**
 	 * Empty object-typed config values serialize as JSON objects ({}), not arrays ([]).
 	 *
 	 * @covers ::get_items

--- a/routes/identity/package.json
+++ b/routes/identity/package.json
@@ -16,6 +16,8 @@
 		"@wordpress/fields": "file:../../packages/fields",
 		"@wordpress/html-entities": "file:../../packages/html-entities",
 		"@wordpress/i18n": "file:../../packages/i18n",
-		"@wordpress/lazy-editor": "file:../../packages/lazy-editor"
+		"@wordpress/lazy-editor": "file:../../packages/lazy-editor",
+		"@wordpress/routes-lock-unlock": "file:../lock-unlock",
+		"@wordpress/views": "file:../../packages/views"
 	}
 }

--- a/routes/identity/route.ts
+++ b/routes/identity/route.ts
@@ -1,6 +1,14 @@
 import { resolveSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { _x } from '@wordpress/i18n';
+import { unlock } from '@wordpress/routes-lock-unlock';
+
+/**
+ * The stage only renders a form, so it requests the `form` of the entity view
+ * configuration alone. Must match the fields the stage requests so both resolve
+ * under the same cache key.
+ */
+const VIEW_CONFIG_FIELDS = 'form';
 
 /**
  * Route configuration for the site identity.
@@ -13,8 +21,18 @@ export const route = {
 		};
 	},
 	loader: async () => {
-		// The stage renders a form over the site settings, so preload them
-		// before the surface mounts.
-		await resolveSelect( coreStore ).getEntityRecord( 'root', 'site' );
+		await Promise.all( [
+			// The stage renders a form over the site settings, so preload them
+			// before the surface mounts.
+			resolveSelect( coreStore ).getEntityRecord( 'root', 'site' ),
+			// Preload the form configuration the stage renders.
+			unlock( resolveSelect( coreStore ) ).getViewConfig(
+				'root',
+				'site',
+				{
+					fields: VIEW_CONFIG_FIELDS,
+				}
+			),
+		] );
 	},
 };

--- a/routes/identity/stage.tsx
+++ b/routes/identity/stage.tsx
@@ -2,7 +2,8 @@ import { Page } from '@wordpress/admin-ui';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { DataForm, type Field, type Form } from '@wordpress/dataviews';
+import { DataForm, type Field } from '@wordpress/dataviews';
+import { useViewConfig } from '@wordpress/views';
 import { MediaEdit } from '@wordpress/fields';
 import { loadEditorAssets } from '@wordpress/lazy-editor';
 import { useEffect, useState } from '@wordpress/element';
@@ -98,13 +99,12 @@ const fields: Field< SiteSettings >[] = [
 	},
 ];
 
-const form: Form = {
-	layout: {
-		type: 'regular',
-		labelPosition: 'top',
-	},
-	fields: [ 'title', 'description', 'site_logo', 'site_icon' ],
-};
+/**
+ * The stage only renders a form, so it requests the `form` of the entity view
+ * configuration alone. Must match the fields the route loader requests so both
+ * resolve under the same cache key.
+ */
+const VIEW_CONFIG_FIELDS = [ 'form' ];
 
 function Identity() {
 	const data = useSelect(
@@ -118,11 +118,22 @@ function Identity() {
 		[]
 	);
 	const { editEntityRecord } = useDispatch( coreStore );
+	const { form } = useViewConfig( {
+		kind: 'root',
+		name: 'site',
+		fields: VIEW_CONFIG_FIELDS,
+	} );
 
 	const onChange = ( edits: Record< string, any > ) => {
 		// The site entity is a singleton and has no record key.
 		editEntityRecord( 'root', 'site', undefined, edits );
 	};
+
+	if ( ! form ) {
+		// The route loader resolves the form configuration before the stage
+		// mounts, so this only guards against the store being reset.
+		return null;
+	}
 
 	return (
 		<Page title={ _x( 'Identity', 'site identity' ) } headingLevel={ 2 }>

--- a/routes/identity/tsconfig.json
+++ b/routes/identity/tsconfig.json
@@ -19,7 +19,8 @@
 		{ "path": "../../packages/fields/tsconfig.build.json" },
 		{ "path": "../../packages/html-entities/tsconfig.build.json" },
 		{ "path": "../../packages/i18n/tsconfig.build.json" },
-		{ "path": "../../packages/lazy-editor" }
+		{ "path": "../../packages/lazy-editor" },
+		{ "path": "../../packages/views/tsconfig.build.json" }
 	],
 	"include": [ "**/*.ts", "**/*.tsx" ],
 	"exclude": [ "build", "node_modules" ]


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/79895

## What?

Makes the **Identity** screen take its form from the view configuration endpoint, served by `GET /wp/v2/view-config?kind=root&name=site`, instead of a hard-coded form. Both the extensible site editor route (`routes/identity`) and the site editor v1 screen (`packages/edit-site`) are updated, so the two stay in sync.

## Why?

The tracking issue asks every screen of the extensible site editor to take its view configuration from the endpoint. The Identity screen renders a form rather than a list, and the endpoint had no form definition for the `root`/`site` entity, so this PR adds one and wires the route to it. Plugins can now adjust the form through the `get_entity_view_config_root_site` filter, as they can for the post type screens.

## How?

- PHP (`lib/compat/wordpress-7.2/view-config-api.php`): adds a base definition for the `root`/`site` entity that provides the `form` the Identity screen renders (regular layout with labels on top, and the site title, tagline, logo, and icon fields). Only the form is defined, since the site settings are a singleton record that is never listed in a view. A PHPUnit test covers the response.
- JS (`routes/identity/`): the stage reads the form through `useViewConfig`, requesting only the `form` property, and the route loader preloads it under the same cache key so the form is available when the stage mounts. The fields stay local to the route, as before.
- JS (`packages/edit-site/src/components/sidebar-identity`): the site editor v1 screen reads the form the same way, and renders nothing until it has resolved.

## Testing Instructions

1. Enable the **Extensible Site Editor** experiment under Gutenberg → Experiments, with a block theme active (e.g. Twenty Twenty-Five).
2. Go to `/wp-admin/admin.php?page=site-editor-v2` and click **Identity** in the sidebar.
3. Confirm the form renders as before, with the Site Title, Site Tagline, Site Logo, and Site Icon fields, and that editing a field and saving still works.
4. Open DevTools → Network and confirm a single request to `/wp/v2/view-config?kind=root&name=site&_fields=form` returning `form.layout.type === "regular"` and the four field ids.
5. Add a filter in a plugin or `functions.php` and confirm it's honored, e.g. the Site Icon field disappears with:
   ```php
   add_filter( 'get_entity_view_config_root_site', function ( $data ) {
       return $data->remove( array( 'form' => array( 'fields' => array( 'site_icon' ) ) ), 1 );
   } );
   ```
6. Go to `/wp-admin/site-editor.php?p=%2Fidentity` (the site editor v1) and repeat steps 3 to 5 there.
7. Run `npm run test:unit:php:base -- -- --filter Tests_REST_View_Config_Controller`.

### Testing Instructions for Keyboard

Open the Identity screen in either site editor, use Tab to move through the four fields, and confirm they can be edited with the keyboard as before.

## Screenshots or screencast

The screens look the same as before the change.

## Use of AI Tools

Implemented with Claude Code (Claude Fable 5.1). Reviewed and adjusted by the author.
