### PR TITLE
core/embed: service provider/sources fallback, fix #20105

### DIFF
--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -38,6 +38,14 @@
 			"type": "boolean",
 			"default": true,
 			"role": "content"
+		},
+		"fallbacks": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "string"
+			},
+			"role": "content"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/embed/edit.jsx
+++ b/packages/block-library/src/embed/edit.jsx
@@ -31,6 +31,7 @@ const EmbedEdit = ( props ) => {
 			previewable,
 			responsive,
 			url: attributesUrl,
+			fallbacks,
 		},
 		attributes,
 		isSelected,
@@ -264,6 +265,10 @@ const EmbedEdit = ( props ) => {
 				allowResponsive={ allowResponsive }
 				toggleResponsive={ toggleResponsive }
 				switchBackToURLInput={ () => setIsEditingURL( true ) }
+				fallbacks={ fallbacks }
+				setFallbacks={ ( value ) =>
+					setAttributes( { fallbacks: value } )
+				}
 			/>
 			<figure
 				{ ...blockProps }

--- a/packages/block-library/src/embed/embed-controls.jsx
+++ b/packages/block-library/src/embed/embed-controls.jsx
@@ -6,9 +6,63 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { TextareaControl } from '@wordpress/ui';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 import { pencil } from '@wordpress/icons';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
+/**
+ * Reads the fallback URLs out of the field: one per line, ignoring blank lines
+ * and surrounding whitespace.
+ *
+ * @param {string} text Field contents.
+ *
+ * @return {string[]} Fallback URLs.
+ */
+function parseFallbacks( text ) {
+	return text
+		.split( '\n' )
+		.map( ( line ) => line.trim() )
+		.filter( Boolean );
+}
+
+/**
+ * A line-per-URL field for the block's alternative sources.
+ *
+ * @param {Object}   props
+ * @param {string[]} props.fallbacks    Fallback URLs stored on the block.
+ * @param {Function} props.setFallbacks Stores a new list of fallback URLs.
+ */
+function FallbackURLsControl( { fallbacks, setFallbacks } ) {
+	// The field keeps the text as typed. Deriving it from the stored list on
+	// every keystroke would drop the blank line the moment Enter is pressed,
+	// leaving no way to type a second URL.
+	const [ text, setText ] = useState( () => fallbacks.join( '\n' ) );
+	const [ storedFallbacks, setStoredFallbacks ] = useState( fallbacks );
+
+	// Adopt the stored list when it changes elsewhere, such as on undo.
+	if ( storedFallbacks !== fallbacks ) {
+		setStoredFallbacks( fallbacks );
+		if ( parseFallbacks( text ).join( '\n' ) !== fallbacks.join( '\n' ) ) {
+			setText( fallbacks.join( '\n' ) );
+		}
+	}
+
+	return (
+		<TextareaControl
+			label={ __( 'Fallback URLs' ) }
+			description={ __(
+				'Alternative URLs for the same content, one per line. They are saved with the block so a front end can try them in order if the embed above cannot be played.'
+			) }
+			value={ text }
+			onValueChange={ ( value ) => {
+				setText( value );
+				setFallbacks( parseFallbacks( value ) );
+			} }
+		/>
+	);
+}
 
 function getResponsiveHelp( checked ) {
 	return checked
@@ -27,6 +81,8 @@ const EmbedControls = ( {
 	allowResponsive,
 	toggleResponsive,
 	switchBackToURLInput,
+	fallbacks,
+	setFallbacks,
 } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -71,6 +127,12 @@ const EmbedControls = ( {
 					</ToolsPanel>
 				</InspectorControls>
 			) }
+			<InspectorControls group="advanced">
+				<FallbackURLsControl
+					fallbacks={ fallbacks }
+					setFallbacks={ setFallbacks }
+				/>
+			</InspectorControls>
 		</>
 	);
 };

--- a/packages/block-library/src/embed/save.jsx
+++ b/packages/block-library/src/embed/save.jsx
@@ -6,7 +6,7 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { url, caption, type, providerNameSlug } = attributes;
+	const { url, caption, type, providerNameSlug, fallbacks } = attributes;
 
 	if ( ! url ) {
 		return null;
@@ -18,8 +18,14 @@ export default function save( { attributes } ) {
 		[ `wp-block-embed-${ providerNameSlug }` ]: providerNameSlug,
 	} );
 
+	// Only emitted when fallbacks are set, so blocks without them save exactly
+	// as before and no deprecation is needed.
+	const fallbackProps = fallbacks?.length
+		? { 'data-fallbacks': fallbacks.join( ' ' ) }
+		: {};
+
 	return (
-		<figure { ...useBlockProps.save( { className } ) }>
+		<figure { ...useBlockProps.save( { className, ...fallbackProps } ) }>
 			<div className="wp-block-embed__wrapper">
 				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
 			</div>

--- a/packages/block-library/src/embed/test/embed-controls.jsdom.test.js
+++ b/packages/block-library/src/embed/test/embed-controls.jsdom.test.js
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { createElement, useState } from '@wordpress/element';
+import EmbedControls from '../embed-controls';
+
+vi.mock( '@wordpress/block-editor', async () => {
+	const { createElement: mockCreateElement } = await import(
+		'@wordpress/element'
+	);
+
+	return {
+		store: {},
+		BlockControls: ( { children } ) =>
+			mockCreateElement( 'div', null, children ),
+		// The real component is a slot fill, so it renders nothing without a
+		// block editor around it. Render the fill in place and record which
+		// inspector group it was filled into.
+		InspectorControls: ( { group, children } ) =>
+			mockCreateElement(
+				'div',
+				{ 'data-testid': `inspector-controls-${ group ?? 'default' }` },
+				children
+			),
+	};
+} );
+
+const VIMEO_URL = 'https://vimeo.com/668136661';
+const PEERTUBE_URL = 'https://tube.example/w/abc123';
+
+const controlsProps = ( fallbacks, setFallbacks ) => ( {
+	showEditButton: false,
+	themeSupportsResponsive: false,
+	blockSupportsResponsive: false,
+	allowResponsive: true,
+	toggleResponsive: () => {},
+	switchBackToURLInput: () => {},
+	fallbacks,
+	setFallbacks,
+} );
+
+/**
+ * Renders the controls the way the block does: the list is owned by the block
+ * attributes, so every keystroke round-trips through `setFallbacks`.
+ *
+ * @param {Object}   props
+ * @param {string[]} [props.initialFallbacks] Fallback URLs the block starts with.
+ * @param {Function} [props.onChange]         Called with each stored list.
+ */
+function ControlledEmbedControls( { initialFallbacks = [], onChange } ) {
+	const [ fallbacks, setFallbacks ] = useState( initialFallbacks );
+
+	return createElement(
+		EmbedControls,
+		controlsProps( fallbacks, ( value ) => {
+			onChange?.( value );
+			setFallbacks( value );
+		} )
+	);
+}
+
+const renderControls = ( props ) =>
+	render( createElement( ControlledEmbedControls, props ) );
+
+const getFallbacksField = () =>
+	screen.getByRole( 'textbox', { name: 'Fallback URLs' } );
+
+describe( 'core/embed fallback URLs control', () => {
+	it( 'lives in the Advanced panel', () => {
+		renderControls();
+
+		expect(
+			within(
+				screen.getByTestId( 'inspector-controls-advanced' )
+			).getByRole( 'textbox', { name: 'Fallback URLs' } )
+		).toBeVisible();
+	} );
+
+	it( 'shows the stored fallback URLs one per line', () => {
+		renderControls( { initialFallbacks: [ VIMEO_URL, PEERTUBE_URL ] } );
+
+		expect( getFallbacksField() ).toHaveValue(
+			`${ VIMEO_URL }\n${ PEERTUBE_URL }`
+		);
+	} );
+
+	it( 'is empty when the block has no fallback URL', () => {
+		renderControls();
+
+		expect( getFallbacksField() ).toHaveValue( '' );
+	} );
+
+	it( 'stores a single typed URL', async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+		renderControls( { onChange } );
+
+		await user.type( getFallbacksField(), VIMEO_URL );
+
+		expect( onChange ).toHaveBeenLastCalledWith( [ VIMEO_URL ] );
+	} );
+
+	it( 'stores a second URL typed on a new line', async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+		renderControls( {
+			initialFallbacks: [ VIMEO_URL ],
+			onChange,
+		} );
+
+		const field = getFallbacksField();
+		await user.click( field );
+		await user.keyboard( `{End}{Enter}${ PEERTUBE_URL }` );
+
+		expect( field ).toHaveValue( `${ VIMEO_URL }\n${ PEERTUBE_URL }` );
+		expect( onChange ).toHaveBeenLastCalledWith( [
+			VIMEO_URL,
+			PEERTUBE_URL,
+		] );
+	} );
+
+	it( 'ignores blank lines and surrounding whitespace', async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+		renderControls( { onChange } );
+
+		await user.click( getFallbacksField() );
+		await user.keyboard(
+			`  ${ VIMEO_URL }  {Enter}{Enter}\t${ PEERTUBE_URL }`
+		);
+
+		expect( onChange ).toHaveBeenLastCalledWith( [
+			VIMEO_URL,
+			PEERTUBE_URL,
+		] );
+	} );
+
+	it( 'shows the stored list again when it changes elsewhere, such as on undo', () => {
+		const { rerender } = render(
+			createElement(
+				EmbedControls,
+				controlsProps( [ VIMEO_URL, PEERTUBE_URL ], () => {} )
+			)
+		);
+
+		rerender(
+			createElement(
+				EmbedControls,
+				controlsProps( [ VIMEO_URL ], () => {} )
+			)
+		);
+
+		expect( getFallbacksField() ).toHaveValue( VIMEO_URL );
+	} );
+
+	it( 'stores an empty list when the field is cleared', async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+		renderControls( {
+			initialFallbacks: [ VIMEO_URL ],
+			onChange,
+		} );
+
+		await user.clear( getFallbacksField() );
+
+		expect( onChange ).toHaveBeenLastCalledWith( [] );
+		expect( getFallbacksField() ).toHaveValue( '' );
+	} );
+} );

