### PR TITLE
fix: expose lightbox captions to assistive technology

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -378,8 +378,8 @@ function block_core_image_print_lightbox_overlay() {
 					<span class="wp-lightbox-navigation-text" data-wp-bind--hidden="!state.hasNavigationText">{$prev_button_text}</span>
 				</button>
 				<div class="lightbox-image-container">
-					<figure data-wp-bind--class="state.selectedImage.figureClassNames" data-wp-bind--style="state.figureStyles">
-						<img data-wp-bind--alt="state.selectedImage.alt" data-wp-bind--class="state.selectedImage.imgClassNames" data-wp-bind--style="state.imgStyles" data-wp-bind--src="state.selectedImage.currentSrc">
+					<figure aria-hidden="true" data-wp-bind--class="state.selectedImage.figureClassNames" data-wp-bind--style="state.figureStyles">
+						<img alt="" data-wp-bind--class="state.selectedImage.imgClassNames" data-wp-bind--style="state.imgStyles" data-wp-bind--src="state.selectedImage.currentSrc">
 					</figure>
 				</div>
 				<div class="lightbox-image-container">
@@ -392,6 +392,7 @@ function block_core_image_print_lightbox_overlay() {
 							data-wp-bind--srcset="state.enlargedSrcset"
 							sizes="100vw"
 						>
+						<figcaption data-wp-bind--hidden="!state.selectedImage.caption" data-wp-text="state.selectedImage.caption"></figcaption>
 					</figure>
 				</div>
 				<button type="button" style="fill:{$close_button_color}" class="wp-lightbox-navigation-button wp-lightbox-navigation-button-next" data-wp-bind--hidden="!state.hasNavigation" data-wp-on--click="actions.showNextImage" data-wp-bind--aria-label="state.nextButtonAriaLabel">

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -326,11 +326,12 @@
 		}
 
 		figcaption {
-			display: block;
-			max-width: var(--wp--lightbox-image-width);
-			margin-top: 1rem;
-			color: #fff;
-			text-align: center;
+			clip-path: inset(50%);
+			height: 1px;
+			overflow: hidden;
+			position: absolute;
+			white-space: nowrap;
+			width: 1px;
 		}
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -326,7 +326,11 @@
 		}
 
 		figcaption {
-			display: none;
+			display: block;
+			max-width: var(--wp--lightbox-image-width);
+			margin-top: 1rem;
+			color: #fff;
+			text-align: center;
 		}
 	}
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -619,6 +619,12 @@ const { state, actions, callbacks } = store(
 				}
 
 				const figure = ref.parentElement;
+				const caption = figure.querySelector( 'figcaption' );
+				state.metadata[ imageId ].caption = (
+					caption?.innerText ||
+					caption?.textContent ||
+					''
+				).trim();
 				const figureWidth = ref.parentElement.clientWidth;
 
 				// It needs special handling for the height because a caption will cause
