### PR TITLE
Test: Make browser tests independent of execution order

### DIFF
--- a/packages/components/src/composite/legacy/test/index.browser.test.tsx
+++ b/packages/components/src/composite/legacy/test/index.browser.test.tsx
@@ -1,13 +1,39 @@
-import { describe, expect, it, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { queryByAttribute, screen, waitFor } from '@testing-library/react';
 import { render, renderHook } from 'vitest-browser-react';
+import { logged } from '@wordpress/deprecated';
 import {
 	Composite,
 	CompositeGroup,
 	CompositeItem,
 	useCompositeState,
 } from '..';
+
+const DEPRECATION_MESSAGES = {
+	useCompositeState:
+		'wp.components.__unstableUseCompositeState is deprecated since version 6.7. Please use Composite instead.',
+	Composite:
+		'wp.components.__unstableComposite is deprecated since version 6.7. Please use Composite instead.',
+	CompositeItem:
+		'wp.components.__unstableCompositeItem is deprecated since version 6.7. Please use Composite.Item instead.',
+	CompositeGroup:
+		'wp.components.__unstableCompositeGroup is deprecated since version 6.7. Please use Composite.Group or Composite.Row instead.',
+};
+
+// Interaction cases start with their known deprecations already logged.
+// Each warning case clears only its own message before rendering.
+beforeEach( () => {
+	for ( const message of Object.values( DEPRECATION_MESSAGES ) ) {
+		logged[ message ] = true;
+	}
+} );
+
+afterEach( () => {
+	for ( const message of Object.values( DEPRECATION_MESSAGES ) ) {
+		delete logged[ message ];
+	}
+} );
 
 type InitialState = Parameters< typeof useCompositeState >[ 0 ];
 type CompositeState = ReturnType< typeof useCompositeState >;
@@ -128,26 +154,25 @@ function getShiftTestItems() {
 	};
 }
 
