### PR TITLE
Test: Prototype shared Vite server for Node and jsdom projects

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -104,7 +104,7 @@ jobs:
               run: npm run lint:js -- --format compact --quiet --prune-suppressions
 
             - name: Test agent skill setup
-              run: npm run test:unit:vitest -- --project=node tools/agents/test/setup-skills.test.js
+              run: npm run test:unit:vitest -- --project='unit (node)' tools/agents/test/setup-skills.test.js
 
             - name: Lint Styles
               if: ${{ matrix.annotations }}

--- a/test/unit/scripts/discover-test-files.mjs
+++ b/test/unit/scripts/discover-test-files.mjs
@@ -20,6 +20,7 @@ export const TEST_IGNORES = [
 ];
 
 export const VITEST_PROJECT_NAMES = [ 'node', 'jsdom', 'browser' ];
+export const VITEST_SHARED_PROJECT_NAME = 'unit';
 
 const JSDOM_TEST_PATH_PATTERN = /\.jsdom\.test\.[jt]sx?$/;
 const BROWSER_TEST_PATH_PATTERN = /\.browser\.test\.[jt]sx?$/;
@@ -70,6 +71,14 @@ export function getTestEnvironmentName( testPath ) {
 	}
 
 	return 'node';
+}
+
+export function getVitestProjectName( listedProjectName ) {
+	const nestedProjectName = listedProjectName.match(
+		new RegExp( `^${ VITEST_SHARED_PROJECT_NAME } \\(([^)]+)\\)$` )
+	)?.[ 1 ];
+
+	return nestedProjectName ?? listedProjectName.replace( / \(.+\)$/, '' );
 }
 
 export function getVitestTestsByProject( discoveredTests, manifest ) {

--- a/test/unit/scripts/test-infrastructure-policy.mjs
+++ b/test/unit/scripts/test-infrastructure-policy.mjs
@@ -290,7 +290,7 @@ function getPropertyName( property ) {
 function findConfigIsolationOptOuts( rootDir ) {
 	const violations = [];
 	const configFiles = globSync(
-		'**/{vite,vitest}.config.{js,jsx,cjs,mjs,ts,tsx,cts,mts}',
+		'**/{vite,vitest}{,.*}.config.{js,jsx,cjs,mjs,ts,tsx,cts,mts}',
 		{
 			cwd: rootDir,
 			ignore: SOURCE_IGNORES,
@@ -342,7 +342,10 @@ export function findVitestIsolationOptOuts( rootDir ) {
 	].sort();
 }
 
-export function validateVitestCleanupConfig( vitestConfig ) {
+export function validateVitestCleanupConfig(
+	vitestConfig,
+	configFile = 'test/unit/vitest.config.mjs'
+) {
 	const violations = [];
 	const requiredOptions = [
 		'isolate',
@@ -354,39 +357,39 @@ export function validateVitestCleanupConfig( vitestConfig ) {
 
 	for ( const option of requiredOptions ) {
 		if ( vitestConfig.test?.[ option ] !== true ) {
-			violations.push(
-				`test/unit/vitest.config.mjs: test.${ option } must be true`
-			);
+			violations.push( `${ configFile }: test.${ option } must be true` );
 		}
 	}
 	if ( vitestConfig.test?.globals !== false ) {
-		violations.push(
-			'test/unit/vitest.config.mjs: test.globals must remain false'
-		);
+		violations.push( `${ configFile }: test.globals must remain false` );
 	}
 	if ( vitestConfig.test?.clearMocks !== false ) {
 		violations.push(
-			'test/unit/vitest.config.mjs: test.clearMocks must remain false while test.mockReset is true'
+			`${ configFile }: test.clearMocks must remain false while test.mockReset is true`
 		);
 	}
 
 	for ( const project of vitestConfig.test?.projects ?? [] ) {
+		if ( typeof project === 'string' ) {
+			continue;
+		}
+
 		const projectName = project.test?.name ?? 'unnamed';
 		if ( project.extends !== true ) {
 			violations.push(
-				`test/unit/vitest.config.mjs: ${ projectName } must set extends: true to inherit the shared isolation defaults`
+				`${ configFile }: ${ projectName } must set extends: true to inherit the shared isolation defaults`
 			);
 		}
 		for ( const option of requiredOptions ) {
 			if ( project.test?.[ option ] === false ) {
 				violations.push(
-					`test/unit/vitest.config.mjs: ${ projectName } overrides test.${ option } with false`
+					`${ configFile }: ${ projectName } overrides test.${ option } with false`
 				);
 			}
 		}
 		if ( project.test?.globals === true ) {
 			violations.push(
-				`test/unit/vitest.config.mjs: ${ projectName } enables global Vitest APIs`
+				`${ configFile }: ${ projectName } enables global Vitest APIs`
 			);
 		}
 	}

--- a/test/unit/scripts/test/discover-test-files.test.js
+++ b/test/unit/scripts/test/discover-test-files.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	findAddedLegacyJestTests,
 	getTestEnvironmentName,
+	getVitestProjectName,
 	getVitestTestsByProject,
 } from '../discover-test-files.mjs';
 import { sourceHasTestEnvironmentOverride } from '../test-environment-overrides.mjs';
@@ -19,6 +20,16 @@ describe( 'getTestEnvironmentName', () => {
 
 	it( 'routes *.browser.test.* filenames to Browser Mode', () => {
 		expect( getTestEnvironmentName( 'example.browser.test.js' ) ).toBe(
+			'browser'
+		);
+	} );
+} );
+
+describe( 'getVitestProjectName', () => {
+	it( 'normalizes nested Node and jsdom project labels', () => {
+		expect( getVitestProjectName( 'unit (node)' ) ).toBe( 'node' );
+		expect( getVitestProjectName( 'unit (jsdom)' ) ).toBe( 'jsdom' );
+		expect( getVitestProjectName( 'browser (chromium)' ) ).toBe(
 			'browser'
 		);
 	} );

--- a/test/unit/scripts/test/test-infrastructure-policy.test.js
+++ b/test/unit/scripts/test/test-infrastructure-policy.test.js
@@ -211,7 +211,7 @@ describe( 'runner isolation policy', () => {
 			recursive: true,
 		} );
 		writeFileSync(
-			path.join( rootDir, 'vitest.config.mjs' ),
+			path.join( rootDir, 'vitest.node-jsdom.config.mjs' ),
 			`const isolate = true;
 export default {
 	test: {
@@ -238,8 +238,8 @@ export default {
 			'.github/workflows/test.yml:1 disables Vitest module isolation: vitest --no-isolate',
 			'package.json:scripts.test disables Vitest module isolation: vitest --no-isolate',
 			'package.json:scripts.test:browser disables Vitest module isolation: vitest --browser.isolate=false',
-			'vitest.config.mjs:4 must set isolate to the literal value true',
-			'vitest.config.mjs:6 must set isolate to the literal value true',
+			'vitest.node-jsdom.config.mjs:4 must set isolate to the literal value true',
+			'vitest.node-jsdom.config.mjs:6 must set isolate to the literal value true',
 		] );
 	} );
 
@@ -258,22 +258,26 @@ export default {
 		);
 	} );
 
-	it( 'requires every Vitest project to inherit the shared defaults', () => {
+	it( 'allows referenced project containers while requiring inline projects to inherit shared cleanup defaults', () => {
 		expect(
 			validateVitestCleanupConfig( {
 				test: {
+					clearMocks: false,
 					globals: false,
 					isolate: true,
 					mockReset: true,
 					restoreMocks: true,
 					unstubEnvs: true,
 					unstubGlobals: true,
-					projects: [ { extends: false, test: { name: 'escape' } } ],
+					projects: [
+						'vitest.unit.config.mjs',
+						{ extends: false, test: { name: 'escape' } },
+					],
 				},
 			} )
-		).toContain(
-			'test/unit/vitest.config.mjs: escape must set extends: true to inherit the shared isolation defaults'
-		);
+		).toEqual( [
+			'test/unit/vitest.config.mjs: escape must set extends: true to inherit the shared isolation defaults',
+		] );
 	} );
 } );
 

--- a/test/unit/scripts/validate-test-routing.mjs
+++ b/test/unit/scripts/validate-test-routing.mjs
@@ -9,6 +9,7 @@ import {
 	findAddedLegacyJestTests,
 	findOverlappingVitestProjectTests,
 	getTestEnvironmentName,
+	getVitestProjectName,
 	getVitestTests,
 	getVitestTestsByProject,
 	VITEST_PROJECT_NAMES,
@@ -95,7 +96,7 @@ function listVitestTestsByProject() {
 		const match = line.match( /^\[([^\]]+)\]\s+(.+)$/ );
 		assert.ok( match, `Unexpected Vitest list output: ${ line }` );
 		const [ , listedProjectName, testPath ] = match;
-		const projectName = listedProjectName.replace( / \(.+\)$/, '' );
+		const projectName = getVitestProjectName( listedProjectName );
 		assert.ok(
 			testsByProject[ projectName ],
 			`Unexpected Vitest project \`${ projectName }\`. Expected only: ${ VITEST_PROJECT_NAMES.join(

--- a/test/unit/scripts/validate-vitest-conventions.mjs
+++ b/test/unit/scripts/validate-vitest-conventions.mjs
@@ -55,7 +55,9 @@ const vitestTestSet = new Set( vitestTests );
 const jsdomTests = new Set( vitestTestsByProject.jsdom );
 const browserTests = new Set( vitestTestsByProject.browser );
 const vitestInfrastructure = [
+	'vitest.unit.config.mjs',
 	'test/unit/vitest.config.mjs',
+	'test/unit/vitest.node-jsdom.config.mjs',
 	...globSync( 'test/unit/config/**/*.vitest*.{js,jsx,mjs,ts,tsx}', {
 		cwd: ROOT_DIR,
 		nodir: true,
@@ -140,15 +142,23 @@ const rootPackageJson = JSON.parse(
 const unitTestPackageJson = JSON.parse(
 	readFileSync( path.join( ROOT_DIR, 'test/unit/package.json' ), 'utf8' )
 );
-const vitestConfig = (
-	await import(
-		pathToFileURL( path.join( ROOT_DIR, 'test/unit/vitest.config.mjs' ) )
-	)
-).default;
+const vitestConfigFiles = [
+	'test/unit/vitest.config.mjs',
+	'test/unit/vitest.node-jsdom.config.mjs',
+];
+const vitestConfigs = await Promise.all(
+	vitestConfigFiles.map( async ( configFile ) => [
+		configFile,
+		( await import( pathToFileURL( path.join( ROOT_DIR, configFile ) ) ) )
+			.default,
+	] )
+);
 violations.push(
 	...findVitestIsolationOptOuts( ROOT_DIR ),
 	...validateRoutingScripts( rootPackageJson, unitTestPackageJson ),
-	...validateVitestCleanupConfig( vitestConfig ),
+	...vitestConfigs.flatMap( ( [ configFile, config ] ) =>
+		validateVitestCleanupConfig( config, configFile )
+	),
 	...validateVitestShuffleScripts( rootPackageJson, unitTestPackageJson )
 );
 

--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -35,7 +35,7 @@ const vitestTests = getVitestTestsByProject(
 	discoverTestFiles( ROOT_DIR ),
 	testMigration
 );
-const styleMockAlias = {
+export const styleMockAlias = {
 	find: /^.*\.(?:css|scss)$/,
 	replacement: path.join( ROOT_DIR, 'test/unit/config/style-mock.vitest.js' ),
 };
@@ -76,7 +76,7 @@ const transpiledPackageNames = globSync(
 		return relative.split( path.sep )[ 1 ];
 	} );
 
-export default defineConfig( {
+export const sharedViteConfig = {
 	root: ROOT_DIR,
 	oxc: {
 		jsx: {
@@ -152,105 +152,96 @@ export default defineConfig( {
 			},
 		],
 	},
+};
+
+export const sharedTestConfig = {
+	// mockReset already clears every mock. Keep clearMocks disabled to make
+	// that overlap explicit and avoid a redundant cleanup pass.
+	clearMocks: false,
+	globals: false,
+	includeTaskLocation: true,
+	isolate: true,
+	mockReset: true,
+	passWithNoTests: false,
+	reporters,
+	sequence: {
+		hooks: 'list',
+		setupFiles: 'list',
+	},
+	snapshotFormat: {
+		escapeString: false,
+		printBasicPrototype: false,
+	},
+	restoreMocks: true,
+	unstubEnvs: true,
+	unstubGlobals: true,
+};
+
+export const nodeProject = {
+	extends: true,
 	test: {
-		projects: [
-			{
-				extends: true,
-				resolve: {
-					alias: [ styleMockAlias ],
-				},
-				test: {
-					name: 'node',
-					environment: 'node',
-					pool: 'threads',
-					include: vitestTests.node,
-					setupFiles: [
-						gutenbergEnvSetupFile,
-						path.join(
-							ROOT_DIR,
-							'test/unit/config/console.vitest.js'
-						),
-						isolationSetupFile,
-					],
-				},
-			},
-			{
-				extends: true,
-				resolve: {
-					alias: [ styleMockAlias ],
-				},
-				test: {
-					name: 'jsdom',
-					environment: 'jsdom',
-					pool: 'threads',
-					environmentOptions: {
-						jsdom: {
-							url: 'http://localhost/',
-						},
-					},
-					include: vitestTests.jsdom,
-					setupFiles: [
-						path.join(
-							ROOT_DIR,
-							'test/unit/config/setup-globals.vitest.js'
-						),
-						path.join(
-							ROOT_DIR,
-							'test/unit/config/global-mocks.vitest.js'
-						),
-						gutenbergEnvSetupFile,
-						path.join(
-							ROOT_DIR,
-							'test/unit/config/console.vitest.js'
-						),
-						path.join(
-							ROOT_DIR,
-							'test/unit/config/testing-library.vitest.js'
-						),
-						isolationSetupFile,
-					],
-				},
-			},
-			{
-				extends: true,
-				test: {
-					name: 'browser',
-					include: vitestTests.browser,
-					setupFiles: [
-						path.join(
-							ROOT_DIR,
-							'test/unit/config/console.vitest.js'
-						),
-						isolationSetupFile,
-					],
-					browser: {
-						enabled: true,
-						headless: true,
-						instances: [ { browser: 'chromium' } ],
-						provider: playwright(),
-					},
-				},
-			},
+		name: 'node',
+		environment: 'node',
+		pool: 'threads',
+		include: vitestTests.node,
+		setupFiles: [
+			gutenbergEnvSetupFile,
+			path.join( ROOT_DIR, 'test/unit/config/console.vitest.js' ),
+			isolationSetupFile,
 		],
-		// mockReset already clears every mock. Keep clearMocks disabled to make
-		// that overlap explicit and avoid a redundant cleanup pass.
-		clearMocks: false,
-		globals: false,
-		includeTaskLocation: true,
-		isolate: true,
-		mockReset: true,
-		passWithNoTests: false,
-		reporters,
-		sequence: {
-			hooks: 'list',
-			setupFiles: 'list',
+	},
+};
+
+export const jsdomProject = {
+	extends: true,
+	test: {
+		name: 'jsdom',
+		environment: 'jsdom',
+		pool: 'threads',
+		environmentOptions: {
+			jsdom: {
+				url: 'http://localhost/',
+			},
 		},
-		snapshotFormat: {
-			escapeString: false,
-			printBasicPrototype: false,
+		include: vitestTests.jsdom,
+		setupFiles: [
+			path.join( ROOT_DIR, 'test/unit/config/setup-globals.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/global-mocks.vitest.js' ),
+			gutenbergEnvSetupFile,
+			path.join( ROOT_DIR, 'test/unit/config/console.vitest.js' ),
+			path.join( ROOT_DIR, 'test/unit/config/testing-library.vitest.js' ),
+			isolationSetupFile,
+		],
+	},
+};
+
+const browserProject = {
+	extends: true,
+	test: {
+		name: 'browser',
+		include: vitestTests.browser,
+		setupFiles: [
+			path.join( ROOT_DIR, 'test/unit/config/console.vitest.js' ),
+			isolationSetupFile,
+		],
+		browser: {
+			enabled: true,
+			headless: true,
+			instances: [ { browser: 'chromium' } ],
+			provider: playwright(),
 		},
-		restoreMocks: true,
-		unstubEnvs: true,
-		unstubGlobals: true,
+	},
+};
+
+export default defineConfig( {
+	...sharedViteConfig,
+	test: {
+		...sharedTestConfig,
+		projects: [
+			// Vitest roots referenced config files at their directory. The
+			// repository-root proxy preserves the existing include paths.
+			path.join( ROOT_DIR, 'vitest.unit.config.mjs' ),
+			browserProject,
+		],
 	},
 } );

--- a/test/unit/vitest.node-jsdom.config.mjs
+++ b/test/unit/vitest.node-jsdom.config.mjs
@@ -1,0 +1,21 @@
+import { defineProject } from 'vitest/config';
+import {
+	jsdomProject,
+	nodeProject,
+	sharedTestConfig,
+	sharedViteConfig,
+	styleMockAlias,
+} from './vitest.config.mjs';
+
+export default defineProject( {
+	...sharedViteConfig,
+	resolve: {
+		...sharedViteConfig.resolve,
+		alias: [ ...sharedViteConfig.resolve.alias, styleMockAlias ],
+	},
+	test: {
+		...sharedTestConfig,
+		name: 'unit',
+		projects: [ nodeProject, jsdomProject ],
+	},
+} );

--- a/vitest.unit.config.mjs
+++ b/vitest.unit.config.mjs
@@ -1,0 +1,3 @@
+// Keep this proxy at the repository root so the referenced Node and jsdom
+// project container inherits the same Vite root as the main configuration.
+export { default } from './test/unit/vitest.node-jsdom.config.mjs';


### PR DESCRIPTION
## What?

Follow up to #82687.

Prototype a nested Vitest project for the Node and jsdom suites so they inherit one configuration and share one Vite server. Browser Mode remains a separate project.

This also re-tests `fsModuleCache`; it is not enabled by this PR.

## Why?

Node and jsdom currently build separate Vite module graphs. Vitest 5 can share a server between nested inline projects, but the first prototype rooted its referenced configuration under `test/unit` and discovered no integration tests.

## How?

- Add a repository-root proxy for the referenced Node/jsdom project container. This preserves the existing repository-relative include paths.
- Move shared Vite and test options to the container, then keep the Node and jsdom projects inline so Vitest reuses one server.
- Normalize nested project labels in routing checks and validate cleanup defaults in both configuration files.
- Update the focused CI project selector. Browser Mode stays independent.

<details>
<summary>Benchmark notes</summary>

On the #82687 merge commit, five alternating runs used shard 1/8, four workers, seed 80855, and the same 134 files / 3,476 tests each time.

- Separate servers: 52.4s median, 55.3s mean.
- Shared server: 47.7s median, 59.2s mean.

The shared server improved the median by 9.0%, but two slow samples made the mean 7.0% worse. This remains a prototype rather than a stable performance claim.

A separate three-run warm-cache comparison improved both the median (42.6s vs 46.0s) and mean (43.9s vs 47.3s). However, priming took 97.0s, the single-shard cache occupied 84 MB across 5,959 files, and [`fsModuleCache` does not support Browser Mode](https://vitest.dev/config/fsmodulecache). It remains disabled.

</details>

## Testing Instructions

1. Run `npm run test:unit:routing`. Confirm it validates 1,071 Vitest files, with every test assigned exactly once.
2. Run `DEBUG=vitest:projects npm exec --no -- vitest list --config=test/unit/vitest.config.mjs --filesOnly`. Confirm `unit (jsdom)` reuses the Vite server created for `unit (node)` and Browser Mode creates a separate server.
3. Run `npm run test:unit:vitest -- --project='unit (node)' test/unit/scripts/test/discover-test-files.test.js test/unit/scripts/test/test-infrastructure-policy.test.js`.
4. Run `npm run test:unit:vitest -- --project='browser (chromium)'`.
5. Run `npm run build` and `npm run typecheck`.

### Testing Instructions for Keyboard

Not applicable. This PR does not change UI behavior.

## Screenshots or screencast

Not applicable.

## Use of AI Tools

Codex was used to prototype the configuration, add tests, run benchmarks, and draft this PR. The resulting diff and verification output were reviewed before publication.