--- a/packages/block-library/src/embed/test/save.jsdom.test.js
+++ b/packages/block-library/src/embed/test/save.jsdom.test.js
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	createBlock,
+	getBlockAttributesNamesByRole,
+	parse,
+	registerBlockType,
+	serialize,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import metadata from '../block.json';
+import deprecated from '../deprecated';
+import save from '../save';
+
+const { name } = metadata;
+
+const VIDEO_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+const MIRROR_URL = 'https://vimeo.com/668136661';
+const SECOND_MIRROR_URL = 'https://tube.example/w/abc123';
+
+const videoAttributes = {
+	url: VIDEO_URL,
+	type: 'video',
+	providerNameSlug: 'youtube',
+};
+
+// The markup an embed block has always saved, before fallback URLs existed.
+const SAVED_WITHOUT_FALLBACKS = [
+	`<!-- wp:embed {"url":"${ VIDEO_URL }","type":"video","providerNameSlug":"youtube"} -->`,
+	'<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube"><div class="wp-block-embed__wrapper">',
+	VIDEO_URL,
+	'</div></figure>',
+	'<!-- /wp:embed -->',
+].join( '\n' );
+
+describe( 'core/embed fallback URLs', () => {
+	beforeAll( () => {
+		registerBlockType( { name, ...metadata }, { save, deprecated } );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( name );
+	} );
+
+	describe( 'saved markup', () => {
+		it( 'saves the markup unchanged when no fallback URL is set', () => {
+			const block = createBlock( name, videoAttributes );
+
+			// An embed without fallbacks must save byte-identically to how it
+			// saved before the attribute existed, so nothing is invalidated.
+			expect( serialize( block ) ).toBe( SAVED_WITHOUT_FALLBACKS );
+		} );
+
+		it( 'saves the fallback URLs on the wrapper, separated by spaces', () => {
+			const block = createBlock( name, {
+				...videoAttributes,
+				fallbacks: [ MIRROR_URL, SECOND_MIRROR_URL ],
+			} );
+
+			expect( serialize( block ) ).toBe(
+				[
+					`<!-- wp:embed {"url":"${ VIDEO_URL }","type":"video","providerNameSlug":"youtube","fallbacks":["${ MIRROR_URL }","${ SECOND_MIRROR_URL }"]} -->`,
+					`<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube" data-fallbacks="${ MIRROR_URL } ${ SECOND_MIRROR_URL }"><div class="wp-block-embed__wrapper">`,
+					VIDEO_URL,
+					'</div></figure>',
+					'<!-- /wp:embed -->',
+				].join( '\n' )
+			);
+		} );
+
+		it( 'keeps a fallback URL that contains a comma intact', () => {
+			// Commas are legitimate in URLs (YouTube playlist parameters, for
+			// one), which is why the saved list is separated by spaces.
+			const playlistURL =
+				'https://www.youtube.com/watch_videos?video_ids=dQw4w9WgXcQ,5YDT4RLPIgA';
+			const block = createBlock( name, {
+				...videoAttributes,
+				fallbacks: [ playlistURL, MIRROR_URL ],
+			} );
+
+			expect( serialize( block ) ).toContain(
+				`data-fallbacks="${ playlistURL } ${ MIRROR_URL }"`
+			);
+		} );
+
+		it( 'saves no markup at all when the block has no URL', () => {
+			const block = createBlock( name, {
+				fallbacks: [ MIRROR_URL ],
+			} );
+
+			expect( serialize( block ) ).toBe(
+				`<!-- wp:embed {"fallbacks":["${ MIRROR_URL }"]} /-->`
+			);
+		} );
+	} );
+
+	describe( 'parsing', () => {
+		it( 'still validates embeds saved before fallback URLs existed', () => {
+			const [ block ] = parse( SAVED_WITHOUT_FALLBACKS );
+
+			expect( block.isValid ).toBe( true );
+			expect( block.attributes.fallbacks ).toEqual( [] );
+		} );
+
+		it( 'validates and restores an embed saved with fallback URLs', () => {
+			const [ block ] = parse(
+				serialize(
+					createBlock( name, {
+						...videoAttributes,
+						fallbacks: [ MIRROR_URL, SECOND_MIRROR_URL ],
+					} )
+				)
+			);
+
+			expect( block.isValid ).toBe( true );
+			expect( block.attributes.fallbacks ).toEqual( [
+				MIRROR_URL,
+				SECOND_MIRROR_URL,
+			] );
+		} );
+	} );
+
+	describe( 'attribute definition', () => {
+		it( 'defaults to an empty list', () => {
+			expect( createBlock( name, videoAttributes ).attributes ).toEqual(
+				expect.objectContaining( { fallbacks: [] } )
+			);
+		} );
+
+		it( 'is content, so content-only editing and pattern overrides reach it', () => {
+			expect(
+				getBlockAttributesNamesByRole( name, 'content' )
+			).toContain( 'fallbacks' );
+		} );
+	} );
+} );


