### PR TITLE
Layout hooks: roll out usage of normalizeLegacyLayout to the block-editor layout hooks

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Internal
 
 -   `BlockPreview`: Stop applying the private `Disabled` component class name to block previews ([#82651](https://github.com/WordPress/gutenberg/pull/82651)).
--   Layout hooks: Use `normalizeLegacyLayout` in `useLayoutClasses`, `useLayoutStyles`, the block layout styles wrapper and `isAxialBlockGapAllowed`, replacing four inline copies of the legacy `inherit` / size check ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
+-   Layout hooks: Use `normalizeLegacyLayout` in `useLayoutClasses`, `useLayoutStyles`, the block layout styles wrapper and `isAxialBlockGapAllowed`, replacing four inline copies of the legacy `inherit` / size check ([#82710](https://github.com/WordPress/gutenberg/pull/82710)).
 -   Pattern Overrides Dropdown: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#77492](https://github.com/WordPress/gutenberg/pull/77492)).
 -   Allowed Blocks Modal: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#78119](https://github.com/WordPress/gutenberg/pull/78119)).
 -   Block Switcher: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` for the bindings hint ([#77366](https://github.com/WordPress/gutenberg/pull/77366)).

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Internal
 
 -   `BlockPreview`: Stop applying the private `Disabled` component class name to block previews ([#82651](https://github.com/WordPress/gutenberg/pull/82651)).
+-   Layout hooks: Use `normalizeLegacyLayout` in `useLayoutClasses`, `useLayoutStyles`, the block layout styles wrapper and `isAxialBlockGapAllowed`, replacing four inline copies of the legacy `inherit` / size check ([#TBD](https://github.com/WordPress/gutenberg/pull/TBD)).
 -   Pattern Overrides Dropdown: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#77492](https://github.com/WordPress/gutenberg/pull/77492)).
 -   Allowed Blocks Modal: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` ([#78119](https://github.com/WordPress/gutenberg/pull/78119)).
 -   Block Switcher: Use `Text` from `@wordpress/ui` instead of `__experimentalText` from `@wordpress/components` for the bindings hint ([#77366](https://github.com/WordPress/gutenberg/pull/77366)).

--- a/packages/block-editor/src/hooks/gap.js
+++ b/packages/block-editor/src/hooks/gap.js
@@ -1,4 +1,5 @@
 import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/utils';
+import { normalizeLegacyLayout } from '../layouts/utils';
 
 /**
  * Returns whether the current layout can use separate row and column gaps.
@@ -8,10 +9,7 @@ import { getSpacingPresetCssVar } from '../components/spacing-sizes-control/util
  * @return {boolean} Whether axial block gap controls should be available.
  */
 export function isAxialBlockGapAllowed( layout, defaultLayout ) {
-	const usedLayout =
-		layout?.inherit || layout?.contentSize || layout?.wideSize
-			? { ...layout, type: 'constrained' }
-			: layout || defaultLayout || {};
+	const usedLayout = normalizeLegacyLayout( layout ) || defaultLayout || {};
 
 	return [ 'flex', 'grid' ].includes( usedLayout?.type );
 }

--- a/packages/block-editor/src/hooks/layout.jsx
+++ b/packages/block-editor/src/hooks/layout.jsx
@@ -23,6 +23,7 @@ import { useSettings } from '../components/use-settings';
 import { getLayoutType, getLayoutTypes } from '../layouts';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
+import { normalizeLegacyLayout } from '../layouts/utils';
 import { cleanEmptyObject, useBlockSettings, useStyleOverride } from './utils';
 import { unlock } from '../lock-unlock';
 import { globalStylesDataKey } from '../store/private-keys';
@@ -162,9 +163,7 @@ export function useLayoutClasses( blockAttributes = {}, blockName = '' ) {
 	const { default: defaultBlockLayout } =
 		getBlockSupport( blockName, layoutBlockSupportKey ) || {};
 	const usedLayout =
-		layout?.inherit || layout?.contentSize || layout?.wideSize
-			? { ...layout, type: 'constrained' }
-			: layout || defaultBlockLayout || {};
+		normalizeLegacyLayout( layout ) || defaultBlockLayout || {};
 
 	const layoutClassnames = [];
 
@@ -231,11 +230,7 @@ export function useLayoutClasses( blockAttributes = {}, blockName = '' ) {
  */
 export function useLayoutStyles( blockAttributes = {}, blockName, selector ) {
 	const { layout = {}, style = {} } = blockAttributes;
-	// Update type for blocks using legacy layouts.
-	const usedLayout =
-		layout?.inherit || layout?.contentSize || layout?.wideSize
-			? { ...layout, type: 'constrained' }
-			: layout || {};
+	const usedLayout = normalizeLegacyLayout( layout ) || {};
 	const fullLayoutType = getLayoutType( usedLayout?.type || 'default' );
 	const [ blockGapSupport ] = useSettings( 'spacing.blockGap' );
 	const hasBlockGapSupport = blockGapSupport !== null;
@@ -696,9 +691,7 @@ function BlockWithLayoutStyles( {
 	const { default: defaultBlockLayout } =
 		getBlockSupport( name, layoutBlockSupportKey ) || {};
 	const usedLayout =
-		layout?.inherit || layout?.contentSize || layout?.wideSize
-			? { ...layout, type: 'constrained' }
-			: layout || defaultBlockLayout || {};
+		normalizeLegacyLayout( layout ) || defaultBlockLayout || {};
 
 	const selectorPrefix = `wp-container-${ kebabCase( name ) }-is-layout-`;
 	// Higher specificity to override defaults from theme.json.


### PR DESCRIPTION
## What?

In #82637 I added the `normalizeLegacyLayout` function as a simple helper function for handling legacy layout objects where the `constrained` layout type was indicated by the presence of `inherit: true` or content and wide sizes.

This PR rolls out usage of that function to the layout hooks files.

## Why?

We're duplicating this check in a few places, and by using the helper function instead, it (hopefully) improves readability and maintainability as this helper is covered by unit tests.

In short: just a small code quality change to try to tidy things up.

Note: I haven't rolled this out to the editor or block-library packages. For now, I think it just helps a little to tidy things up in the block-editor package.

## How?

Replace the hard-coded conversion to a layout object with `type: 'constrained'` with a call to `normalizeLegacyLayout` which was introduced in #82637.

## Testing Instructions

TL;DR — check that layout styles continue to render for blocks like group, row, stack, grid, gallery, and that a constrained group block continues to set custom content and wide sizes. If you'd like a more thorough set of instructions, here's some Claude generated testing instructions:

<details>
<summary>Claude generated testing instructions</summary>

Use a block theme such as Twenty Twenty-Five. Each step exercises one of the four call sites.

  1. **Layout class names** (`useLayoutClasses`). Insert a Group block, switch its layout between Flow, Constrained, Flex and Grid in the inspector. Inspect the block
  wrapper in the editor and confirm the `is-layout-*` class changes to match each time.

  2. **Layout styles** (`useLayoutStyles`). With a Constrained Group selected, set custom Content and Wide widths in the inspector. Confirm the inner blocks are
  constrained to those widths in the canvas.

  3. **Block layout styles wrapper**. Insert a Gallery, which declares its layout only as a support default. Confirm the images still lay out in a flex row and that
  Wide and Full alignments are not offered on an image inside it.

  4. **Axial gap controls** (`isAxialBlockGapAllowed`). Select a Flex or Grid Group and confirm the Block spacing control offers separate horizontal and vertical
  values. Switch the same block to Flow or Constrained and confirm it collapses to a single value.

  5. **Legacy markup**. Switch to the code editor and paste a Group using the pre-layout-type form:

  ```html
  <!-- wp:group {"layout":{"inherit":true}} -->
  <div class="wp-block-group"><!-- wp:paragraph -->
  <p>Legacy constrained group</p>
  <!-- /wp:paragraph --></div>
  <!-- /wp:group -->
```

  Back in the visual editor, confirm the Group has the is-layout-constrained class, its paragraph is constrained to the content width, and the paragraph's alignment menu offers Wide and Full width. Repeat with {"layout":{"contentSize":"600px"}} in place of the inherit flag.

</details>

## Screenshots or screencast <!-- if applicable -->

Nothing to see here as this PR should be a no-op.

## Use of AI Tools

Claude Code (Fable 5.1)
