### PR TITLE
CI: Move required trunk baseline after latest npm releases

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -589,3 +589,14 @@ jobs:
                   npm exec --no release-cli -- npm-latest --semver minor --ci --repository-path ../publish
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    move-required-trunk-baseline:
+        name: Move required trunk baseline
+        needs: npm-publish
+        permissions:
+            contents: write
+            statuses: write
+            pull-requests: read
+        uses: ./.github/workflows/required-changes-from-trunk.yml
+        with:
+            mode: move-baseline

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -125,3 +125,15 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   WP_VERSION: ${{ github.event.inputs.wp_version }}
+
+    move-required-trunk-baseline:
+        name: Move required trunk baseline
+        needs: release
+        if: github.repository == 'WordPress/gutenberg' && github.event.inputs.release_type == 'latest'
+        permissions:
+            contents: write
+            statuses: write
+            pull-requests: read
+        uses: ./.github/workflows/required-changes-from-trunk.yml
+        with:
+            mode: move-baseline

--- a/.github/workflows/required-changes-from-trunk.yml
+++ b/.github/workflows/required-changes-from-trunk.yml
@@ -1,6 +1,11 @@
 name: Required changes from trunk
 
 on:
+    workflow_call:
+        inputs:
+            mode:
+                required: true
+                type: string
     pull_request_target:
         types: [opened, synchronize, reopened, ready_for_review, edited, closed]
         branches: [trunk]
@@ -20,7 +25,7 @@ permissions: {}
 
 env:
     # One source of truth for both jobs. No markers: the baseline moves only
-    # through a labeled merge or a dispatch, never because a path changed.
+    # after a latest package release, a labeled merge, or a dispatch.
     PR_BASELINES: '[{"name":"required-trunk-changes","label":"Require PR update"}]'
     STATUS_CONTEXT: Required changes from trunk
     DESCRIPTION_PASS: Includes required {base} changes.
@@ -54,15 +59,15 @@ jobs:
 
     refresh-pr-statuses:
         name: Move the required trunk baseline and refresh statuses
-        # The baseline moves only through explicit intent: a merged pull request
-        # carrying the label, or a dispatch with mode move-baseline. Every trunk
-        # push recovers a move whose own run was lost, and continues a refresh
-        # that stopped on its write budget.
+        # The baseline moves only through explicit intent: a latest package
+        # release, a merged pull request carrying the label, or a dispatch with
+        # mode move-baseline. Every trunk push recovers a move whose own run was
+        # lost, and continues a refresh that stopped on its write budget.
         if: >
             github.repository == 'WordPress/gutenberg' && (
                 (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged) ||
                 (github.event_name == 'push' && github.ref_name == 'trunk') ||
-                github.event_name == 'workflow_dispatch'
+                inputs.mode != ''
             )
         runs-on: ubuntu-latest
         timeout-minutes: 60

--- a/docs/contributors/code/release/package-release-and-core-updates.md
+++ b/docs/contributors/code/release/package-release-and-core-updates.md
@@ -22,6 +22,8 @@ We deliberately update the `wp/latest` branch within the Gutenberg repo with the
 
 Behind the scenes, all steps are automated via `npm exec --no release-cli -- npm-latest`. For the record, the manual process would look very close to the following steps:
 
+After a successful `latest` release updates `trunk`, the workflow also moves the required-trunk baseline to the current `trunk` commit. Open pull requests must then merge or rebase `trunk` before they can be merged. This automation initially excludes standalone bugfix package releases to limit disruption. Maintainers can still dispatch the Required changes from trunk workflow with `mode: move-baseline` when a bugfix release needs it.
+
 1. Ensure the WordPress `trunk` branch is open for enhancements.
 2. Get the last published Gutenberg release branch with `git fetch`.
 3. Check out the `wp/latest` branch.

--- a/docs/contributors/code/required-changes-from-trunk.md
+++ b/docs/contributors/code/required-changes-from-trunk.md
@@ -1,13 +1,14 @@
 # Required changes from trunk
 
-The `Required changes from trunk` status check ensures open pull requests contain the latest required repo-wide infrastructure changes from `trunk` (toolchain bumps like a Node.js upgrade, or repo-wide formatting and linting changes) before they can be merged. This prevents a pull request based on an older commit from passing CI against an outdated toolchain or reintroducing old-style code.
+The `Required changes from trunk` status check ensures open pull requests contain changes that must not be overwritten, such as published package metadata, toolchain updates, or repo-wide formatting changes, before they can be merged. This prevents a pull request based on an older commit from restoring stale release data or passing CI against outdated repository conventions.
 
 ## How it works
 
 A movable git ref, `refs/baselines/required-trunk-changes`, points at the last `trunk` commit that every open pull request must contain. The check passes when that commit is an ancestor of the pull request head, and fails otherwise. While the ref does not exist, nothing is required and every pull request passes.
 
-The baseline moves only through explicit maintainer intent, in one of two ways:
+The baseline moves only through explicit release or maintainer intent, in one of three ways:
 
+-   Completing a `latest` npm package release,
 -   Merging a pull request that carries the `Require PR update` label, or
 -   Dispatching the `Required changes from trunk` workflow with `mode: move-baseline`.
 


### PR DESCRIPTION
Follow-up to #82709 and #82725.

## What?

Move the required-trunk baseline after a successful `latest` npm package release updates `trunk`.

## Why?

These releases backport package versions, changelogs, and the lockfile to `trunk`. An older pull request can otherwise restore stale release metadata, as #82709 demonstrated.

## How?

Call the existing Required changes from trunk workflow after both automatic RC1 publishing and manual `latest` publishing. The two release paths share the same baseline action, permissions, concurrency, and recovery behavior.

Standalone bugfix releases are excluded from the automatic policy for now to limit forced-update friction. Maintainers can still move the baseline manually when a bugfix release needs it.

## Testing Instructions

1. Confirm the GitHub Actions workflow lint checks pass.
2. Confirm both successful `npm-latest` paths call the Required changes from trunk workflow with `mode: move-baseline`.
3. Confirm `bugfix`, `development`, and WordPress-version releases do not move the baseline automatically.

### Testing Instructions for Keyboard

Not applicable. This PR does not change the UI.

## Use of AI Tools

Codex was used to investigate, implement, and verify this change.
