### PR TITLE
Editor: Coerce `multiple` to a boolean in the media modal wrapper

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 
+-   `MediaUpload`: Coerce `multiple` to a boolean before passing it to the experimental media modal; callers such as the playlist block and the inserter media tab pass the legacy media frame's `'add'` mode. ([#](https://github.com/WordPress/gutenberg/pull/))
 -   `PostURL`: Translate the copy permalink button label, which was hardcoded in English ([#82642](https://github.com/WordPress/gutenberg/pull/82642)).
 -   User autocompleter: Don't open the mention popup when the `@` follows other text, such as while typing an email address; mentions still trigger after a space, punctuation, or at the start of a line ([#47249](https://github.com/WordPress/gutenberg/pull/47249)).
 -   More menu: Align SVG prefix icons with item labels using `Menu.PrefixIcon`, preserving Dashicon and custom component support. ([#82346](https://github.com/WordPress/gutenberg/pull/82346))

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Bug Fixes
 
--   `MediaUpload`: Coerce `multiple` to a boolean before passing it to the experimental media modal; callers such as the playlist block and the inserter media tab pass the legacy media frame's `'add'` mode. ([#](https://github.com/WordPress/gutenberg/pull/))
+-   `MediaUpload`: Coerce `multiple` to a boolean before passing it to the experimental media modal; callers such as the playlist block and the inserter media tab pass the legacy media frame's `'add'` mode. ([#82715](https://github.com/WordPress/gutenberg/pull/82715))
 -   `PostURL`: Translate the copy permalink button label, which was hardcoded in English ([#82642](https://github.com/WordPress/gutenberg/pull/82642)).
 -   User autocompleter: Don't open the mention popup when the `@` follows other text, such as while typing an email address; mentions still trigger after a space, punctuation, or at the start of a line ([#47249](https://github.com/WordPress/gutenberg/pull/47249)).
 -   More menu: Align SVG prefix icons with item labels using `Menu.PrefixIcon`, preserving Dashicon and custom component support. ([#82346](https://github.com/WordPress/gutenberg/pull/82346))

--- a/packages/editor/src/hooks/media-upload.jsx
+++ b/packages/editor/src/hooks/media-upload.jsx
@@ -93,7 +93,8 @@ class MediaUploadModalWrapper extends Component {
 				{ render( { open: this.openModal } ) }
 				<MediaUploadModalWithPostContext
 					allowedTypes={ allowedTypes }
-					multiple={ multiple }
+					// Callers may pass the legacy frame's `'add'` mode; the modal takes a boolean.
+					multiple={ !! multiple }
 					value={ value }
 					onSelect={ ( media ) => {
 						onSelect( media );


### PR DESCRIPTION
## What?
Extracted from: https://github.com/WordPress/gutenberg/pull/82678

The `editor.MediaUpload` wrapper for the experimental media modal passes `multiple` as is, and some callers(playlist block, inserter media tab) pass the legacy media frame's `'add'` value. This coerces it to the boolean the modal expects.

## Testing Instructions
1. Enable the `Media Upload Modal` experiment.
2. Insert a Playlist block and add some tracks through the modal.
3. Everything should work as before.

## Use of AI Tools
Fable 5.1 with direction, changes and review.
