### PR TITLE
Command Palette: only add the admin bar node when Core does not provide it

### DIFF
--- a/lib/compat/wordpress-7.0/command-palette.php
+++ b/lib/compat/wordpress-7.0/command-palette.php
@@ -57,10 +57,6 @@ function gutenberg_admin_bar_command_palette_menu( WP_Admin_Bar $wp_admin_bar ):
 		)
 	);
 }
-if ( has_action( 'admin_bar_menu', 'wp_admin_bar_command_palette_menu' ) ) {
-	remove_action( 'admin_bar_menu', 'wp_admin_bar_command_palette_menu', 55 );
-}
-add_action( 'admin_bar_menu', 'gutenberg_admin_bar_command_palette_menu', 55 );
 
 function gutenberg_add_admin_bar_styles() {
 	if ( ! is_admin_bar_showing() ) {
@@ -99,4 +95,8 @@ function gutenberg_add_admin_bar_styles() {
 CSS;
 	wp_add_inline_style( 'admin-bar', $css );
 }
-add_action( 'admin_bar_init', 'gutenberg_add_admin_bar_styles' );
+
+if ( ! function_exists( 'wp_admin_bar_command_palette_menu' ) ) {
+	add_action( 'admin_bar_menu', 'gutenberg_admin_bar_command_palette_menu', 55 );
+	add_action( 'admin_bar_init', 'gutenberg_add_admin_bar_styles' );
+}


### PR DESCRIPTION
This is extracted out from https://github.com/WordPress/gutenberg/pull/79451.

## What

This PR fixes the logic of command palette node registration in 7.0 compat. Before, it registers the node and enqueues the styles unconditionally, causing doubled Dashicon & SVG icon issue in the linked PR (https://github.com/WordPress/gutenberg/pull/79451/changes#r3970437640).

Now, we move the hooks inside an `if ( ! function_exists( 'wp_admin_bar_command_palette_menu' ) )` guard, which is skipped when Core already supports command palette (7.0+).

## Testing instructions

Test the GB PR with various versions. We can use the following Playground links. For each one, verify the command palette is still working:

- https://playground.wordpress.net/?wp=6.9&gutenberg-pr=82733
- https://playground.wordpress.net/?wp=7.0&gutenberg-pr=82733
- https://playground.wordpress.net/?wp=7.1&gutenberg-pr=82733