### PR TITLE
Test: Root the Vitest browser project where its dependencies are declared

### DIFF
--- a/test/unit/vitest.config.mjs
+++ b/test/unit/vitest.config.mjs
@@ -11,10 +11,8 @@ import {
 	getVitestTestsByProject,
 } from './scripts/discover-test-files.mjs';
 
-const ROOT_DIR = path.resolve(
-	path.dirname( fileURLToPath( import.meta.url ) ),
-	'../..'
-);
+const CONFIG_DIR = path.dirname( fileURLToPath( import.meta.url ) );
+const ROOT_DIR = path.resolve( CONFIG_DIR, '../..' );
 const nodeRequire = createRequire( import.meta.url );
 const emotionPlugin = nodeRequire.resolve( '@swc/plugin-emotion' );
 const gutenbergEnvSetupFile = path.join(
@@ -213,8 +211,15 @@ export default defineConfig( {
 			},
 			{
 				extends: true,
+				/*
+				 * Browser mode pre-bundles the Vitest runtime, which Vite resolves
+				 * from the project root. Root the project where the test
+				 * dependencies are declared so resolution stays layout agnostic.
+				 */
+				root: CONFIG_DIR,
 				test: {
 					name: 'browser',
+					dir: ROOT_DIR,
 					include: vitestTests.browser,
 					setupFiles: [
 						path.join(


### PR DESCRIPTION
## What?

Roots the Vitest `browser` project at `test/unit`, where the test dependencies are declared, and keeps test discovery at the repository root via `test.dir`.

## Why?

Browser mode pre-bundles the Vitest runtime, listing `vitest`, `vitest/internal/browser` and `vitest/internal/traces` in `optimizeDeps.include` since #82687. Vite resolves those from the project root, which was the repository root, so it only worked while they were hoisted there. With an isolated `node_modules` layout ([#75814](https://github.com/WordPress/gutenberg/pull/75814)) none of the include entries resolve. `vitest` is still pre-bundled because the dependency scanner finds it through the setup files, but `vitest/internal/browser` is not, so the tester loads a second copy of the runtime and every browser test fails with `Vitest failed to find the runner` ([failing run](https://github.com/WordPress/gutenberg/actions/runs/34373813581/job/102541459059?pr=75814)).

## How?

Sets `root` on the browser project only, so the `node` and `jsdom` projects are untouched. Browser test paths now print relative to `test/unit`.

## Testing Instructions

1. Run `npm run test:unit:vitest -- --project browser`.
2. Both test files pass, and Vite logs no `Failed to resolve dependency` warnings.

## Use of AI Tools

Claude Code diagnosed the resolution failure and drafted the change and this description. I reviewed and tested both.
