### PR TITLE
Fields: Show a message in MediaEdit when the user can't upload media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51765,7 +51765,7 @@
 				"remove-accents": "^0.5.0"
 			},
 			"devDependencies": {
-				"@testing-library/react": "^16.3.2",
+				"@testing-library/react": "^16.3.3",
 				"vitest": "^5.0.0"
 			},
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51765,6 +51765,7 @@
 				"remove-accents": "^0.5.0"
 			},
 			"devDependencies": {
+				"@testing-library/react": "^16.3.2",
 				"vitest": "^5.0.0"
 			},
 			"engines": {

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 
+-   `MediaEdit`: Show a message instead of the picker when the user lacks permission to upload media. ([#](https://github.com/WordPress/gutenberg/pull/))
 -   `author`: Drop the custom `sort` callback, which read `_embedded.author` from the arguments although `Field.sort` receives the field values (the author ids), so every comparison returned `0` and in-memory sorting by author was a no-op. The field now sorts by author id through the `integer` type, matching the order the REST API returns for `orderby=author` ([#82559](https://github.com/WordPress/gutenberg/pull/82559)).
 -   Hide the slug field for posts without a permalink, such as posts of non-public post types, matching the classic post URL panel ([#82341](https://github.com/WordPress/gutenberg/pull/82341)).
 -   Normalize special characters in exported pattern filenames to prevent broken or unreadable files. ([#77033](https://github.com/WordPress/gutenberg/pull/77033))

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `MediaEdit`: Show a message instead of the picker when the user lacks permission to upload media. ([#82720](https://github.com/WordPress/gutenberg/pull/82720))
+
 ## 0.47.0 (2026-09-10)
 
 ### Enhancements
@@ -12,7 +16,6 @@
 
 ### Bug Fixes
 
--   `MediaEdit`: Show a message instead of the picker when the user lacks permission to upload media. ([#82720](https://github.com/WordPress/gutenberg/pull/82720))
 -   `author`: Drop the custom `sort` callback, which read `_embedded.author` from the arguments although `Field.sort` receives the field values (the author ids), so every comparison returned `0` and in-memory sorting by author was a no-op. The field now sorts by author id through the `integer` type, matching the order the REST API returns for `orderby=author` ([#82559](https://github.com/WordPress/gutenberg/pull/82559)).
 -   Hide the slug field for posts without a permalink, such as posts of non-public post types, matching the classic post URL panel ([#82341](https://github.com/WordPress/gutenberg/pull/82341)).
 -   Normalize special characters in exported pattern filenames to prevent broken or unreadable files. ([#77033](https://github.com/WordPress/gutenberg/pull/77033))

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug Fixes
 
--   `MediaEdit`: Show a message instead of the picker when the user lacks permission to upload media. ([#](https://github.com/WordPress/gutenberg/pull/))
+-   `MediaEdit`: Show a message instead of the picker when the user lacks permission to upload media. ([#82720](https://github.com/WordPress/gutenberg/pull/82720))
 -   `author`: Drop the custom `sort` callback, which read `_embedded.author` from the arguments although `Field.sort` receives the field values (the author ids), so every comparison returned `0` and in-memory sorting by author was a no-op. The field now sorts by author id through the `integer` type, matching the order the REST API returns for `orderby=author` ([#82559](https://github.com/WordPress/gutenberg/pull/82559)).
 -   Hide the slug field for posts without a permalink, such as posts of non-public post types, matching the classic post URL panel ([#82341](https://github.com/WordPress/gutenberg/pull/82341)).
 -   Normalize special characters in exported pattern filenames to prevent broken or unreadable files. ([#77033](https://github.com/WordPress/gutenberg/pull/77033))

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -76,7 +76,7 @@
 		"remove-accents": "^0.5.0"
 	},
 	"devDependencies": {
-		"@testing-library/react": "^16.3.2",
+		"@testing-library/react": "^16.3.3",
 		"vitest": "^5.0.0"
 	},
 	"peerDependencies": {

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -76,6 +76,7 @@
 		"remove-accents": "^0.5.0"
 	},
 	"devDependencies": {
+		"@testing-library/react": "^16.3.2",
 		"vitest": "^5.0.0"
 	},
 	"peerDependencies": {

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -865,28 +865,18 @@ export default function MediaEdit< Item >( {
 		},
 		[ isTouched ]
 	);
-	const legend =
-		field.label &&
-		( hideLabelFromVision ? (
-			<VisuallyHidden render={ <legend /> }>
-				{ field.label }
-			</VisuallyHidden>
-		) : (
-			<BaseControl.VisualLabel as="legend" style={ { marginBottom: 0 } }>
-				{ field.label }
-			</BaseControl.VisualLabel>
-		) );
 	if ( ! canUpload ) {
 		return (
 			<fieldset className="fields__media-edit" data-field-id={ field.id }>
-				<VStack spacing={ 2 }>
-					{ legend }
-					<WCText variant="muted">
-						{ __(
-							'To edit this field, you need permission to upload media.'
-						) }
-					</WCText>
-				</VStack>
+				<WCText>
+					{ sprintf(
+						/* translators: %s: The field label. */
+						__(
+							'%s: To edit this field, you need permission to upload media.'
+						),
+						field.label
+					) }
+				</WCText>
 			</fieldset>
 		);
 	}
@@ -950,7 +940,19 @@ export default function MediaEdit< Item >( {
 							: CompactMediaEditAttachments;
 						return (
 							<VStack spacing={ 2 }>
-								{ legend }
+								{ field.label &&
+									( hideLabelFromVision ? (
+										<VisuallyHidden render={ <legend /> }>
+											{ field.label }
+										</VisuallyHidden>
+									) : (
+										<BaseControl.VisualLabel
+											as="legend"
+											style={ { marginBottom: 0 } }
+										>
+											{ field.label }
+										</BaseControl.VisualLabel>
+									) ) }
 								<AttachmentsComponent
 									allItems={ allItems }
 									addButtonLabel={ addButtonLabel }

--- a/packages/fields/src/components/media-edit/index.tsx
+++ b/packages/fields/src/components/media-edit/index.tsx
@@ -600,6 +600,15 @@ export default function MediaEdit< Item >( {
 	validity,
 }: MediaEditProps< Item > ) {
 	const value = field.getValue( { item: data } );
+	// While the permission is unresolved, show the picker, as the editor does.
+	const canUpload = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'attachment',
+			} ) ?? true,
+		[]
+	);
 	const [ isTouched, setIsTouched ] = useState( false );
 	const validityTargetRef = useRef< HTMLInputElement >( null );
 	const [ customValidity, setCustomValidity ] = useState<
@@ -856,6 +865,31 @@ export default function MediaEdit< Item >( {
 		},
 		[ isTouched ]
 	);
+	const legend =
+		field.label &&
+		( hideLabelFromVision ? (
+			<VisuallyHidden render={ <legend /> }>
+				{ field.label }
+			</VisuallyHidden>
+		) : (
+			<BaseControl.VisualLabel as="legend" style={ { marginBottom: 0 } }>
+				{ field.label }
+			</BaseControl.VisualLabel>
+		) );
+	if ( ! canUpload ) {
+		return (
+			<fieldset className="fields__media-edit" data-field-id={ field.id }>
+				<VStack spacing={ 2 }>
+					{ legend }
+					<WCText variant="muted">
+						{ __(
+							'To edit this field, you need permission to upload media.'
+						) }
+					</WCText>
+				</VStack>
+			</fieldset>
+		);
+	}
 	return (
 		<Stack direction="column" gap="sm" onBlur={ onBlur }>
 			<fieldset className="fields__media-edit" data-field-id={ field.id }>
@@ -916,19 +950,7 @@ export default function MediaEdit< Item >( {
 							: CompactMediaEditAttachments;
 						return (
 							<VStack spacing={ 2 }>
-								{ field.label &&
-									( hideLabelFromVision ? (
-										<VisuallyHidden render={ <legend /> }>
-											{ field.label }
-										</VisuallyHidden>
-									) : (
-										<BaseControl.VisualLabel
-											as="legend"
-											style={ { marginBottom: 0 } }
-										>
-											{ field.label }
-										</BaseControl.VisualLabel>
-									) ) }
+								{ legend }
 								<AttachmentsComponent
 									allItems={ allItems }
 									addButtonLabel={ addButtonLabel }

--- a/packages/fields/src/components/media-edit/test/index.jsdom.test.tsx
+++ b/packages/fields/src/components/media-edit/test/index.jsdom.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+	createReduxStore,
+	createRegistry,
+	RegistryProvider,
+} from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import MediaEdit from '../index';
+
+globalThis.wpVitest.mockMatchMedia();
+globalThis.wpVitest.mockResizeObserver();
+
+const field = {
+	id: 'featured_media',
+	type: 'media',
+	label: 'Featured Image',
+	placeholder: 'Set featured image',
+	getValue: ( { item }: { item: { featured_media?: number } } ) =>
+		item.featured_media,
+	setValue: ( { value }: { value?: number } ) => ( {
+		featured_media: value ?? 0,
+	} ),
+} as any;
+
+// The component reads the upload permission and the attachments from the
+// `core` store; a stand-in avoids the resolvers' requests.
+function createTestRegistry( { canUpload = true } = {} ) {
+	const registry = createRegistry();
+	registry.register(
+		createReduxStore( 'core', {
+			reducer: ( state = {} ) => state,
+			selectors: {
+				canUser: () => canUpload,
+				getEntityRecords: () => null,
+			},
+			actions: {
+				receiveEntityRecords: () => ( {
+					type: 'RECEIVE_ENTITY_RECORDS',
+				} ),
+			},
+		} )
+	);
+	registry.register( noticesStore );
+	return registry;
+}
+
+describe( 'MediaEdit', () => {
+	it( 'shows a message instead of the picker without upload permission', () => {
+		render(
+			<RegistryProvider
+				value={ createTestRegistry( { canUpload: false } ) }
+			>
+				<MediaEdit
+					data={ { featured_media: 0 } }
+					field={ field }
+					onChange={ () => {} }
+				/>
+			</RegistryProvider>
+		);
+		expect( screen.getByText( 'Featured Image' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'To edit this field, you need permission to upload media.'
+			)
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Set featured image' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/fields/src/components/media-edit/test/index.jsdom.test.tsx
+++ b/packages/fields/src/components/media-edit/test/index.jsdom.test.tsx
@@ -58,10 +58,9 @@ describe( 'MediaEdit', () => {
 				/>
 			</RegistryProvider>
 		);
-		expect( screen.getByText( 'Featured Image' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText(
-				'To edit this field, you need permission to upload media.'
+				'Featured Image: To edit this field, you need permission to upload media.'
 			)
 		).toBeInTheDocument();
 		expect(


### PR DESCRIPTION
## What?


The classic featured image panel shows a message instead of the picker when the user can't upload media(`MediaUploadCheck`), but `MediaEdit` shows the picker regardless. This adds the same check to `MediaEdit`, using `canUser` for creating attachments, and shows a message in place of the picker. The copy is generic because the component is also for other media fields.

## Testing Instructions
1. Enable the `Editor Inspector: Use DataForm` experiment.
2. Log in as a contributor and create a new post.
3. Instead of the featured image picker, the summary should show a message about needing permission to upload media, like the classic panel does.
4. As an admin everything should work as before.



#### `Editor Inspector: Use DataForm` experiment
| Disabled  | Enabled |
| ------ | ----- |
|<img width="279" height="172" alt="Screenshot 2026-09-10 at 1 09 32 PM" src="https://github.com/user-attachments/assets/740a7e16-2f0c-47b4-a0d1-e141a5757128" />|<img width="279" height="189" alt="Screenshot 2026-09-10 at 1 07 58 PM" src="https://github.com/user-attachments/assets/01fd5c33-a268-4b0d-b7c2-e99b04609178" />|

## Use of AI Tools
Fable 5.1 with direction, changes and review.
