### PR TITLE
Editor: Add a fixedRenderingMode prop for contexts with one mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -31,9 +31,7 @@ function useNavigateToPreviousEntityRecord() {
 	return goBack;
 }
 
-export function useSpecificEditorSettings( {
-	defaultRenderingMode = 'post-only',
-} = {} ) {
+export function useSpecificEditorSettings() {
 	const { query } = useLocation();
 	const { canvas = 'view' } = query;
 	const onNavigateToEntityRecord = useNavigateToEntityRecord();
@@ -96,14 +94,12 @@ export function useSpecificEditorSettings( {
 			onNavigateToEntityRecord,
 			onNavigateToPreviousEntityRecord,
 			isPreviewMode: canvas === 'view',
-			defaultRenderingMode,
 		};
 	}, [
 		settings,
 		globalStyles,
 		globalSettings,
 		canvas,
-		defaultRenderingMode,
 		currentPostIsTrashed,
 		onNavigateToEntityRecord,
 		onNavigateToPreviousEntityRecord,

--- a/packages/edit-site/src/components/editor/index.jsx
+++ b/packages/edit-site/src/components/editor/index.jsx
@@ -77,8 +77,9 @@ function getNavigationPath( location, postType ) {
 export default function EditSiteEditor( {
 	isHomeRoute = false,
 	// Routes that stand for the whole site pass 'template-locked', so the
-	// canvas shows the template around whatever it is rendering.
-	defaultRenderingMode = 'post-only',
+	// canvas shows the template around whatever it is rendering, and the
+	// controls for switching it are not offered.
+	fixedRenderingMode,
 } ) {
 	const location = useLocation();
 	const history = useHistory();
@@ -111,9 +112,7 @@ export default function EditSiteEditor( {
 		'edit-site-editor__loading-progress'
 	);
 
-	const editorSettings = useSpecificEditorSettings( {
-		defaultRenderingMode,
-	} );
+	const editorSettings = useSpecificEditorSettings();
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 	const { setCurrentRevisionId, resetStylesNavigation } = unlock(
 		useDispatch( editorStore )
@@ -207,6 +206,7 @@ export default function EditSiteEditor( {
 					postId={ postWithTemplate ? context.postId : postId }
 					templateId={ postWithTemplate ? postId : undefined }
 					settings={ editorSettings }
+					fixedRenderingMode={ fixedRenderingMode }
 					className="edit-site-editor__editor-interface"
 					customSaveButton={
 						_isPreviewingTheme && <SaveButton size="compact" />

--- a/packages/edit-site/src/components/editor/index.jsx
+++ b/packages/edit-site/src/components/editor/index.jsx
@@ -79,7 +79,7 @@ export default function EditSiteEditor( {
 	// Routes that stand for the whole site pass 'template-locked', so the
 	// canvas shows the template around whatever it is rendering, and the
 	// controls for switching it are not offered.
-	fixedRenderingMode,
+	renderingMode,
 } ) {
 	const location = useLocation();
 	const history = useHistory();
@@ -206,7 +206,7 @@ export default function EditSiteEditor( {
 					postId={ postWithTemplate ? context.postId : postId }
 					templateId={ postWithTemplate ? postId : undefined }
 					settings={ editorSettings }
-					fixedRenderingMode={ fixedRenderingMode }
+					renderingMode={ renderingMode }
 					className="edit-site-editor__editor-interface"
 					customSaveButton={
 						_isPreviewingTheme && <SaveButton size="compact" />

--- a/packages/edit-site/src/components/site-editor-routes/home.jsx
+++ b/packages/edit-site/src/components/site-editor-routes/home.jsx
@@ -22,7 +22,7 @@ export const homeRoute = {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ||
 				isClassicThemeWithStyleBookSupport( siteData ) ? (
-				<Editor isHomeRoute fixedRenderingMode="template-locked" />
+				<Editor isHomeRoute renderingMode="template-locked" />
 			) : undefined;
 		},
 		mobileSidebar( { siteData } ) {

--- a/packages/edit-site/src/components/site-editor-routes/home.jsx
+++ b/packages/edit-site/src/components/site-editor-routes/home.jsx
@@ -22,7 +22,7 @@ export const homeRoute = {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ||
 				isClassicThemeWithStyleBookSupport( siteData ) ? (
-				<Editor isHomeRoute defaultRenderingMode="template-locked" />
+				<Editor isHomeRoute fixedRenderingMode="template-locked" />
 			) : undefined;
 		},
 		mobileSidebar( { siteData } ) {

--- a/packages/edit-site/src/components/site-editor-routes/identity.jsx
+++ b/packages/edit-site/src/components/site-editor-routes/identity.jsx
@@ -8,7 +8,7 @@ export const identityRoute = {
 	areas: {
 		sidebar: <SidebarNavigationScreenIdentity />,
 		content: <SidebarIdentity />,
-		preview: <Editor fixedRenderingMode="template-locked" />,
+		preview: <Editor renderingMode="template-locked" />,
 		mobileContent: <SidebarIdentity />,
 	},
 	widths: {

--- a/packages/edit-site/src/components/site-editor-routes/identity.jsx
+++ b/packages/edit-site/src/components/site-editor-routes/identity.jsx
@@ -8,7 +8,7 @@ export const identityRoute = {
 	areas: {
 		sidebar: <SidebarNavigationScreenIdentity />,
 		content: <SidebarIdentity />,
-		preview: <Editor defaultRenderingMode="template-locked" />,
+		preview: <Editor fixedRenderingMode="template-locked" />,
 		mobileContent: <SidebarIdentity />,
 	},
 	widths: {

--- a/packages/edit-site/src/components/site-editor-routes/styles.jsx
+++ b/packages/edit-site/src/components/site-editor-routes/styles.jsx
@@ -42,7 +42,7 @@ function StylesPreviewArea( { siteData } ) {
 		return <StyleBookPreviewArea siteData={ siteData } />;
 	}
 
-	return <Editor defaultRenderingMode="template-locked" />;
+	return <Editor fixedRenderingMode="template-locked" />;
 }
 
 export const stylesRoute = {

--- a/packages/edit-site/src/components/site-editor-routes/styles.jsx
+++ b/packages/edit-site/src/components/site-editor-routes/styles.jsx
@@ -42,7 +42,7 @@ function StylesPreviewArea( { siteData } ) {
 		return <StyleBookPreviewArea siteData={ siteData } />;
 	}
 
-	return <Editor fixedRenderingMode="template-locked" />;
+	return <Editor renderingMode="template-locked" />;
 }
 
 export const stylesRoute = {

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -27,6 +27,7 @@
 -   Post actions: Append an ellipsis (`…`) to the "Set as homepage" and "Set as posts page" action labels, which open a confirmation dialog, following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 -   Show a "Privacy Policy Page" badge in the document bar and the post card panel for the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
 -   `PostCardPanel`: Migrate the page-type badge from the private Components `Badge` to `@wordpress/ui` `Badge`. ([#82500](https://github.com/WordPress/gutenberg/pull/82500)).
+-   `EditorProvider`: Add a `fixedRenderingMode` prop for editors that exist to show one rendering mode. It replaces the usual resolution, so the user's saved "Show template" preference cannot override it, and the controls that switch modes are not offered ([#82711](https://github.com/WordPress/gutenberg/pull/82711)).
 
 ### Bug Fixes
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -27,7 +27,7 @@
 -   Post actions: Append an ellipsis (`…`) to the "Set as homepage" and "Set as posts page" action labels, which open a confirmation dialog, following the menu ellipsis guideline. The dialog titles keep the ellipsis-free wording. ([#81994](https://github.com/WordPress/gutenberg/pull/81994))
 -   Show a "Privacy Policy Page" badge in the document bar and the post card panel for the page assigned in Settings > Privacy, alongside the existing "Homepage" and "Posts Page" badges ([#82422](https://github.com/WordPress/gutenberg/pull/82422)).
 -   `PostCardPanel`: Migrate the page-type badge from the private Components `Badge` to `@wordpress/ui` `Badge`. ([#82500](https://github.com/WordPress/gutenberg/pull/82500)).
--   `EditorProvider`: Add a `fixedRenderingMode` prop for editors that exist to show one rendering mode. It replaces the usual resolution, so the user's saved "Show template" preference cannot override it, and the controls that switch modes are not offered ([#82711](https://github.com/WordPress/gutenberg/pull/82711)).
+-   `EditorProvider`: Add a `renderingMode` prop for editors that exist to show one rendering mode. It replaces the usual resolution, so the user's saved "Show template" preference cannot override it, and the controls that switch modes are not offered ([#82711](https://github.com/WordPress/gutenberg/pull/82711)).
 
 ### Bug Fixes
 

--- a/packages/editor/src/components/editor/index.jsx
+++ b/packages/editor/src/components/editor/index.jsx
@@ -19,7 +19,7 @@ function Editor( {
 	children,
 	initialEdits,
 	initialViewport,
-	fixedRenderingMode,
+	renderingMode,
 
 	// This could be part of the settings.
 	onActionPerformed,
@@ -51,7 +51,9 @@ function Editor( {
 				select( editorStore );
 
 			const postArgs = [ 'postType', postType, postId ];
-			const renderingMode = getRenderingMode();
+			// Named apart from the `renderingMode` prop, which is what this
+			// editor was told to be in rather than what it is in now.
+			const currentRenderingMode = getRenderingMode();
 			const currentPostType = getCurrentPostType();
 			const _isBlockTheme = getCurrentTheme()?.is_block_theme;
 			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
@@ -83,7 +85,7 @@ function Editor( {
 					_isBlockTheme &&
 					userCanEditGlobalStyles &&
 					( currentPostType === 'wp_template' ||
-						renderingMode === 'template-locked' ),
+						currentRenderingMode === 'template-locked' ),
 			};
 		},
 		[ postType, postId, templateId ]
@@ -110,7 +112,7 @@ function Editor( {
 					settings={ settings }
 					initialEdits={ initialEdits }
 					initialViewport={ initialViewport }
-					fixedRenderingMode={ fixedRenderingMode }
+					renderingMode={ renderingMode }
 					useSubRegistry={ false }
 				>
 					<EditorInterface { ...props }>

--- a/packages/editor/src/components/editor/index.jsx
+++ b/packages/editor/src/components/editor/index.jsx
@@ -19,6 +19,7 @@ function Editor( {
 	children,
 	initialEdits,
 	initialViewport,
+	fixedRenderingMode,
 
 	// This could be part of the settings.
 	onActionPerformed,
@@ -109,6 +110,7 @@ function Editor( {
 					settings={ settings }
 					initialEdits={ initialEdits }
 					initialViewport={ initialViewport }
+					fixedRenderingMode={ fixedRenderingMode }
 					useSubRegistry={ false }
 				>
 					<EditorInterface { ...props }>

--- a/packages/editor/src/components/post-template/block-theme.jsx
+++ b/packages/editor/src/components/post-template/block-theme.jsx
@@ -20,6 +20,7 @@ export default function BlockThemeControl() {
 		onNavigateToEntityRecord,
 		getEditorSettings,
 		hasGoBack,
+		hasFixedRenderingMode,
 		id,
 	} = useSelect( ( select ) => {
 		const {
@@ -35,6 +36,7 @@ export default function BlockThemeControl() {
 			hasGoBack: editorSettings.hasOwnProperty(
 				'onNavigateToPreviousEntityRecord'
 			),
+			hasFixedRenderingMode: !! editorSettings.fixedRenderingMode,
 			id: getCurrentTemplateId(),
 		};
 	}, [] );
@@ -137,22 +139,29 @@ export default function BlockThemeControl() {
 							<ResetDefaultTemplate onClick={ onClose } />
 							{ canCreateTemplate && <CreateNewTemplate /> }
 						</MenuGroup>
-						<MenuGroup>
-							<MenuItem
-								icon={ ! isTemplateHidden ? check : undefined }
-								isSelected={ ! isTemplateHidden }
-								role="menuitemcheckbox"
-								onClick={ () => {
-									const newRenderingMode = isTemplateHidden
-										? 'template-locked'
-										: 'post-only';
-									setRenderingMode( newRenderingMode );
-									setDefaultRenderingMode( newRenderingMode );
-								} }
-							>
-								{ __( 'Show template' ) }
-							</MenuItem>
-						</MenuGroup>
+						{ ! hasFixedRenderingMode && (
+							<MenuGroup>
+								<MenuItem
+									icon={
+										! isTemplateHidden ? check : undefined
+									}
+									isSelected={ ! isTemplateHidden }
+									role="menuitemcheckbox"
+									onClick={ () => {
+										const newRenderingMode =
+											isTemplateHidden
+												? 'template-locked'
+												: 'post-only';
+										setRenderingMode( newRenderingMode );
+										setDefaultRenderingMode(
+											newRenderingMode
+										);
+									} }
+								>
+									{ __( 'Show template' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
 					</>
 				) }
 			</DropdownMenu>

--- a/packages/editor/src/components/post-template/block-theme.jsx
+++ b/packages/editor/src/components/post-template/block-theme.jsx
@@ -20,7 +20,7 @@ export default function BlockThemeControl() {
 		onNavigateToEntityRecord,
 		getEditorSettings,
 		hasGoBack,
-		hasFixedRenderingMode,
+		hasRenderingMode,
 		id,
 	} = useSelect( ( select ) => {
 		const {
@@ -36,7 +36,7 @@ export default function BlockThemeControl() {
 			hasGoBack: editorSettings.hasOwnProperty(
 				'onNavigateToPreviousEntityRecord'
 			),
-			hasFixedRenderingMode: !! editorSettings.fixedRenderingMode,
+			hasRenderingMode: !! editorSettings.renderingMode,
 			id: getCurrentTemplateId(),
 		};
 	}, [] );
@@ -139,7 +139,7 @@ export default function BlockThemeControl() {
 							<ResetDefaultTemplate onClick={ onClose } />
 							{ canCreateTemplate && <CreateNewTemplate /> }
 						</MenuGroup>
-						{ ! hasFixedRenderingMode && (
+						{ ! hasRenderingMode && (
 							<MenuGroup>
 								<MenuItem
 									icon={

--- a/packages/editor/src/components/preview-dropdown/index.jsx
+++ b/packages/editor/src/components/preview-dropdown/index.jsx
@@ -31,7 +31,7 @@ function PreviewMenu( { forceIsAutosaveable, disabled } ) {
 		isViewable,
 		showIconLabels,
 		isTemplateHidden,
-		hasFixedRenderingMode,
+		hasRenderingMode,
 		templateId,
 		isResponsiveEditing,
 		isResponsiveEditingEnabled,
@@ -65,7 +65,7 @@ function PreviewMenu( { forceIsAutosaveable, disabled } ) {
 			isViewable: getPostType( _currentPostType )?.viewable ?? false,
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isTemplateHidden: getRenderingMode() === 'post-only',
-			hasFixedRenderingMode: !! getEditorSettings().fixedRenderingMode,
+			hasRenderingMode: !! getEditorSettings().renderingMode,
 			templateId: getCurrentTemplateId(),
 			isResponsiveEditing: _isResponsiveEditing(),
 			isResponsiveEditingEnabled:
@@ -231,7 +231,7 @@ function PreviewMenu( { forceIsAutosaveable, disabled } ) {
 						</Menu.Group>
 					</>
 				) }
-				{ ! isTemplate && !! templateId && ! hasFixedRenderingMode && (
+				{ ! isTemplate && !! templateId && ! hasRenderingMode && (
 					<>
 						<Menu.Separator />
 						<Menu.Group>

--- a/packages/editor/src/components/preview-dropdown/index.jsx
+++ b/packages/editor/src/components/preview-dropdown/index.jsx
@@ -31,6 +31,7 @@ function PreviewMenu( { forceIsAutosaveable, disabled } ) {
 		isViewable,
 		showIconLabels,
 		isTemplateHidden,
+		hasFixedRenderingMode,
 		templateId,
 		isResponsiveEditing,
 		isResponsiveEditingEnabled,
@@ -64,6 +65,7 @@ function PreviewMenu( { forceIsAutosaveable, disabled } ) {
 			isViewable: getPostType( _currentPostType )?.viewable ?? false,
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isTemplateHidden: getRenderingMode() === 'post-only',
+			hasFixedRenderingMode: !! getEditorSettings().fixedRenderingMode,
 			templateId: getCurrentTemplateId(),
 			isResponsiveEditing: _isResponsiveEditing(),
 			isResponsiveEditingEnabled:
@@ -229,7 +231,7 @@ function PreviewMenu( { forceIsAutosaveable, disabled } ) {
 						</Menu.Group>
 					</>
 				) }
-				{ ! isTemplate && !! templateId && (
+				{ ! isTemplate && !! templateId && ! hasFixedRenderingMode && (
 					<>
 						<Menu.Separator />
 						<Menu.Group>

--- a/packages/editor/src/components/provider/index.jsx
+++ b/packages/editor/src/components/provider/index.jsx
@@ -144,7 +144,7 @@ function useBlockEditorProps( post, template, mode ) {
  * @param {boolean} props.recovery                       Indicates if the editor is in recovery mode.
  * @param {Array}   props.initialEdits                   The initial edits for the editor.
  * @param {string}  [props.initialViewport]              The device type an entity opens at, one of those `setDeviceType` accepts. Each entity opens at the width it names, so a width set from the device preview is view state that does not follow the user into the next one. The current width is left alone when omitted.
- * @param {string}  [props.fixedRenderingMode]           The rendering mode this editor stays in, one of `post-only` or `template-locked`. Unlike the `defaultRenderingMode` editor setting, which is a starting point the user's saved "Show template" preference overrides, this is what the editor is for: it wins over that preference, and the controls that switch modes are not offered. Use it where only one mode makes sense, such as the site editor screens that show the whole site. The mode is resolved normally when omitted.
+ * @param {string}  [props.renderingMode]                The rendering mode this editor stays in, one of `post-only` or `template-locked`. Unlike the `defaultRenderingMode` editor setting, which is a starting point the user's saved "Show template" preference overrides, this is what the editor is for: it wins over that preference, and the controls that switch modes are not offered. Use it where only one mode makes sense, such as the site editor screens that show the whole site. The mode is resolved normally when omitted.
  * @param {Object}  props.children                       The child components.
  * @param {Object}  [props.BlockEditorProviderComponent] The block editor provider component to use. Defaults to ExperimentalBlockEditorProvider.
  * @param {Object}  [props.__unstableTemplate]           The template object.
@@ -170,7 +170,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		recovery,
 		initialEdits,
 		initialViewport,
-		fixedRenderingMode,
+		renderingMode,
 		children,
 		BlockEditorProviderComponent = ExperimentalBlockEditorProvider,
 		__unstableTemplate: template,
@@ -203,7 +203,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				// is for, so it wins over the post type default and the
 				// user's saved preference.
 				const _defaultMode =
-					fixedRenderingMode ?? getDefaultRenderingMode( post.type );
+					renderingMode ?? getDefaultRenderingMode( post.type );
 				/**
 				 * To avoid content "flash", wait until rendering mode has been resolved.
 				 * This is important for the initial render of the editor.
@@ -242,7 +242,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					currentRevisionId: _getCurrentRevisionId(),
 				};
 			},
-			[ post.type, post.id, hasTemplate, fixedRenderingMode ]
+			[ post.type, post.id, hasTemplate, renderingMode ]
 		);
 
 		const shouldRenderTemplate = hasTemplate && mode !== 'post-only';
@@ -391,8 +391,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		useLayoutEffect( () => {
 			// Sent on every sync, including as `undefined`, so that a value
 			// from a previous mount does not survive: editor settings merge.
-			updateEditorSettings( { ...settings, fixedRenderingMode } );
-		}, [ settings, fixedRenderingMode, updateEditorSettings ] );
+			updateEditorSettings( { ...settings, renderingMode } );
+		}, [ settings, renderingMode, updateEditorSettings ] );
 
 		// Synchronizes the active template with the state.
 		useEffect( () => {

--- a/packages/editor/src/components/provider/index.jsx
+++ b/packages/editor/src/components/provider/index.jsx
@@ -144,6 +144,7 @@ function useBlockEditorProps( post, template, mode ) {
  * @param {boolean} props.recovery                       Indicates if the editor is in recovery mode.
  * @param {Array}   props.initialEdits                   The initial edits for the editor.
  * @param {string}  [props.initialViewport]              The device type an entity opens at, one of those `setDeviceType` accepts. Each entity opens at the width it names, so a width set from the device preview is view state that does not follow the user into the next one. The current width is left alone when omitted.
+ * @param {string}  [props.fixedRenderingMode]           The rendering mode this editor stays in, one of `post-only` or `template-locked`. Unlike the `defaultRenderingMode` editor setting, which is a starting point the user's saved "Show template" preference overrides, this is what the editor is for: it wins over that preference, and the controls that switch modes are not offered. Use it where only one mode makes sense, such as the site editor screens that show the whole site. The mode is resolved normally when omitted.
  * @param {Object}  props.children                       The child components.
  * @param {Object}  [props.BlockEditorProviderComponent] The block editor provider component to use. Defaults to ExperimentalBlockEditorProvider.
  * @param {Object}  [props.__unstableTemplate]           The template object.
@@ -169,6 +170,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		recovery,
 		initialEdits,
 		initialViewport,
+		fixedRenderingMode,
 		children,
 		BlockEditorProviderComponent = ExperimentalBlockEditorProvider,
 		__unstableTemplate: template,
@@ -197,7 +199,11 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					select( coreStore );
 
 				const _mode = getRenderingMode();
-				const _defaultMode = getDefaultRenderingMode( post.type );
+				// A caller that names the mode is stating what this context
+				// is for, so it wins over the post type default and the
+				// user's saved preference.
+				const _defaultMode =
+					fixedRenderingMode ?? getDefaultRenderingMode( post.type );
 				/**
 				 * To avoid content "flash", wait until rendering mode has been resolved.
 				 * This is important for the initial render of the editor.
@@ -236,7 +242,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					currentRevisionId: _getCurrentRevisionId(),
 				};
 			},
-			[ post.type, post.id, hasTemplate ]
+			[ post.type, post.id, hasTemplate, fixedRenderingMode ]
 		);
 
 		const shouldRenderTemplate = hasTemplate && mode !== 'post-only';
@@ -383,8 +389,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// Synchronize the editor settings as they change.
 		// Do it as a layout effect so that rendered UI with outdated settings is not painted.
 		useLayoutEffect( () => {
-			updateEditorSettings( settings );
-		}, [ settings, updateEditorSettings ] );
+			// Sent on every sync, including as `undefined`, so that a value
+			// from a previous mount does not survive: editor settings merge.
+			updateEditorSettings( { ...settings, fixedRenderingMode } );
+		}, [ settings, fixedRenderingMode, updateEditorSettings ] );
 
 		// Synchronizes the active template with the state.
 		useEffect( () => {

--- a/packages/editor/src/components/provider/index.jsx
+++ b/packages/editor/src/components/provider/index.jsx
@@ -389,8 +389,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// Synchronize the editor settings as they change.
 		// Do it as a layout effect so that rendered UI with outdated settings is not painted.
 		useLayoutEffect( () => {
-			// Settings merge, so pass the prop even when `undefined` to clear a
-			// mode left behind by a previous mount.
+			// Settings merge, so pass the prop even when `undefined`. That clears the
+			// mode when this editor stays mounted but loses the prop, as when going
+			// from Home to Navigation: both show the front page in the same editor.
 			updateEditorSettings( { ...settings, renderingMode } );
 		}, [ settings, renderingMode, updateEditorSettings ] );
 

--- a/packages/editor/src/components/provider/index.jsx
+++ b/packages/editor/src/components/provider/index.jsx
@@ -393,16 +393,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			// mode when this editor stays mounted but loses the prop, as when going
 			// from Home to Navigation: both show the front page in the same editor.
 			updateEditorSettings( { ...settings, renderingMode } );
-		}, [ settings, renderingMode, updateEditorSettings ] );
 
-		// Clear the mode when this editor goes away, so whatever mounts in its
-		// place without a mode of its own, such as the style book on `/styles`,
-		// does not inherit it. Kept out of the sync above, which re-runs on
-		// every settings change: on the styles route, with every edit.
-		useLayoutEffect(
-			() => () => updateEditorSettings( { renderingMode: undefined } ),
-			[ updateEditorSettings ]
-		);
+			return () => updateEditorSettings( { renderingMode: undefined } );
+		}, [ settings, renderingMode, updateEditorSettings ] );
 
 		// Synchronizes the active template with the state.
 		useEffect( () => {

--- a/packages/editor/src/components/provider/index.jsx
+++ b/packages/editor/src/components/provider/index.jsx
@@ -389,9 +389,13 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// Synchronize the editor settings as they change.
 		// Do it as a layout effect so that rendered UI with outdated settings is not painted.
 		useLayoutEffect( () => {
-			// Sent on every sync, including as `undefined`, so that a value
-			// from a previous mount does not survive: editor settings merge.
+			// Settings merge, so pass the prop even when `undefined` to clear a
+			// mode left behind by a previous mount.
 			updateEditorSettings( { ...settings, renderingMode } );
+
+			// And clear it on the way out, for whatever mounts next without a
+			// mode of its own: the style book on `/styles`, for one.
+			return () => updateEditorSettings( { renderingMode: undefined } );
 		}, [ settings, renderingMode, updateEditorSettings ] );
 
 		// Synchronizes the active template with the state.

--- a/packages/editor/src/components/provider/index.jsx
+++ b/packages/editor/src/components/provider/index.jsx
@@ -392,11 +392,16 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			// Settings merge, so pass the prop even when `undefined` to clear a
 			// mode left behind by a previous mount.
 			updateEditorSettings( { ...settings, renderingMode } );
-
-			// And clear it on the way out, for whatever mounts next without a
-			// mode of its own: the style book on `/styles`, for one.
-			return () => updateEditorSettings( { renderingMode: undefined } );
 		}, [ settings, renderingMode, updateEditorSettings ] );
+
+		// Clear the mode when this editor goes away, so whatever mounts in its
+		// place without a mode of its own, such as the style book on `/styles`,
+		// does not inherit it. Kept out of the sync above, which re-runs on
+		// every settings change: on the styles route, with every edit.
+		useLayoutEffect(
+			() => () => updateEditorSettings( { renderingMode: undefined } ),
+			[ updateEditorSettings ]
+		);
 
 		// Synchronizes the active template with the state.
 		useEffect( () => {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -721,10 +721,7 @@ export const setRenderingMode =
 		// An editor opened with a rendering mode of its own is showing what
 		// that context is for, so it stays in that mode. Applying that mode is
 		// what puts the editor in it, so only a move away is ignored.
-		if (
-			settings.fixedRenderingMode &&
-			mode !== settings.fixedRenderingMode
-		) {
+		if ( settings.renderingMode && mode !== settings.renderingMode ) {
 			return;
 		}
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -716,10 +716,19 @@ export function updateEditorSettings( settings ) {
 export const setRenderingMode =
 	( mode ) =>
 	( { dispatch, registry, select } ) => {
+		const settings = select.getEditorSettings();
+
+		// An editor opened with a rendering mode of its own is showing what
+		// that context is for, so it stays in that mode. Applying that mode is
+		// what puts the editor in it, so only a move away is ignored.
 		if (
-			select.__unstableIsEditorReady() &&
-			! select.getEditorSettings().isPreviewMode
+			settings.fixedRenderingMode &&
+			mode !== settings.fixedRenderingMode
 		) {
+			return;
+		}
+
+		if ( select.__unstableIsEditorReady() && ! settings.isPreviewMode ) {
 			registry.dispatch( blockEditorStore ).clearSelectedBlock();
 		}
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -2,6 +2,7 @@ import { speak } from '@wordpress/a11y';
 import apiFetch from '@wordpress/api-fetch';
 import { escapeHTML } from '@wordpress/escape-html';
 import deprecated from '@wordpress/deprecated';
+import warning from '@wordpress/warning';
 import {
 	parse,
 	synchronizeBlocksWithTemplate,
@@ -720,8 +721,12 @@ export const setRenderingMode =
 
 		// An editor opened with a rendering mode of its own is showing what
 		// that context is for, so it stays in that mode. Applying that mode is
-		// what puts the editor in it, so only a move away is ignored.
+		// what puts the editor in it, so only a move away is ignored. It warns,
+		// or the caller could not tell why nothing changed.
 		if ( settings.renderingMode && mode !== settings.renderingMode ) {
+			warning(
+				`setRenderingMode( '${ mode }' ) was ignored: this editor is using overriding rendering mode from '${ settings.renderingMode }'.`
+			);
 			return;
 		}
 

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -52,7 +52,7 @@ export const createTemplate =
 					template: savedTemplate.slug,
 				}
 			);
-		const { defaultRenderingMode, fixedRenderingMode } =
+		const { defaultRenderingMode, renderingMode } =
 			select.getEditorSettings();
 		registry
 			.dispatch( noticesStore )
@@ -62,7 +62,7 @@ export const createTemplate =
 					type: 'snackbar',
 					// An editor with a fixed rendering mode has no other mode
 					// to go back to, so the action is not offered.
-					actions: fixedRenderingMode
+					actions: renderingMode
 						? []
 						: [
 								{

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -52,22 +52,27 @@ export const createTemplate =
 					template: savedTemplate.slug,
 				}
 			);
+		const { defaultRenderingMode, fixedRenderingMode } =
+			select.getEditorSettings();
 		registry
 			.dispatch( noticesStore )
 			.createSuccessNotice(
 				__( "Custom template created. You're in template mode now." ),
 				{
 					type: 'snackbar',
-					actions: [
-						{
-							label: __( 'Back' ),
-							onClick: () =>
-								dispatch.setRenderingMode(
-									select.getEditorSettings()
-										.defaultRenderingMode
-								),
-						},
-					],
+					// An editor with a fixed rendering mode has no other mode
+					// to go back to, so the action is not offered.
+					actions: fixedRenderingMode
+						? []
+						: [
+								{
+									label: __( 'Back' ),
+									onClick: () =>
+										dispatch.setRenderingMode(
+											defaultRenderingMode
+										),
+								},
+						  ],
 				}
 			);
 		return savedTemplate;

--- a/packages/editor/src/store/test/actions.jsdom.test.js
+++ b/packages/editor/src/store/test/actions.jsdom.test.js
@@ -1240,7 +1240,7 @@ describe( 'Editor actions', () => {
 		it( 'applies the fixed mode, so an editor can enter it', () => {
 			const registry = createRegistryWithStores();
 			registry.dispatch( editorStore ).updateEditorSettings( {
-				fixedRenderingMode: 'template-locked',
+				renderingMode: 'template-locked',
 			} );
 
 			registry
@@ -1255,7 +1255,7 @@ describe( 'Editor actions', () => {
 		it( 'ignores a move away from the fixed mode', () => {
 			const registry = createRegistryWithStores();
 			registry.dispatch( editorStore ).updateEditorSettings( {
-				fixedRenderingMode: 'template-locked',
+				renderingMode: 'template-locked',
 			} );
 			registry
 				.dispatch( editorStore )
@@ -1271,7 +1271,7 @@ describe( 'Editor actions', () => {
 		it( 'changes the mode again once the fixed mode is cleared', () => {
 			const registry = createRegistryWithStores();
 			registry.dispatch( editorStore ).updateEditorSettings( {
-				fixedRenderingMode: 'template-locked',
+				renderingMode: 'template-locked',
 			} );
 			registry
 				.dispatch( editorStore )
@@ -1281,7 +1281,7 @@ describe( 'Editor actions', () => {
 			// has to clear it: editor settings merge, and the site editor
 			// shares one store across its routes.
 			registry.dispatch( editorStore ).updateEditorSettings( {
-				fixedRenderingMode: undefined,
+				renderingMode: undefined,
 			} );
 			registry.dispatch( editorStore ).setRenderingMode( 'post-only' );
 

--- a/packages/editor/src/store/test/actions.jsdom.test.js
+++ b/packages/editor/src/store/test/actions.jsdom.test.js
@@ -1219,4 +1219,75 @@ describe( 'Editor actions', () => {
 			);
 		} );
 	} );
+
+	describe( 'setRenderingMode', () => {
+		it( 'changes the mode when none is fixed', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editorStore ).setRenderingMode( 'post-only' );
+			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
+				'post-only'
+			);
+
+			registry
+				.dispatch( editorStore )
+				.setRenderingMode( 'template-locked' );
+			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
+				'template-locked'
+			);
+		} );
+
+		it( 'applies the fixed mode, so an editor can enter it', () => {
+			const registry = createRegistryWithStores();
+			registry.dispatch( editorStore ).updateEditorSettings( {
+				fixedRenderingMode: 'template-locked',
+			} );
+
+			registry
+				.dispatch( editorStore )
+				.setRenderingMode( 'template-locked' );
+
+			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
+				'template-locked'
+			);
+		} );
+
+		it( 'ignores a move away from the fixed mode', () => {
+			const registry = createRegistryWithStores();
+			registry.dispatch( editorStore ).updateEditorSettings( {
+				fixedRenderingMode: 'template-locked',
+			} );
+			registry
+				.dispatch( editorStore )
+				.setRenderingMode( 'template-locked' );
+
+			registry.dispatch( editorStore ).setRenderingMode( 'post-only' );
+
+			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
+				'template-locked'
+			);
+		} );
+
+		it( 'changes the mode again once the fixed mode is cleared', () => {
+			const registry = createRegistryWithStores();
+			registry.dispatch( editorStore ).updateEditorSettings( {
+				fixedRenderingMode: 'template-locked',
+			} );
+			registry
+				.dispatch( editorStore )
+				.setRenderingMode( 'template-locked' );
+
+			// Leaving a route that fixes the mode sends `undefined`, which
+			// has to clear it: editor settings merge, and the site editor
+			// shares one store across its routes.
+			registry.dispatch( editorStore ).updateEditorSettings( {
+				fixedRenderingMode: undefined,
+			} );
+			registry.dispatch( editorStore ).setRenderingMode( 'post-only' );
+
+			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
+				'post-only'
+			);
+		} );
+	} );
 } );

--- a/packages/editor/src/store/test/actions.jsdom.test.js
+++ b/packages/editor/src/store/test/actions.jsdom.test.js
@@ -7,6 +7,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { createRegistry } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as preferencesStore } from '@wordpress/preferences';
+import warning from '@wordpress/warning';
 import { store as editorStore } from '..';
 import * as actions from '../actions';
 import { unlock } from '../../lock-unlock';
@@ -16,6 +17,8 @@ vi.hoisted( () => globalThis.wpVitest.mockMatchMedia() );
 vi.mock( '@wordpress/a11y', () => ( {
 	speak: vi.fn(),
 } ) );
+
+vi.mock( '@wordpress/warning' );
 
 const postId = 44;
 
@@ -1221,6 +1224,10 @@ describe( 'Editor actions', () => {
 	} );
 
 	describe( 'setRenderingMode', () => {
+		beforeEach( () => {
+			warning.mockClear();
+		} );
+
 		it( 'changes the mode when none is fixed', () => {
 			const registry = createRegistryWithStores();
 
@@ -1235,6 +1242,7 @@ describe( 'Editor actions', () => {
 			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
 				'template-locked'
 			);
+			expect( warning ).not.toHaveBeenCalled();
 		} );
 
 		it( 'applies the fixed mode, so an editor can enter it', () => {
@@ -1250,9 +1258,12 @@ describe( 'Editor actions', () => {
 			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
 				'template-locked'
 			);
+			// Applying the mode is how the editor enters it, so it is not a
+			// request to refuse.
+			expect( warning ).not.toHaveBeenCalled();
 		} );
 
-		it( 'ignores a move away from the fixed mode', () => {
+		it( 'ignores a move away from the fixed mode, and warns', () => {
 			const registry = createRegistryWithStores();
 			registry.dispatch( editorStore ).updateEditorSettings( {
 				renderingMode: 'template-locked',
@@ -1265,6 +1276,10 @@ describe( 'Editor actions', () => {
 
 			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
 				'template-locked'
+			);
+			expect( warning ).toHaveBeenCalledTimes( 1 );
+			expect( warning ).toHaveBeenCalledWith(
+				expect.stringContaining( "setRenderingMode( 'post-only' )" )
 			);
 		} );
 
@@ -1288,6 +1303,7 @@ describe( 'Editor actions', () => {
 			expect( registry.select( editorStore ).getRenderingMode() ).toBe(
 				'post-only'
 			);
+			expect( warning ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -246,6 +246,89 @@ test.describe( 'Style Revisions', () => {
 		}
 	} );
 
+	// The controls this checks belong to the v1 site editor shell.
+	test( 'should show the template on the styles route whatever the user prefers', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		test.skip(
+			isSiteEditorV2,
+			'The v1 site editor shell is not present in v2.'
+		);
+
+		// Styling the site means styling the template around it, so the
+		// styles route shows the template even when the canvas is a page and
+		// the user has turned "Show template" off while editing pages.
+		const frontPage = await requestUtils.createPage( {
+			title: 'Home',
+			status: 'publish',
+		} );
+		await requestUtils.updateSiteSettings( {
+			show_on_front: 'page',
+			page_on_front: frontPage.id,
+		} );
+
+		try {
+			await admin.visitSiteEditor();
+			await page.evaluate( async () => {
+				const theme = window.wp.data
+					.select( 'core' )
+					.getCurrentTheme()?.stylesheet;
+				await window.wp.data
+					.dispatch( 'core/preferences' )
+					.set( 'core', 'renderingModes', {
+						[ theme ]: { page: 'post-only' },
+					} );
+			} );
+
+			await admin.visitSiteEditor();
+			await page
+				.getByRole( 'region', { name: 'Navigation' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
+			await editor.canvas.locator( '.wp-block' ).first().waitFor();
+
+			await expect
+				.poll( () =>
+					page.evaluate( () =>
+						window.wp.data
+							.select( 'core/editor' )
+							.getRenderingMode()
+					)
+				)
+				.toBe( 'template-locked' );
+
+			// With one mode to be in, the editor does not offer to leave it.
+			await page
+				.locator(
+					'iframe.edit-site-visual-editor__editor-canvas[role="button"]'
+				)
+				.click();
+			await expect( page ).toHaveURL( /canvas=edit/ );
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'View', exact: true } )
+				.click();
+			await expect(
+				page.getByRole( 'menuitemcheckbox', { name: 'Show template' } )
+			).toBeHidden();
+			await page.keyboard.press( 'Escape' );
+		} finally {
+			await page.evaluate( () =>
+				window.wp.data
+					.dispatch( 'core/preferences' )
+					.set( 'core', 'renderingModes', {} )
+			);
+			await requestUtils.updateSiteSettings( {
+				show_on_front: 'posts',
+				page_on_front: 0,
+			} );
+			await requestUtils.deleteAllPages();
+		}
+	} );
+
 	// The back button this exercises ("Open Navigation") and the clickable
 	// canvas belong to the v1 site editor shell; v2 has no equivalent.
 	test( 'should keep the site preview clickable after leaving the styles editor', async ( {

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -2,6 +2,10 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const isSiteEditorV2 = !! process.env.GUTENBERG_E2E_SITE_EDITOR_V2;
 
+// The rendering mode preference is keyed by theme, so the tests that set it
+// have to name the same theme the fixture activates.
+const THEME = 'emptytheme';
+
 test.use( {
 	userGlobalStylesRevisions: async (
 		{ editor, page, requestUtils },
@@ -18,7 +22,7 @@ test.describe( 'Style Revisions', () => {
 
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all( [
-			requestUtils.activateTheme( 'emptytheme' ),
+			requestUtils.activateTheme( THEME ),
 			requestUtils.deleteAllTemplates( 'wp_template' ),
 			requestUtils.deleteAllTemplates( 'wp_template_part' ),
 		] );
@@ -27,7 +31,7 @@ test.describe( 'Style Revisions', () => {
 
 	test.beforeEach( async ( { admin } ) => {
 		await admin.visitSiteEditor( {
-			postId: 'emptytheme//index',
+			postId: `${ THEME }//index`,
 			postType: 'wp_template',
 			canvas: 'edit',
 		} );
@@ -258,25 +262,25 @@ test.describe( 'Style Revisions', () => {
 			'The v1 site editor shell is not present in v2.'
 		);
 
-		// Styling the site means styling the template around it, so the
-		// styles route shows the template even when the canvas is a page and
-		// the user has turned "Show template" off while editing pages.
-		const frontPage = await requestUtils.createPage( {
-			title: 'Home',
-			status: 'publish',
-		} );
-		await requestUtils.updateSiteSettings( {
-			show_on_front: 'page',
-			page_on_front: frontPage.id,
-		} );
-
-		// Set over REST rather than dispatched, so it is persisted before the
-		// editor reads it.
-		await requestUtils.setPreferences( 'core', {
-			renderingModes: { emptytheme: { page: 'post-only' } },
-		} );
-
 		try {
+			// Styling the site means styling the template around it, so the
+			// styles route shows the template even when the canvas is a page
+			// and the user has turned "Show template" off while editing pages.
+			const frontPage = await requestUtils.createPage( {
+				title: 'Home',
+				status: 'publish',
+			} );
+			await requestUtils.updateSiteSettings( {
+				show_on_front: 'page',
+				page_on_front: frontPage.id,
+			} );
+
+			// Set over REST rather than dispatched, so it is persisted before
+			// the editor reads it.
+			await requestUtils.setPreferences( 'core', {
+				renderingModes: { [ THEME ]: { page: 'post-only' } },
+			} );
+
 			await admin.visitSiteEditor();
 			await page
 				.getByRole( 'region', { name: 'Navigation' } )

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -270,19 +270,13 @@ test.describe( 'Style Revisions', () => {
 			page_on_front: frontPage.id,
 		} );
 
-		try {
-			await admin.visitSiteEditor();
-			await page.evaluate( async () => {
-				const theme = window.wp.data
-					.select( 'core' )
-					.getCurrentTheme()?.stylesheet;
-				await window.wp.data
-					.dispatch( 'core/preferences' )
-					.set( 'core', 'renderingModes', {
-						[ theme ]: { page: 'post-only' },
-					} );
-			} );
+		// Set over REST rather than dispatched, so it is persisted before the
+		// editor reads it.
+		await requestUtils.setPreferences( 'core', {
+			renderingModes: { emptytheme: { page: 'post-only' } },
+		} );
 
+		try {
 			await admin.visitSiteEditor();
 			await page
 				.getByRole( 'region', { name: 'Navigation' } )
@@ -316,11 +310,9 @@ test.describe( 'Style Revisions', () => {
 			).toBeHidden();
 			await page.keyboard.press( 'Escape' );
 		} finally {
-			await page.evaluate( () =>
-				window.wp.data
-					.dispatch( 'core/preferences' )
-					.set( 'core', 'renderingModes', {} )
-			);
+			await requestUtils.setPreferences( 'core', {
+				renderingModes: {},
+			} );
 			await requestUtils.updateSiteSettings( {
 				show_on_front: 'posts',
 				page_on_front: 0,


### PR DESCRIPTION
## What

Follow up to #82624, as discussed there.

The site editor's global routes (home, identity, styles) show the site, so they show the template around whatever the canvas is rendering. 

#82624 did that with the `defaultRenderingMode` setting, but a default is overridden by the user's saved "Show template" preference, so the mode didn't stick and surfaced the bug that #82624 tried to fix.



https://github.com/user-attachments/assets/30b5efed-607b-4cb3-884b-cdd77f9981aa



## Why

`getDefaultRenderingMode` checks the preference before editor settings:

| saved preference | mode on `/styles` before | after |
|---|---|---|
| none | `template-locked` | `template-locked` |
| `renderingModes[theme].page = 'post-only'` | `post-only` ✗ | `template-locked` ✓ |

## How

`fixedRenderingMode` on `EditorProvider` replaces the resolution rather than joining it. 

The provider publishes it to editor settings, where the two mode-switching controls (in the view menu and in the block  inspector) read it and hide themselves.

`setRenderingMode` ignores any incoming mode trying to switch if `fixedRenderingMode` is set.

Replaces the `defaultRenderingMode` prop #82624 added to the site editor's `Editor` wrapper. The `defaultRenderingMode` setting itself is unchanged.

`defaultRenderingMode` = a starting point the user can override. `fixedRenderingMode` = what this editor is for. (open to naming here!)


## Follow-ups
- the v2 site editor gets the same treatment here: https://github.com/WordPress/gutenberg/pull/82712


## Testing Instructions

1. Block theme, **Settings → Reading** set to a static page.
2. In the **post editor**, open any page and turn **Show template** off.
3. **Appearance → Editor → Styles**. The template renders, and "Show template" is absent from the View menu.
4. Open a page from **Pages**: `post-only`, "Show template" present and working.
5. Back on **Styles**, in the sidebar Summary open the **Template** row → **Create new template**. The notice appears without a "Back" action. From a page in step 4, "Back" is still offered and works.


## Use of AI

A fair bit, but directed by me after exhaustive interrogation and manual testing.