### PR DESCRIPTION
## What?
Closes #20105

**core/embed** support for multiple alternative sources

## Why?
There are multiple ways a service like Youtube could fail, video block should support multiple source URLs

## How?
Adds one attribute, one Advanced-panel control, and one conditional save prop, fix #20105

## Testing Instructions
- Add a video block
- In the side panel, the "Alternate video sources" allow to provide multiple URLs

### Testing Instructions for Keyboard
Traditional `<tab>`-accessible controls. `<enter>` validate/add a new URL.

## Screenshots

|Before|After|
|-|-|
| <img width="284" height="333" alt="Screenshot from 2026-09-10 20-24-44" src="https://github.com/user-attachments/assets/250b0cd9-8d8f-46fb-b44d-c2e97cd26111" />| <img width="282" height="682" alt="Screenshot from 2026-09-10 20-26-58" src="https://github.com/user-attachments/assets/512a343d-f900-4d54-afb5-b90e142ce49b" />|

## Details

| File | Change |
| --- | --- |
| `block.json` | `fallbacks`: `array` of `string`, default `[]` |
| `embed-controls.jsx` | a `TextareaControl` in `InspectorControls group="advanced"`, one URL per line |
| `edit.jsx` | passes the attribute and its setter through |
| `save.jsx` | emits `data-fallbacks="url1 url2"` **only when the list is non-empty** |