-// Checking for deprecation warnings before other tests because the `deprecated`
-// utility only fires a console.warn the first time a component is rendered.
 describe( 'Shows a deprecation warning', () => {
 	it( 'useCompositeState', async () => {
+		delete logged[ DEPRECATION_MESSAGES.useCompositeState ];
 		await renderHook( () => useCompositeState() );
 		expect( console ).toHaveWarnedWith(
-			'wp.components.__unstableUseCompositeState is deprecated since version 6.7. Please use Composite instead.'
+			DEPRECATION_MESSAGES.useCompositeState
 		);
 	} );
 	it( 'Composite', async () => {
+		delete logged[ DEPRECATION_MESSAGES.Composite ];
 		const Test = () => {
 			const props = useCompositeState();
 			return <Composite { ...props } />;
 		};
 		await render( <Test /> );
-		expect( console ).toHaveWarnedWith(
-			'wp.components.__unstableComposite is deprecated since version 6.7. Please use Composite instead.'
-		);
+		expect( console ).toHaveWarnedWith( DEPRECATION_MESSAGES.Composite );
 	} );
 	it( 'CompositeItem', async () => {
+		delete logged[ DEPRECATION_MESSAGES.CompositeItem ];
 		const Test = () => {
 			const props = useCompositeState();
 			return (
@@ -158,10 +183,11 @@ describe( 'Shows a deprecation warning', () => {
 		};
 		await render( <Test /> );
 		expect( console ).toHaveWarnedWith(
-			'wp.components.__unstableCompositeItem is deprecated since version 6.7. Please use Composite.Item instead.'
+			DEPRECATION_MESSAGES.CompositeItem
 		);
 	} );
 	it( 'CompositeGroup', async () => {
+		delete logged[ DEPRECATION_MESSAGES.CompositeGroup ];
 		const Test = () => {
 			const props = useCompositeState();
 			return (
@@ -174,7 +200,7 @@ describe( 'Shows a deprecation warning', () => {
 		};
 		await render( <Test /> );
 		expect( console ).toHaveWarnedWith(
-			'wp.components.__unstableCompositeGroup is deprecated since version 6.7. Please use Composite.Group or Composite.Row instead.'
+			DEPRECATION_MESSAGES.CompositeGroup
 		);
 	} );
 } );

--- a/packages/components/src/popover/test/index.browser.test.tsx
+++ b/packages/components/src/popover/test/index.browser.test.tsx
@@ -10,6 +10,7 @@ import {
 	placementToMotionAnimationProps,
 } from '../utils';
 import Popover from '..';
+import { Provider as SlotFillProvider } from '../../slot-fill';
 import type { PopoverProps } from '../types';
 import { PopoverInsideIframeRenderedInExternalSlot } from './utils/index.js';
 
@@ -266,23 +267,59 @@ describe( 'Popover', () => {
 			const setup = async (
 				props?: Partial< React.ComponentProps< typeof Popover > >
 			) => {
-				const user = await userEvent.setup();
+				const user = userEvent.setup();
+				function Test() {
+					const [ isOpen, setIsOpen ] = useState( false );
+					return (
+						<>
+							<button onClick={ () => setIsOpen( true ) }>
+								Before popover
+							</button>
+							<Popover.Slot />
+							{ isOpen && (
+								<Popover
+									data-testid="popover-element"
+									{ ...props }
+								>
+									<button>Button 1</button>
+									<button>Button 2</button>
+									<button>Button 3</button>
+								</Popover>
+							) }
+							<button>After popover</button>
+						</>
+					);
+				}
 				const view = await render(
-					<Popover data-testid="popover-element" { ...props }>
-						<button>Button 1</button>
-						<button>Button 2</button>
-						<button>Button 3</button>
-					</Popover>
+					<SlotFillProvider>
+						<Test />
+					</SlotFillProvider>
 				);
+				const beforeButton = screen.getByRole( 'button', {
+					name: 'Before popover',
+				} );
+				const afterButton = screen.getByRole( 'button', {
+					name: 'After popover',
+				} );
+				await user.click( beforeButton );
 
 				const popover = screen.getByTestId( 'popover-element' );
 				await waitFor( () => expect( popover ).toBeVisible() );
 
-				const [ firstButton, secondButton, thirdButton ] =
-					screen.getAllByRole( 'button' );
+				const firstButton = screen.getByRole( 'button', {
+					name: 'Button 1',
+				} );
+				const secondButton = screen.getByRole( 'button', {
+					name: 'Button 2',
+				} );
+				const thirdButton = screen.getByRole( 'button', {
+					name: 'Button 3',
+				} );
 
 				return {
 					...view,
+					beforeButton,
+					afterButton,
 					popover,
 					firstButton,
 					secondButton,
@@ -351,7 +388,7 @@ describe( 'Popover', () => {
 				test( 'when `focusOnMount` is false if `constrainTabbing` is true', async () => {
 					const {
 						user,
-						baseElement,
+						beforeButton,
 						firstButton,
 						secondButton,
 						thirdButton,
@@ -360,7 +397,7 @@ describe( 'Popover', () => {
 						constrainTabbing: true,
 					} );
 
-					expect( baseElement ).toHaveFocus();
+					expect( beforeButton ).toHaveFocus();
 					await user.tab();
 					expect( firstButton ).toHaveFocus();
 					await user.tab();
@@ -382,7 +419,8 @@ describe( 'Popover', () => {
 
 					const {
 						user,
-						baseElement,
+						beforeButton,
+						afterButton,
 						firstButton,
 						secondButton,
 						thirdButton,
@@ -394,23 +432,28 @@ describe( 'Popover', () => {
 					await user.tab();
 					expect( thirdButton ).toHaveFocus();
 					await user.tab();
-					expect( baseElement ).toHaveFocus();
-					await user.tab();
+					expect( afterButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( thirdButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( secondButton ).toHaveFocus();
+					await user.tab( { shift: true } );
 					expect( firstButton ).toHaveFocus();
 					await user.tab( { shift: true } );
-					expect( baseElement ).toHaveFocus();
+					expect( beforeButton ).toHaveFocus();
 				} );
 
 				test( 'when `focusOnMount` is false', async () => {
 					const {
 						user,
-						baseElement,
+						beforeButton,
+						afterButton,
 						firstButton,
 						secondButton,
 						thirdButton,
 					} = await setup( { focusOnMount: false } );
 
-					expect( baseElement ).toHaveFocus();
+					expect( beforeButton ).toHaveFocus();
 					await user.tab();
 					expect( firstButton ).toHaveFocus();
 					await user.tab();
@@ -418,17 +461,22 @@ describe( 'Popover', () => {
 					await user.tab();
 					expect( thirdButton ).toHaveFocus();
 					await user.tab();
-					expect( baseElement ).toHaveFocus();
-					await user.tab();
+					expect( afterButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( thirdButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( secondButton ).toHaveFocus();
+					await user.tab( { shift: true } );
 					expect( firstButton ).toHaveFocus();
 					await user.tab( { shift: true } );
-					expect( baseElement ).toHaveFocus();
+					expect( beforeButton ).toHaveFocus();
 				} );
 
 				test( 'when `focusOnMount` is true if `constrainTabbing` is false', async () => {
 					const {
 						user,
-						baseElement,
+						beforeButton,
+						afterButton,
 						popover,
 						firstButton,
 						secondButton,
@@ -446,17 +494,22 @@ describe( 'Popover', () => {
 					await user.tab();
 					expect( thirdButton ).toHaveFocus();
 					await user.tab();
-					expect( baseElement ).toHaveFocus();
-					await user.tab();
+					expect( afterButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( thirdButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( secondButton ).toHaveFocus();
+					await user.tab( { shift: true } );
 					expect( firstButton ).toHaveFocus();
 					await user.tab( { shift: true } );
-					expect( baseElement ).toHaveFocus();
+					expect( beforeButton ).toHaveFocus();
 				} );
 
 				test( 'when `focusOnMount` is "firstElement" if `constrainTabbing` is false', async () => {
 					const {
 						user,
-						baseElement,
+						beforeButton,
+						afterButton,
 						firstButton,
 						secondButton,
 						thirdButton,
@@ -471,11 +524,15 @@ describe( 'Popover', () => {
 					await user.tab();
 					expect( thirdButton ).toHaveFocus();
 					await user.tab();
-					expect( baseElement ).toHaveFocus();
-					await user.tab();
+					expect( afterButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( thirdButton ).toHaveFocus();
+					await user.tab( { shift: true } );
+					expect( secondButton ).toHaveFocus();
+					await user.tab( { shift: true } );
 					expect( firstButton ).toHaveFocus();
 					await user.tab( { shift: true } );
-					expect( baseElement ).toHaveFocus();
+					expect( beforeButton ).toHaveFocus();
 				} );
 			} );
 		} );

--- a/packages/theme/src/test/theme-provider.browser.test.tsx
+++ b/packages/theme/src/test/theme-provider.browser.test.tsx
@@ -312,22 +312,41 @@ describe( 'ThemeProvider', () => {
 				.spyOn( console, 'warn' )
 				.mockImplementation( () => {} );
 
-			await render(
-				<>
-					<ThemeProvider isRoot color={ { primary: PRIMARY } }>
-						<div>a</div>
-					</ThemeProvider>
-					<ThemeProvider isRoot color={ { primary: OTHER_PRIMARY } }>
-						<div>b</div>
-					</ThemeProvider>
-				</>
-			);
+			// Competing root providers intentionally conflict. Keep their document
+			// separate so their cleanup order cannot change later tests' tokens.
+			const iframe = document.createElement( 'iframe' );
+			document.body.appendChild( iframe );
+			const iframeDoc = iframe.contentDocument!;
+			const container = iframeDoc.createElement( 'div' );
+			iframeDoc.body.appendChild( container );
+			let unmount:
+				| Awaited< ReturnType< typeof render > >[ 'unmount' ]
+				| undefined;
 
-			expect( warn ).toHaveBeenCalledWith(
-				expect.stringContaining( 'More than one root provider' )
-			);
+			try {
+				( { unmount } = await render(
+					<>
+						<ThemeProvider isRoot color={ { primary: PRIMARY } }>
+							<div>a</div>
+						</ThemeProvider>
+						<ThemeProvider
+							isRoot
+							color={ { primary: OTHER_PRIMARY } }
+						>
+							<div>b</div>
+						</ThemeProvider>
+					</>,
+					{ container }
+				) );
 
-			warn.mockRestore();
+				expect( warn ).toHaveBeenCalledWith(
+					expect.stringContaining( 'More than one root provider' )
+				);
+			} finally {
+				await unmount?.();
+				iframe.remove();
+				warn.mockRestore();
+			}
 		} );
 
 		it( 'does not warn for a single root provider', async () => {


### PR DESCRIPTION
See #80855. Follow-up to #82742, based directly on trunk.

## What?

Make the ThemeProvider, legacy Composite, and Popover browser tests independent of test order.

## Why?

Shuffling individual tests reproduces eight failures on trunk. The suites share root styles or deprecation state between cases, or assume Tab will return from outside the test iframe.

## How?

- Render the intentionally conflicting root ThemeProviders in a disposable iframe.
- Reset the four known Composite deprecation messages per test, preserving their warning assertions.
- Open Popover from a button and test Tab and Shift+Tab against controls on both sides of its slot.

## Testing Instructions

Run the affected suites with shuffled files and test cases:

```sh
npm run test:unit:vitest -- --project=browser --sequence.shuffle --sequence.seed=80857 \
  packages/theme/src/test/theme-provider.browser.test.tsx \
  packages/components/src/composite/legacy/test/index.browser.test.tsx \
  packages/components/src/popover/test/index.browser.test.tsx
```

All 157 tests should pass, including the existing warning, root-style cleanup, and keyboard assertions.

<details>
<summary>Additional verification</summary>

The full browser suite passed with the same file and test-case shuffle: 1,281 tests across 90 files. The earlier Tooltip timing and Cropper detached-frame failures did not reproduce on trunk in these runs, so those suites remain unchanged.

</details>

## Use of AI Tools

Codex investigated the failures, authored the test changes, ran verification, and performed an independent review.
