### PR TITLE
Site Editor v2: Show the template on the routes that show the site

### DIFF
--- a/packages/boot/src/components/canvas/index.tsx
+++ b/packages/boot/src/components/canvas/index.tsx
@@ -164,6 +164,7 @@ export default function Canvas( { canvas }: CanvasProps ) {
 				<Editor
 					postType={ canvas.postType }
 					postId={ canvas.postId }
+					renderingMode={ canvas.renderingMode }
 					settings={ settings }
 					backButton={ backButton }
 					onActionPerformed={ onActionPerformed }

--- a/packages/boot/src/store/types.ts
+++ b/packages/boot/src/store/types.ts
@@ -53,6 +53,13 @@ export interface CanvasData {
 	 * Indicates if the canvas is in preview mode.
 	 */
 	isPreview?: boolean;
+
+	/**
+	 * The rendering mode the canvas stays in, for routes that show the site
+	 * rather than one piece of content. Resolved from the post type and the
+	 * user's preference when omitted.
+	 */
+	renderingMode?: 'post-only' | 'template-locked';
 }
 
 /**

--- a/packages/lazy-editor/src/components/editor/index.tsx
+++ b/packages/lazy-editor/src/components/editor/index.tsx
@@ -24,6 +24,7 @@ interface EditorProps {
 	backButton?: ReactNode;
 	onActionPerformed?: ( actionId: string, items: any[] ) => void;
 	initialViewport?: string;
+	renderingMode?: string;
 }
 
 /**
@@ -36,6 +37,7 @@ interface EditorProps {
  * @param {ReactNode} props.backButton        Optional back button to render in editor header
  * @param {Function}  props.onActionPerformed Optional callback run after a post action
  * @param {string}    props.initialViewport   Optional device type the entity opens at
+ * @param {string}    props.renderingMode     Optional rendering mode the editor stays in, for a route that shows the site rather than one piece of content
  * @return The editor component with loading states
  */
 export function Editor( {
@@ -45,6 +47,7 @@ export function Editor( {
 	backButton,
 	onActionPerformed,
 	initialViewport,
+	renderingMode,
 }: EditorProps ) {
 	// Resolve homepage when no postType/postId provided
 	const homePage = useSelect(
@@ -133,6 +136,7 @@ export function Editor( {
 			styles={ finalSettings.styles }
 			onActionPerformed={ onActionPerformed }
 			initialViewport={ initialViewport }
+			renderingMode={ renderingMode }
 		>
 			{ backButton && <BackButton>{ backButton }</BackButton> }
 			{ /*

--- a/routes/home/route.ts
+++ b/routes/home/route.ts
@@ -5,6 +5,9 @@ export const route = {
 	async canvas() {
 		return {
 			isPreview: true,
+			// This route shows the site, so it shows the template around
+			// whatever the canvas resolves to, including a static front page.
+			renderingMode: 'template-locked' as const,
 		};
 	},
 };

--- a/routes/identity/route.ts
+++ b/routes/identity/route.ts
@@ -18,6 +18,9 @@ export const route = {
 	async canvas() {
 		return {
 			isPreview: true,
+			// This route shows the site, so it shows the template around
+			// whatever the canvas resolves to, including a static front page.
+			renderingMode: 'template-locked' as const,
 		};
 	},
 	loader: async () => {

--- a/routes/styles/route.ts
+++ b/routes/styles/route.ts
@@ -57,6 +57,9 @@ export const route = {
 		}
 		return {
 			isPreview: true,
+			// Styling the site means styling the template around it, so it is
+			// shown even when the canvas resolves to a static front page.
+			renderingMode: 'template-locked' as const,
 		};
 	},
 };


### PR DESCRIPTION
## What

Stacked on #82711 — review that first.

The v2 home, identity and styles routes show the page's content without the template around it when the site uses a static front page.

### Before


https://github.com/user-attachments/assets/aa61d107-b41a-4934-aa05-6c26f046d3dd


### After



https://github.com/user-attachments/assets/7ae4615e-e9cf-47e6-8367-0b36995ecf35






## Why

Those routes render the canvas with no entity, so the lazy editor falls back to `getHomePage()`. With a static front page that resolves to a `page`, which defaults to `post-only`. Same cause as #82624 in v1.

## How

Pass `renderingMode` from the three routes, through the canvas descriptor and the lazy editor, to the provider — the prop #82711 adds.

## Testing Instructions

1. Enable **Extensible Site Editor** in Experiments.
2. Block theme, **Settings → Reading** set to a static page.
3. In the **post editor**, open a page and turn **Show template** off.
4. `admin.php?page=site-editor-v2` → **Styles**. The canvas shows the header and footer; a colour change applies to them. On `trunk` it shows the page content alone.
5. Same on **Home** and **Identity**.
6. **Pages → any page**: still `post-only`, "Show template" still offered.
