### PR TITLE
Env: Preserve complete lifecycle script error output

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Wait for lifecycle script output streams to close before reporting command failures, so their error output is not lost ([#82735](https://github.com/WordPress/gutenberg/pull/82735)).
+
 ## 11.15.0 (2026-09-10)
 
 ### Bug Fixes

--- a/packages/env/lib/execute-lifecycle-script.js
+++ b/packages/env/lib/execute-lifecycle-script.js
@@ -61,7 +61,7 @@ function executeLifecycleScript( event, config, spinner ) {
 		childProc.on( 'error', reject );
 
 		// Handle the completion of the command based on whether it was successful or not.
-		childProc.on( 'exit', ( code ) => {
+		childProc.on( 'close', ( code ) => {
 			if ( code === 0 ) {
 				// Keep the output of the command in debug mode.
 				if ( config.debug ) {

--- a/packages/env/lib/test/execute-lifecycle-script.js
+++ b/packages/env/lib/test/execute-lifecycle-script.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { createRequire } from 'node:module';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 const require = createRequire( import.meta.url );
@@ -51,6 +52,47 @@ describe( 'executeLifecycleScript', () => {
 		} catch ( error ) {
 			expect( error ).toBeInstanceOf( LifecycleScriptError );
 			expect( error.message ).toMatch( /test Error:\n.*bad option/ );
+		}
+	} );
+
+	it( 'includes all stderr when the process fails', async () => {
+		const childProcess = new EventEmitter();
+		childProcess.stdout = new EventEmitter();
+		childProcess.stderr = new EventEmitter();
+
+		const childProcessModule = require( 'node:child_process' );
+		const exec = vi
+			.spyOn( childProcessModule, 'exec' )
+			.mockReturnValue( childProcess );
+		const modulePath = require.resolve( '../execute-lifecycle-script' );
+		delete require.cache[ modulePath ];
+		const {
+			LifecycleScriptError: MockedLifecycleScriptError,
+			executeLifecycleScript: executeLifecycleScriptWithMock,
+		} = require( modulePath );
+
+		try {
+			const execution = executeLifecycleScriptWithMock(
+				'test',
+				{ lifecycleScripts: { test: 'failing-command' } },
+				spinner
+			);
+
+			childProcess.stderr.emit( 'data', 'first line\n' );
+			childProcess.emit( 'exit', 1 );
+			childProcess.stderr.emit( 'data', 'last line\n' );
+			childProcess.emit( 'close', 1 );
+
+			await expect( execution ).rejects.toMatchObject( {
+				event: 'test',
+				message: 'test Error:\nfirst line\nlast line',
+			} );
+			await expect( execution ).rejects.toBeInstanceOf(
+				MockedLifecycleScriptError
+			);
+		} finally {
+			exec.mockRestore();
+			delete require.cache[ modulePath ];
 		}
 	} );
 } );


### PR DESCRIPTION
Extracted from #80995.

## What?

Makes `wp-env` wait for all lifecycle script output before reporting success or failure.

## Why?

Node can emit a child process's `exit` event before its stdout and stderr streams close. `wp-env` could therefore create `LifecycleScriptError` before collecting the useful end of a failing command's stderr.

## How?

Listens for the child process's `close` event instead of `exit`. A controlled child-process test double emits `exit`, more stderr, and then `close` in a fixed order.

The package exports, dependencies, and entrypoints do not change, so the four-version package compatibility matrix is not applicable.

## Testing Instructions

1. Run `npm run test:unit:vitest -- packages/env/lib/test/execute-lifecycle-script.js`.
2. Confirm all four tests pass, including `includes all stderr when the process fails`.

### Testing Instructions for Keyboard

Not applicable. This change does not affect the UI.

## Use of AI Tools

This PR was implemented with OpenAI Codex. I reviewed the diff and verification results.
