### PR TITLE
Button: validate url protocol before writing it into the saved href

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
 -   Image: Keep the selected image size, and re-point a media file or attachment page link, when an edit in the media editor saves to a new attachment. Cropping, rotating or flipping left the block rendering the full-size file while the size control still reported the size the user had chosen, and left the link pointing at the pre-edit image ([#82316](https://github.com/WordPress/gutenberg/pull/82316)).
 -   Query, Post Template: Treat a `query` attribute that omits `postType` as querying posts, matching `build_query_vars_from_query_block()` ([#82465](https://github.com/WordPress/gutenberg/pull/82465)).
+-   Button: Validate the `url` attribute's protocol against an allowlist before writing it into the saved `href`, so a `javascript:` (or otherwise unsafe) scheme is dropped instead of rendered as a clickable, executable link.
 
 ### Internal
 

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -23,7 +23,7 @@
 -   Icon: Preserve intrinsic SVG styles when applying block styles or rotation, and keep stroke widths scaling with the block's size for compatibility ([#78808](https://github.com/WordPress/gutenberg/pull/78808)).
 -   Image: Keep the selected image size, and re-point a media file or attachment page link, when an edit in the media editor saves to a new attachment. Cropping, rotating or flipping left the block rendering the full-size file while the size control still reported the size the user had chosen, and left the link pointing at the pre-edit image ([#82316](https://github.com/WordPress/gutenberg/pull/82316)).
 -   Query, Post Template: Treat a `query` attribute that omits `postType` as querying posts, matching `build_query_vars_from_query_block()` ([#82465](https://github.com/WordPress/gutenberg/pull/82465)).
--   Button: Validate the `url` attribute's protocol against an allowlist before writing it into the saved `href`, so a `javascript:` (or otherwise unsafe) scheme is dropped instead of rendered as a clickable, executable link.
+-   Button: Validate the `url` attribute's protocol against an allowlist before writing it into the saved `href`, so a `javascript:` (or otherwise unsafe) scheme is dropped instead of rendered as a clickable, executable link ([#82714](https://github.com/WordPress/gutenberg/pull/82714)).
 
 ### Internal
 

--- a/packages/block-library/src/button/save.jsx
+++ b/packages/block-library/src/button/save.jsx
@@ -9,6 +9,7 @@ import {
 	__experimentalGetElementClassName,
 	getTypographyClassesAndStyles,
 } from '@wordpress/block-editor';
+import { getSafeButtonUrl } from './utils';
 
 export default function save( { attributes } ) {
 	const {
@@ -62,7 +63,7 @@ export default function save( { attributes } ) {
 				tagName={ TagName }
 				type={ isButtonTag ? buttonType : null }
 				className={ buttonClasses }
-				href={ isButtonTag ? null : url }
+				href={ isButtonTag ? null : getSafeButtonUrl( url ) }
 				title={ title }
 				style={ buttonStyle }
 				value={ text }

--- a/packages/block-library/src/button/test/utils.js
+++ b/packages/block-library/src/button/test/utils.js
@@ -32,9 +32,7 @@ describe( 'getSafeButtonUrl', () => {
 	} );
 
 	it( 'should reject a javascript: url disguised with a leading or embedded control character', () => {
-		// Browsers strip ASCII tab/newline and leading C0 control chars or
-		// spaces before resolving a URL's scheme, so these still execute as
-		// `javascript:` even though the raw string doesn't start with it.
+		// Browsers strip these before resolving the scheme, so it still executes.
 		expect( getSafeButtonUrl( '\tjavascript:alert(1)' ) ).toBeNull();
 		expect( getSafeButtonUrl( ' javascript:alert(1)' ) ).toBeNull();
 		expect( getSafeButtonUrl( 'java\tscript:alert(1)' ) ).toBeNull();

--- a/packages/block-library/src/button/test/utils.js
+++ b/packages/block-library/src/button/test/utils.js
@@ -1,5 +1,45 @@
 import { describe, expect, it } from 'vitest';
-import { getWidthClasses, isPercentageWidth } from '../utils';
+import { getSafeButtonUrl, getWidthClasses, isPercentageWidth } from '../utils';
+
+describe( 'getSafeButtonUrl', () => {
+	it( 'should return null for an empty or non-string url', () => {
+		expect( getSafeButtonUrl( undefined ) ).toBeNull();
+		expect( getSafeButtonUrl( null ) ).toBeNull();
+		expect( getSafeButtonUrl( '' ) ).toBeNull();
+		expect( getSafeButtonUrl( 123 ) ).toBeNull();
+	} );
+
+	it( 'should return the url unchanged for an allowed protocol', () => {
+		expect( getSafeButtonUrl( 'https://wordpress.org' ) ).toBe(
+			'https://wordpress.org'
+		);
+		expect( getSafeButtonUrl( 'http://wordpress.org' ) ).toBe(
+			'http://wordpress.org'
+		);
+		expect( getSafeButtonUrl( 'mailto:test@example.com' ) ).toBe(
+			'mailto:test@example.com'
+		);
+		expect( getSafeButtonUrl( 'tel:012345678' ) ).toBe( 'tel:012345678' );
+	} );
+
+	it( 'should return a relative url unchanged', () => {
+		expect( getSafeButtonUrl( '/handbook' ) ).toBe( '/handbook' );
+		expect( getSafeButtonUrl( '#section' ) ).toBe( '#section' );
+	} );
+
+	it( 'should reject a javascript: url', () => {
+		expect( getSafeButtonUrl( 'javascript:alert(1)' ) ).toBeNull();
+	} );
+
+	it( 'should reject a javascript: url disguised with a leading or embedded control character', () => {
+		// Browsers strip ASCII tab/newline and leading C0 control chars or
+		// spaces before resolving a URL's scheme, so these still execute as
+		// `javascript:` even though the raw string doesn't start with it.
+		expect( getSafeButtonUrl( '\tjavascript:alert(1)' ) ).toBeNull();
+		expect( getSafeButtonUrl( ' javascript:alert(1)' ) ).toBeNull();
+		expect( getSafeButtonUrl( 'java\tscript:alert(1)' ) ).toBeNull();
+	} );
+} );
 
 describe( 'isPercentageWidth', () => {
 	it( 'should return true for percentage values', () => {

--- a/packages/block-library/src/button/test/utils.js
+++ b/packages/block-library/src/button/test/utils.js
@@ -27,6 +27,28 @@ describe( 'getSafeButtonUrl', () => {
 		expect( getSafeButtonUrl( '#section' ) ).toBe( '#section' );
 	} );
 
+	it( 'should return a relative url unchanged even with a colon later in the path, query, or fragment', () => {
+		expect( getSafeButtonUrl( '/2024/03/10:special-post' ) ).toBe(
+			'/2024/03/10:special-post'
+		);
+		expect( getSafeButtonUrl( '?redirect=https://example.com' ) ).toBe(
+			'?redirect=https://example.com'
+		);
+		expect( getSafeButtonUrl( '#section:1' ) ).toBe( '#section:1' );
+	} );
+
+	it( 'should return the url unchanged for other core-allowed protocols', () => {
+		expect( getSafeButtonUrl( 'ftp://example.com/file' ) ).toBe(
+			'ftp://example.com/file'
+		);
+		expect( getSafeButtonUrl( 'webcal://example.com/cal.ics' ) ).toBe(
+			'webcal://example.com/cal.ics'
+		);
+		expect( getSafeButtonUrl( 'xmpp:user@example.com' ) ).toBe(
+			'xmpp:user@example.com'
+		);
+	} );
+
 	it( 'should reject a javascript: url', () => {
 		expect( getSafeButtonUrl( 'javascript:alert(1)' ) ).toBeNull();
 	} );

--- a/packages/block-library/src/button/utils.js
+++ b/packages/block-library/src/button/utils.js
@@ -1,3 +1,35 @@
+import { getProtocol } from '@wordpress/url';
+
+const ALLOWED_LINK_PROTOCOLS = [ 'http:', 'https:', 'mailto:', 'tel:', 'sms:' ];
+
+/**
+ * Returns the given link URL only if its protocol is on the safe allowlist
+ * (or the URL is relative, i.e. has no protocol), otherwise null. Blocks
+ * `javascript:` and other unsafe schemes from being written into the saved
+ * `href`, including ones hidden behind a leading/embedded tab, newline, or
+ * control character that browsers strip before resolving the scheme
+ * themselves.
+ *
+ * @param {?string} url - The raw link URL to check.
+ * @return {?string} The URL if safe, otherwise null.
+ */
+export function getSafeButtonUrl( url ) {
+	if ( ! url || typeof url !== 'string' ) {
+		return null;
+	}
+
+	const normalized = url
+		.replace( /[\t\n\r]/g, '' )
+		.replace( /^[\x00-\x20]+|[\x00-\x20]+$/g, '' );
+
+	const protocol = getProtocol( normalized )?.toLowerCase();
+	if ( protocol && ! ALLOWED_LINK_PROTOCOLS.includes( protocol ) ) {
+		return null;
+	}
+
+	return url;
+}
+
 /**
  * Returns whether the given width value is a percentage.
  *

--- a/packages/block-library/src/button/utils.js
+++ b/packages/block-library/src/button/utils.js
@@ -1,6 +1,7 @@
 import { getProtocol } from '@wordpress/url';
 
-// Matches WordPress core's own wp_allowed_protocols() allowlist (wp-includes/functions.php) so this doesn't reject links core already treats as safe.
+// Matches wp_allowed_protocols() in wp-includes/functions.php, so this
+// doesn't reject a link the rest of WordPress already treats as safe.
 const ALLOWED_LINK_PROTOCOLS = [
 	'http:',
 	'https:',
@@ -46,7 +47,8 @@ export function getSafeButtonUrl( url ) {
 		.replace( /[\t\n\r]/g, '' )
 		.replace( /^[\x00-\x20]+|[\x00-\x20]+$/g, '' );
 
-	// A leading "/", "?", or "#" is unambiguously relative, so a later colon (e.g. "/2024/03/10:special-post") isn't mistaken for a scheme.
+	// A leading "/", "?", or "#" is unambiguously relative, so a later
+	// colon (e.g. "/2024/03/10:special-post") isn't mistaken for a scheme.
 	if ( /^[/?#]/.test( normalized ) ) {
 		return url;
 	}

--- a/packages/block-library/src/button/utils.js
+++ b/packages/block-library/src/button/utils.js
@@ -1,6 +1,30 @@
 import { getProtocol } from '@wordpress/url';
 
-const ALLOWED_LINK_PROTOCOLS = [ 'http:', 'https:', 'mailto:', 'tel:', 'sms:' ];
+// Matches WordPress core's own wp_allowed_protocols() allowlist (wp-includes/functions.php) so this doesn't reject links core already treats as safe.
+const ALLOWED_LINK_PROTOCOLS = [
+	'http:',
+	'https:',
+	'ftp:',
+	'ftps:',
+	'mailto:',
+	'news:',
+	'irc:',
+	'irc6:',
+	'ircs:',
+	'gopher:',
+	'nntp:',
+	'feed:',
+	'telnet:',
+	'mms:',
+	'rtsp:',
+	'sms:',
+	'svn:',
+	'tel:',
+	'fax:',
+	'xmpp:',
+	'webcal:',
+	'urn:',
+];
 
 /**
  * Returns the given link URL only if its protocol is on the safe allowlist
@@ -21,6 +45,11 @@ export function getSafeButtonUrl( url ) {
 	const normalized = url
 		.replace( /[\t\n\r]/g, '' )
 		.replace( /^[\x00-\x20]+|[\x00-\x20]+$/g, '' );
+
+	// A leading "/", "?", or "#" is unambiguously relative, so a later colon (e.g. "/2024/03/10:special-post") isn't mistaken for a scheme.
+	if ( /^[/?#]/.test( normalized ) ) {
+		return url;
+	}
 
 	const protocol = getProtocol( normalized )?.toLowerCase();
 	if ( protocol && ! ALLOWED_LINK_PROTOCOLS.includes( protocol ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Validate the Button block's `url` attribute against an allowed-protocol list before writing it into the saved `href`, instead of writing it through unchanged.

## Why?

The Button block's `save.jsx` currently does `href={ isButtonTag ? null : url }` with no check on `url` at all. A `javascript:` (or other non-standard-scheme) value saved into the block's `url` attribute is written verbatim into the rendered `<a href>` and executes when the button is clicked on the front end.

This is reachable today by any user with the `unfiltered_html` capability (Administrator, and Editor on a non-multisite install) typing a `javascript:` URL into the Button block's link field — `wp_kses` only strips this for users *without* that capability, and this block does no validation of its own either client- or server-side. I'm not framing this as an urgent security report — WordPress's own stance is that `unfiltered_html`-capable users are a trusted boundary the platform doesn't defend against themselves, and this block's behavior is consistent with that. But the stored payload isn't confined to the author's own session: it persists into `post_content` and fires for every visitor who clicks the button on the published page, which is exactly the shape of issue plugin security review (WordPress.org, Wordfence, Patchstack) treats as worth closing even where core's own threat model doesn't require it. Given the fix is small and has no behavioral downside for legitimate URLs, it seemed worth proposing as plain hardening.

## How?

Added `getSafeButtonUrl()` in `packages/block-library/src/button/utils.js`, reusing `@wordpress/url`'s existing `getProtocol()` (already a dependency of this package) against an allowlist of `http:`, `https:`, `mailto:`, `tel:`, `sms:`, or a relative URL (no protocol). It also strips the ASCII tab/newline and leading C0 control characters/spaces that browsers themselves strip before resolving a URL's scheme, so a value like `"\tjavascript:alert(1)"` — which has no *detectable* protocol under a naive check, but still executes once the browser normalizes it — is caught too.

`save.jsx` now calls this instead of using `url` directly. `edit.jsx` is unchanged — it never writes `url` into a real `href` attribute in the editor canvas, only into `LinkControl`'s state, so there's no equivalent execution surface there.

Scope is intentionally just the Button block, not a sweep of every block that stores a URL — happy to extend this pattern elsewhere if that's wanted, but wanted to keep this PR small and reviewable.

## Testing Instructions

1. Insert a Button block.
2. Set its link URL to `javascript:alert(document.cookie)` (via the link popover, or by setting the `url` attribute directly through the block's REST/API representation).
3. Publish and view the post on the front end.
4. Before this change: the rendered button's `href` is `javascript:alert(document.cookie)`, and clicking it executes the script. After this change: the rendered button has no `href` attribute.
5. Confirm a normal link (`https://wordpress.org`, `mailto:test@example.com`, a relative path like `/handbook`, or a hash link like `#section`) still saves and renders its `href` unchanged.
6. `npm run test:unit:vitest -- packages/block-library/src/button/test/utils.js` — added test cases for `getSafeButtonUrl`, including the tab/control-character bypass case.

### Testing Instructions for Keyboard

No UI change — the link field, its keyboard interaction, and the toolbar are unaffected. Only the saved markup for an already-entered URL changes.

## Screenshots or screencast

Not applicable — no visual change to the block editor UI.

## Use of AI Tools

Used Claude Code (Anthropic) throughout: to identify the missing validation, implement `getSafeButtonUrl()`, and write the accompanying unit tests. I reviewed the change, verified the vulnerable-vs-fixed behavior live in a browser (including the tab/control-character bypass), and take responsibility for the PR's contents.
