### PR TITLE
Project Management: Exclude private APIs config from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,3 +72,4 @@
 # so these stay at the end. Removing them brings back the review requests.
 /tools/eslint/suppressions.json
 /tools/stylelint/stylelint-suppressions.json
+/tools/validation/check-private-apis.config.json


### PR DESCRIPTION
## What?

Follow up to #82538. Adds `tools/validation/check-private-apis.config.json` to the `Exclusions` section at the end of `.github/CODEOWNERS`.

## Why?

Like the lint suppression lists, this file changes as a side effect of unrelated work: a package that gains or drops transitive private API usage has to update its exceptions (e.g. #82499). Without an exclusion, `/tools` sends a review request for every such change.

## How?

Adds the path, without an owner, to the existing `Exclusions` section, where last match wins lets it override `/tools`.

## Testing Instructions

1. Open a PR that touches `tools/validation/check-private-apis.config.json`.
2. Confirm no review is requested for it.

## Use of AI Tools

Claude Code, to add the entry and draft this description. Reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
