### PR TITLE
CI: Ignore Google Chrome APT source during Playwright setup

### DIFF
--- a/.github/setup-playwright/action.yml
+++ b/.github/setup-playwright/action.yml
@@ -67,8 +67,34 @@ runs:
               # `--update=none` needs coreutils 9.3+, so ubuntu-24.04 or newer.
               sudo cp -r --update=none "$HOME/apt-cache/." /var/cache/apt/archives/
 
+              # Playwright downloads its own browser binaries and needs only
+              # Ubuntu packages here. Temporarily hide the runner's Google
+              # Chrome source so an unrelated repository update cannot make
+              # apt reject the dependency installation.
+              google_chrome_sources=(
+                  /etc/apt/sources.list.d/google-chrome.list
+                  /etc/apt/sources.list.d/google-chrome.sources
+              )
+              restore_google_chrome_sources() {
+                  for source in "${google_chrome_sources[@]}"; do
+                      disabled_source="$RUNNER_TEMP/$(basename "$source").disabled"
+                      if [ -f "$disabled_source" ]; then
+                          sudo mv "$disabled_source" "$source"
+                      fi
+                  done
+              }
+              trap restore_google_chrome_sources EXIT
+              for source in "${google_chrome_sources[@]}"; do
+                  if [ -f "$source" ]; then
+                      sudo mv "$source" "$RUNNER_TEMP/$(basename "$source").disabled"
+                  fi
+              done
+
               # shellcheck disable=SC2086 # The browser list is intentionally split into separate arguments.
               npm exec --no --workspace "$WORKSPACE" -- playwright install $BROWSERS --with-deps
+
+              restore_google_chrome_sources
+              trap - EXIT
 
               sudo find /var/cache/apt/archives -maxdepth 1 -name '*.deb' -exec cp --update=none -t "$HOME/apt-cache" {} +
               sudo chown -R "$(id -u):$(id -g)" "$HOME/apt-cache"


### PR DESCRIPTION
Related trunk failures:

- [Unit Tests](https://github.com/WordPress/gutenberg/actions/runs/34385751843)
- [End-to-End Tests](https://github.com/WordPress/gutenberg/actions/runs/34385751856)

## What?

Keep Playwright browser jobs independent from the GitHub runner's Google Chrome APT repository.

## Why?

Google's repository published package metadata that did not match its release checksum. This caused `apt-get update` to fail in 14 browser jobs before any tests ran.

Playwright downloads its own browser binaries, and its Linux dependencies come from Ubuntu. The Google Chrome repository is not needed during this step.

## How?

Temporarily move the runner's Google Chrome source out of APT's source directory while `playwright install --with-deps` runs. An exit trap restores the source on success or failure so reusable runners keep their original configuration.

## Testing Instructions

1. Confirm the Unit Tests, End-to-End Tests, and Storybook workflows complete their Playwright installation steps.
2. Inspect an installation log and confirm APT fetches the Ubuntu package indexes without requesting `dl.google.com/linux/chrome-stable/deb`.

## Use of AI Tools

Codex: failure analysis, implementation, verification, and PR drafting.
