### PR TITLE
Global Styles: Remove dead breakpoint-nested blocks schema entry

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1406,7 +1406,6 @@ class WP_Theme_JSON_Gutenberg {
 					foreach ( array_keys( $responsive_media_queries ) as $breakpoint_state ) {
 						$variation_schema[ $breakpoint_state ]             = $styles_non_top_level;
 						$variation_schema[ $breakpoint_state ]['elements'] = $schema_styles_elements;
-						$variation_schema[ $breakpoint_state ]['blocks']   = $schema_styles_blocks;
 
 						if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 							foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {


### PR DESCRIPTION
## What?

Removes a dead line from the block style variation schema in `WP_Theme_JSON_Gutenberg::sanitize()`.

## Why?

The schema allowed a `blocks` map nested inside a responsive breakpoint state (`variations.<slug>.@mobile.blocks`). That data survives sanitization but nothing reads it when generating CSS, so it never produces any output.

The supported form is the other nesting order — `variations.<slug>.blocks.<block>.@mobile` — which is unaffected.

Props to @talldan for spotting it in https://github.com/WordPress/gutenberg/pull/82403#discussion_r3975668226.

## How?

Deletes the one schema assignment. No other behaviour changes.

## Testing Instructions

Declare a block style variation with `blocks` nested inside a breakpoint state, e.g. in `theme.json`:

```json
{
	"styles": {
		"blocks": {
			"core/group": {
				"variations": {
					"my-variation": {
						"@mobile": {
							"blocks": {
								"core/heading": {
									"typography": { "fontSize": "18px" }
								}
							}
						}
					}
				}
			}
		}
	}
}
```

No CSS is generated for it before or after this change. The reverse nesting (`blocks.core/heading.@mobile`) still generates its media query rule as before.

PHP unit tests should pass.

## Use of AI Tools

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 5)
- **Used for:** Confirming the line was dead (verifying no CSS is generated from that shape) and running the test suites.

All output was reviewed by me before submission.
