### PR TITLE
Storybook: Include stories in docgen TypeScript project

### DIFF
--- a/storybook/tsconfig.docgen.json
+++ b/storybook/tsconfig.docgen.json
@@ -7,5 +7,14 @@
 		"rootDir": ".."
 	},
 	"references": [],
-	"include": [ "**/*.ts", "**/*.tsx", "../packages/*/src/**/*" ]
+	"include": [ "**/*.ts", "**/*.tsx", "../packages/*/src/**/*" ],
+	// Override the base exclusions to admit stories without also admitting tests.
+	"exclude": [
+		"../**/benchmark",
+		"../packages/*/build-*/**",
+		"../packages/*/build/**",
+		"../**/test/**",
+		"../**/tests/**",
+		"../**/__tests__/**"
+	]
 }

--- a/storybook/tsconfig.docgen.json
+++ b/storybook/tsconfig.docgen.json
@@ -11,8 +11,6 @@
 	// Override the base exclusions to admit stories without also admitting tests.
 	"exclude": [
 		"../**/benchmark",
-		"../packages/*/build-*/**",
-		"../packages/*/build/**",
 		"../**/test/**",
 		"../**/tests/**",
 		"../**/__tests__/**"


### PR DESCRIPTION
## What?

Includes TypeScript story files in Storybook's docgen project.

## Why?

The docgen config inherited the root TypeScript exclusions for story files. As a result, `npm run storybook:build` printed 223 warnings and skipped docgen for every loaded TypeScript story module, including the Components `Animate` stories.

## How?

Overrides the inherited exclusions so stories remain in the docgen project while benchmarks, generated builds, and tests stay excluded.

## Testing Instructions

1. Run `npm run storybook:build`.
2. Confirm the build completes without `Skipping docgen` warnings.

## Use of AI Tools

Codex was used to inspect the build logs, prepare the config change, and run verification.