@@ -626,7 +632,6 @@ const { state, actions, callbacks } = store(
 				// account for that when calculating the placement of the button in the
 				// top right corner of the image.
 				let figureHeight = ref.parentElement.clientHeight;
-				const caption = figure.querySelector( 'figcaption' );
 				if ( caption ) {
 					const captionComputedStyle =
 						window.getComputedStyle( caption );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -968,6 +968,69 @@ test.describe( 'Image - lightbox', () => {
 	} );
 
 	test.describe( 'should render as expected on front end', () => {
+		test( 'Caption remains accessible when navigating lightbox images', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.setContent( `<!-- wp:gallery {"linkTo":"none"} -->
+			<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true},"caption":"First <strong>rich &amp; safe</strong> &lt;caption&gt;"} -->
+			<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="First landscape" class="wp-image-${ uploadedMedia.id }"/><figcaption class="wp-element-caption">First <strong>rich &amp; safe</strong> &lt;caption&gt;</figcaption></figure>
+			<!-- /wp:image -->
+			<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true},"caption":"Second <em>formatted</em> caption"} -->
+			<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="" class="wp-image-${ uploadedMedia.id }"/><figcaption class="wp-element-caption">Second <em>formatted</em> caption</figcaption></figure>
+			<!-- /wp:image -->
+			<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none","lightbox":{"enabled":true}} -->
+			<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="Uncaptioned landscape" class="wp-image-${ uploadedMedia.id }"/></figure>
+			<!-- /wp:image --></figure>
+			<!-- /wp:gallery -->` );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			await page.locator( '.wp-block-gallery img' ).first().click();
+
+			const overlay = page.locator( '.wp-lightbox-overlay' );
+			const overlayFigures = overlay.locator(
+				'.lightbox-image-container figure'
+			);
+			const caption = overlay.locator( 'figcaption' );
+
+			await expect( overlay ).toHaveClass( /active/ );
+			await expect( overlayFigures ).toHaveCount( 2 );
+			await expect( overlayFigures.first() ).toHaveAttribute(
+				'aria-hidden',
+				'true'
+			);
+			await expect( caption ).toHaveCount( 1 );
+			await expect( caption ).toHaveText( 'First rich & safe <caption>' );
+			await expect(
+				overlay.getByRole( 'img', { name: 'First landscape' } )
+			).toHaveCount( 1 );
+			expect( await overlay.ariaSnapshot() ).toContain(
+				'First rich & safe <caption>'
+			);
+			await expect( caption ).toHaveCSS( 'display', 'block' );
+			expect( await caption.innerHTML() ).toBe(
+				'First rich &amp; safe &lt;caption&gt;'
+			);
+
+			await page.getByRole( 'button', { name: 'Next' } ).click();
+
+			await expect( caption ).toHaveText( 'Second formatted caption' );
+			await expect( caption.locator( 'em' ) ).toHaveCount( 0 );
+
+			await page.getByRole( 'button', { name: 'Next' } ).click();
+			await expect( caption ).toHaveJSProperty( 'hidden', true );
+			await expect( caption ).toHaveText( '' );
+			expect( await overlay.ariaSnapshot() ).not.toContain(
+				'Second formatted caption'
+			);
+
+			await page.getByRole( 'button', { name: 'Previous' } ).click();
+			await expect( caption ).toHaveJSProperty( 'hidden', false );
+			await expect( caption ).toHaveText( 'Second formatted caption' );
+		} );
+
 		test( "Overlay image should not inherit content image's margins", async ( {
 			editor,
 			page,


### PR DESCRIPTION
## What?

Closes #55088.

Keep lightbox captions available to assistive technology while keeping them visually hidden. Exclude the duplicate animation image from the accessibility tree.

## Why?

`display: none` removes the caption from the accessibility tree. This loses useful context, especially when an image has an empty alt attribute and its description is in the caption.

## How?

Store the source caption as plain text, render one visually hidden `figcaption` for the selected image, and hide it when there is no caption. Mark the duplicate animation figure `aria-hidden="true"` and give its image an empty `alt`.

The Playwright regression checks caption text, duplicate-image exclusion, safe text rendering, and navigation between captioned and uncaptioned images.

## Testing Instructions

1. Publish a gallery with lightbox enabled. Include an image with an empty alt attribute and a formatted caption, an image with a different caption, and an image without a caption.
2. Open the lightbox and inspect its accessibility tree. The selected caption should be available once, without a duplicate named animation image.
3. Navigate forward and back. The caption should follow the selected image, disappear for the uncaptioned image, and return when navigating back.
4. Confirm the caption stays visually hidden and its content is rendered as text rather than injected HTML.

### Testing Instructions for Keyboard

Use Tab and Enter to open the lightbox. Navigate its controls using the keyboard, then close it and check focus return. With a screen reader, read through the dialog and check that the selected caption is available without duplicate image announcements. Repeat after changing images.

### Recorded validation

The existing validation comment for `64515d2` reports a passing focused Chromium/Playwright regression in a local WordPress Docker environment, production build, typecheck, scoped JavaScript lint, PHP syntax, PHP coding standards, and commit hooks. This description update did not rerun those checks. Manual screen-reader testing remains unverified.

## Screenshots or screencast

None attached. The caption remains visually hidden; the accessibility tree and screen-reader behavior are the relevant checks.

## Use of AI Tools

Codex assisted with implementation and the recorded local automated validation. ChatGPT assisted with reviewing and editing this description. Manual accessibility testing remains outstanding.