### PR TITLE
DOM: Find focusable image map areas

### DIFF
--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `focusable.find`: Return linked image-map areas when their mapped image is visible and outside an inert subtree ([#82736](https://github.com/WordPress/gutenberg/pull/82736)).
+
 ## 4.55.0 (2026-09-10)
 
 ### Bug Fixes

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -117,16 +117,17 @@ export function find( context, { sequential = false } = {} ) {
 	const elements = context.querySelectorAll( buildSelector( sequential ) );
 
 	return Array.from( elements ).filter( ( element ) => {
-		// Elements inside an inert subtree are not focusable.
-		if ( element.closest( '[inert]' ) ) {
-			return false;
-		}
-
 		const { nodeName } = element;
 		if ( 'AREA' === nodeName ) {
+			// The mapped image determines whether this region is visible or inert.
 			return isValidFocusableArea(
 				/** @type {HTMLAreaElement} */ ( element )
 			);
+		}
+
+		// Elements inside an inert subtree are not focusable.
+		if ( element.closest( '[inert]' ) ) {
+			return false;
 		}
 
 		return isVisible( element );

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -95,7 +95,7 @@ function isValidFocusableArea( element ) {
 	const img = element.ownerDocument.querySelector(
 		'img[usemap="#' + map.name + '"]'
 	);
-	return !! img && isVisible( img );
+	return !! img && ! img.closest( '[inert]' ) && isVisible( img );
 }
 
 /**
@@ -117,10 +117,6 @@ export function find( context, { sequential = false } = {} ) {
 	const elements = context.querySelectorAll( buildSelector( sequential ) );
 
 	return Array.from( elements ).filter( ( element ) => {
-		if ( ! isVisible( element ) ) {
-			return false;
-		}
-
 		// Elements inside an inert subtree are not focusable.
 		if ( element.closest( '[inert]' ) ) {
 			return false;
@@ -133,6 +129,6 @@ export function find( context, { sequential = false } = {} ) {
 			);
 		}
 
-		return true;
+		return isVisible( element );
 	} );
 }

--- a/packages/dom/src/test/focusable-area.jsdom.test.js
+++ b/packages/dom/src/test/focusable-area.jsdom.test.js
@@ -1,16 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { find } from '../focusable';
 
-function createElementWithLayout( type ) {
-	const element = document.createElement( type );
-	const sizeIfVisible = () => ( element.style.display === 'none' ? 0 : 10 );
+function createImageWithLayout() {
+	const image = document.createElement( 'img' );
 
-	Object.defineProperties( element, {
-		offsetHeight: { get: sizeIfVisible },
-		offsetWidth: { get: sizeIfVisible },
+	Object.defineProperties( image, {
+		offsetHeight: { value: 10 },
+		offsetWidth: { value: 10 },
 	} );
 
-	return element;
+	return image;
 }
 
 describe( 'focusable.find() image map areas', () => {
@@ -18,29 +17,26 @@ describe( 'focusable.find() image map areas', () => {
 		document.body.innerHTML = '';
 	} );
 
-	it( 'finds a mapped area with a visible image', () => {
-		const map = createElementWithLayout( 'map' );
+	it( 'finds an area in a named map referenced by an image', () => {
+		const map = document.createElement( 'map' );
 		map.name = 'testfocus';
-		const area = createElementWithLayout( 'area' );
+		const area = document.createElement( 'area' );
 		area.href = '';
 		map.appendChild( area );
-		const image = createElementWithLayout( 'img' );
+		const image = createImageWithLayout();
 		image.setAttribute( 'usemap', '#testfocus' );
 		document.body.append( map, image );
 
 		expect( find( map ) ).toEqual( [ area ] );
 	} );
 
-	it( 'ignores a mapped area with a hidden image', () => {
-		const map = createElementWithLayout( 'map' );
+	it( 'ignores an area when no image references its map', () => {
+		const map = document.createElement( 'map' );
 		map.name = 'testfocus';
-		const area = createElementWithLayout( 'area' );
+		const area = document.createElement( 'area' );
 		area.href = '';
 		map.appendChild( area );
-		const image = createElementWithLayout( 'img' );
-		image.setAttribute( 'usemap', '#testfocus' );
-		image.style.display = 'none';
-		document.body.append( map, image );
+		document.body.append( map );
 
 		expect( find( map ) ).toEqual( [] );
 	} );

--- a/packages/dom/src/test/focusable.browser.test.js
+++ b/packages/dom/src/test/focusable.browser.test.js
@@ -140,6 +140,54 @@ describe( 'focusable', () => {
 			expect( findFocusable( node ) ).toEqual( [ link ] );
 		} );
 
+		it( 'finds a mapped area whose referenced image is visible', () => {
+			const node = createElement( 'div' );
+			node.innerHTML = `
+				<map name="testfocus">
+					<area href="#target" shape="rect" coords="0,0,30,30" alt="Target">
+				</map>
+				<img usemap="#testfocus" width="40" height="40" alt="">
+			`;
+			const area = node.querySelector( 'area' );
+			const image = node.querySelector( 'img' );
+
+			document.body.appendChild( node );
+
+			expect( area.getClientRects() ).toHaveLength( 0 );
+			expect( image.getClientRects().length ).toBeGreaterThan( 0 );
+			expect( find( node ) ).toEqual( [ area ] );
+		} );
+
+		it( 'ignores a mapped area whose referenced image is hidden', () => {
+			const node = createElement( 'div' );
+			node.innerHTML = `
+				<map name="testfocus">
+					<area href="#target" shape="rect" coords="0,0,30,30" alt="Target">
+				</map>
+				<img usemap="#testfocus" width="40" height="40" alt="" style="visibility: hidden">
+			`;
+			const image = node.querySelector( 'img' );
+
+			document.body.appendChild( node );
+
+			expect( image.getClientRects().length ).toBeGreaterThan( 0 );
+			expect( find( node ) ).toEqual( [] );
+		} );
+
+		it( 'ignores a mapped area whose referenced image is inside an inert subtree', () => {
+			const node = createElement( 'div' );
+			node.innerHTML = `
+				<map name="testfocus">
+					<area href="#target" shape="rect" coords="0,0,30,30" alt="Target">
+				</map>
+				<div inert>
+					<img usemap="#testfocus" width="40" height="40" alt="">
+				</div>
+			`;
+
+			expect( findFocusable( node ) ).toEqual( [] );
+		} );
+
 		it( 'finds contenteditable', () => {
 			const node = createElement( 'div' );
 			const div = createElement( 'div' );

--- a/packages/dom/src/test/focusable.browser.test.js
+++ b/packages/dom/src/test/focusable.browser.test.js
@@ -83,6 +83,8 @@ describe( 'focusable.find() CSS visibility', () => {
 } );
 
 const createElement = ( type ) => document.createElement( type );
+const IMAGE_SOURCE =
+	'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 function findFocusable( context ) {
 	if ( ! context.isConnected ) {
@@ -140,21 +142,24 @@ describe( 'focusable', () => {
 			expect( findFocusable( node ) ).toEqual( [ link ] );
 		} );
 
-		it( 'finds a mapped area whose referenced image is visible', () => {
+		it( 'finds a mapped area whose referenced image is visible', async () => {
 			const node = createElement( 'div' );
 			node.innerHTML = `
 				<map name="testfocus">
 					<area href="#target" shape="rect" coords="0,0,30,30" alt="Target">
 				</map>
-				<img usemap="#testfocus" width="40" height="40" alt="">
+				<img src="${ IMAGE_SOURCE }" usemap="#testfocus" width="40" height="40" alt="">
 			`;
 			const area = node.querySelector( 'area' );
 			const image = node.querySelector( 'img' );
 
 			document.body.appendChild( node );
+			await image.decode();
 
 			expect( area.getClientRects() ).toHaveLength( 0 );
 			expect( image.getClientRects().length ).toBeGreaterThan( 0 );
+			area.focus();
+			expect( area ).toHaveFocus();
 			expect( find( node ) ).toEqual( [ area ] );
 		} );
 
@@ -164,7 +169,7 @@ describe( 'focusable', () => {
 				<map name="testfocus">
 					<area href="#target" shape="rect" coords="0,0,30,30" alt="Target">
 				</map>
-				<img usemap="#testfocus" width="40" height="40" alt="" style="visibility: hidden">
+				<img src="${ IMAGE_SOURCE }" usemap="#testfocus" width="40" height="40" alt="" style="visibility: hidden">
 			`;
 			const image = node.querySelector( 'img' );
 
@@ -181,11 +186,32 @@ describe( 'focusable', () => {
 					<area href="#target" shape="rect" coords="0,0,30,30" alt="Target">
 				</map>
 				<div inert>
-					<img usemap="#testfocus" width="40" height="40" alt="">
+					<img src="${ IMAGE_SOURCE }" usemap="#testfocus" width="40" height="40" alt="">
 				</div>
 			`;
 
 			expect( findFocusable( node ) ).toEqual( [] );
+		} );
+
+		it( "finds a mapped area whose referenced image is outside the map's inert subtree", async () => {
+			const node = createElement( 'div' );
+			node.innerHTML = `
+				<div inert>
+					<map name="testfocus">
+						<area href="#target" shape="rect" coords="0,0,30,30" alt="Target">
+					</map>
+				</div>
+				<img src="${ IMAGE_SOURCE }" usemap="#testfocus" width="40" height="40" alt="">
+			`;
+			const area = node.querySelector( 'area' );
+			const image = node.querySelector( 'img' );
+
+			document.body.appendChild( node );
+			await image.decode();
+
+			area.focus();
+			expect( area ).toHaveFocus();
+			expect( find( node ) ).toEqual( [ area ] );
 		} );
 
 		it( 'finds contenteditable', () => {


### PR DESCRIPTION
Extracted from #80995.

## What?

Fix `focusable.find()` so it returns a linked image map area when a mapped image makes that area focusable.

## Why?

An `<area>` has no layout box. Its mapped image determines whether the area's focusable region is rendered and inert, so applying those checks to the `<area>` rejects valid results.

## How?

Route image map areas through their existing image-specific validation before applying the generic visibility and inert checks. The mapped image must still be visible and outside an inert subtree. Other elements keep the same checks.

Browser Mode uses a decodable image to prove that the area can receive focus even though it has no client rects. It also covers hidden and inert mapped images, plus a visible image mapped to an area inside an inert subtree. The jsdom tests retain map-association coverage.

This changes behavior only. It does not change the public API or dependencies, so the four-version package compatibility matrix is not applicable.

## Testing Instructions

1. Run `npm run test:unit:vitest -- packages/dom/src/test`.
2. Confirm all DOM tests pass, including the image map cases in Chromium.

### Testing Instructions for Keyboard

No separate manual test is needed. Browser Mode verifies that the valid mapped area receives focus and that hidden or inert mapped images do not produce focusable results.

## Use of AI Tools

Codex helped investigate the bug, implement the fix, review the changes, and run verification. The author reviewed the resulting changes.