## What it purposefully does **NOT**

* **No detection.** Core does not decide whether an embed is playable. That requires per-provider APIs, and it is where all the complexity and all the maintenance burden lives. Detection belongs to whoever needs it.
* **No fallback behaviour.** Core does not switch sources, retry, or ship any front-end script. Nothing changes at runtime for anyone who does not opt in.
* **No provider list, no validation, no URL parsing.** The field takes URLs and stores them.
* **No new panel.** It reuses the existing Advanced group.

The patch is therefore a *data model and a UI for it*, nothing more. It makes the feature expressible in core's markup so it can be implemented above core, which is the smallest change that unblocks the issue.

`data-fallbacks` is emitted only when `fallbacks` is non-empty. Every existing embed block has an empty default, so its saved output stays byte-identical and no block is invalidated. That is the reason the attribute is written to the wrapper element conditionally rather than always.

**Why a saved attribute rather than an editor-only one.** Attributes without a `source` live in the block comment delimiter and never reach the front end. A front-end consumer therefore cannot see them, which defeats the purpose. The `data-` attribute is the minimum needed to make the list observable where it matters.

**Why space-separated, not comma-separated.** The issue suggested commas. URLs may legitimately contain commas — YouTube playlist parameters, for example — but never unescaped spaces, so a space-separated `data-` attribute is unambiguous. The editor UI is still line-per-URL, which is what an author actually wants to edit.

**Why `role: "content"`.** The list is editorial content — the same video from another source — not presentation, so it should be treated as content by block-level tooling such as content-only editing and pattern overrides.

**Audio block?"** The same three-line shape would apply unchanged to `core/audio` and to any block with a single external source.
Nothing here is embed-specific except where it is attached. Starting with `core/embed` keeps the review small; extending it later costs an attribute and a control per block.

## Use of AI Tools

Opus 5
