### PR TITLE
Cover Block: Add a Media section to the block inspector panel

### DIFF
--- a/packages/block-library/src/cover/edit/index.jsx
+++ b/packages/block-library/src/cover/edit/index.jsx
@@ -703,6 +703,8 @@ function CoverEdit( {
 			setOverlayColor={ onSetOverlayColor }
 			coverRef={ ref }
 			currentSettings={ currentSettings }
+			onSelectMedia={ onSelectMedia }
+			onUploadError={ onUploadError }
 			toggleUseFeaturedImage={ toggleUseFeaturedImage }
 			updateDimRatio={ onUpdateDimRatio }
 			onClearMedia={ onClearMedia }

--- a/packages/block-library/src/cover/edit/inspector-controls.jsx
+++ b/packages/block-library/src/cover/edit/inspector-controls.jsx
@@ -23,8 +23,13 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { getFilename } from '@wordpress/url';
 import { Link } from '@wordpress/ui';
-import { COVER_MIN_HEIGHT, mediaPosition } from '../shared';
+import {
+	ALLOWED_MEDIA_TYPES,
+	COVER_MIN_HEIGHT,
+	mediaPosition,
+} from '../shared';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import {
@@ -35,6 +40,7 @@ import {
 } from '../../utils/style-state';
 import { DEFAULT_MEDIA_SIZE_SLUG } from '../constants';
 import PosterImage from '../../utils/poster-image';
+import { MediaControl } from '../../utils/media-control';
 
 const {
 	cleanEmptyObject,
@@ -98,7 +104,11 @@ export default function CoverInspectorControls( {
 	setOverlayColor,
 	coverRef,
 	currentSettings,
+	onSelectMedia,
+	onUploadError,
+	toggleUseFeaturedImage,
 	updateDimRatio,
+	onClearMedia,
 	featuredImage,
 } ) {
 	const {
@@ -138,6 +148,24 @@ export default function CoverInspectorControls( {
 		},
 		[ clientId ]
 	);
+	/*
+	 * The block only resolves the featured image record, so the record of a
+	 * media selection of its own is resolved here to name it in the panel.
+	 */
+	const selectedMedia = useSelect(
+		( select ) =>
+			id && ! useFeaturedImage
+				? select( coreStore ).getEntityRecord(
+						'postType',
+						'attachment',
+						id,
+						{ context: 'view' }
+				  )
+				: undefined,
+		[ id, useFeaturedImage ]
+	);
+	const mediaRecord = useFeaturedImage ? featuredImage : selectedMedia;
+
 	const hasSelectedStyleState =
 		! isDefaultBlockStyleState( selectedStyleState );
 	const selectedStyleStateKey = getStyleStateKey( selectedStyleState );
@@ -277,8 +305,49 @@ export default function CoverInspectorControls( {
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
+	/*
+	 * Rendered whether or not media has been set, so that a cover in its setup
+	 * state can be given media from the inspector as well as from the toolbar.
+	 * The settings below stay behind their own condition, having nothing to
+	 * configure until there is media to configure.
+	 */
+	const mediaInspectorPanel = (
+		<InspectorControls group="content">
+			<ToolsPanel
+				label={ __( 'Media' ) }
+				resetAll={ onClearMedia }
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				<ToolsPanelItem
+					label={ __( 'Media' ) }
+					hasValue={ () => !! url || !! useFeaturedImage }
+					onDeselect={ onClearMedia }
+					isShownByDefault
+				>
+					<MediaControl
+						mediaId={ id }
+						mediaUrl={ url }
+						filename={
+							mediaRecord?.media_details?.sizes?.full?.file ||
+							mediaRecord?.slug ||
+							getFilename( url )
+						}
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						onSelect={ onSelectMedia }
+						onError={ onUploadError }
+						onReset={ onClearMedia }
+						useFeaturedImage={ useFeaturedImage }
+						onToggleFeaturedImage={ toggleUseFeaturedImage }
+						emptyLabel={ __( 'Add media' ) }
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
+		</InspectorControls>
+	);
+
 	return (
 		<>
+			{ mediaInspectorPanel }
 			{ ( !! url || useFeaturedImage ) && (
 				<InspectorControls>
 					<ToolsPanel

--- a/packages/block-library/src/utils/media-control.jsx
+++ b/packages/block-library/src/utils/media-control.jsx
@@ -76,16 +76,18 @@ export function MediaControlPreview( {
  * MediaControl - Complete media selection control for inspector panels
  *
  * @param {Object}   props
- * @param {number}   props.mediaId      Media attachment ID
- * @param {string}   props.mediaUrl     Media URL
- * @param {string}   props.filename     Filename to display
- * @param {Array}    props.allowedTypes Allowed media types
- * @param {Function} props.onSelect     Callback when media selected
- * @param {Function} props.onSelectURL  Callback when URL entered
- * @param {Function} props.onError      Error callback
- * @param {Function} props.onReset      Reset/remove callback
- * @param {boolean}  props.isUploading  Whether upload in progress
- * @param {string}   props.emptyLabel   Label when no media (default: 'Add media')
+ * @param {number}   props.mediaId               Media attachment ID
+ * @param {string}   props.mediaUrl              Media URL
+ * @param {string}   props.filename              Filename to display
+ * @param {Array}    props.allowedTypes          Allowed media types
+ * @param {Function} props.onSelect              Callback when media selected
+ * @param {Function} props.onSelectURL           Callback when URL entered
+ * @param {Function} props.onError               Error callback
+ * @param {Function} props.onReset               Reset/remove callback
+ * @param {boolean}  props.isUploading           Whether upload in progress
+ * @param {string}   props.emptyLabel            Label when no media (default: 'Add media')
+ * @param {boolean}  props.useFeaturedImage      Whether the featured image is in use
+ * @param {Function} props.onToggleFeaturedImage Callback toggling the featured image
  * @return {Element} Media control component
  */
 export function MediaControl( {
@@ -99,6 +101,8 @@ export function MediaControl( {
 	onReset,
 	isUploading = false,
 	emptyLabel = __( 'Media' ),
+	useFeaturedImage,
+	onToggleFeaturedImage,
 } ) {
 	const { getSettings } = useSelect( blockEditorStore );
 	const onFilesDrop = ( filesList ) => {
@@ -131,6 +135,8 @@ export function MediaControl( {
 				onSelect={ onSelect }
 				onSelectURL={ onSelectURL }
 				onError={ onError }
+				useFeaturedImage={ useFeaturedImage }
+				onToggleFeaturedImage={ onToggleFeaturedImage }
 				name={
 					<MediaControlPreview
 						url={ mediaUrl }


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/66563

Adds a Media section to the Cover block inspector.

## Why?
- Cover offers media only from the toolbar today.
- Its settings appear only once media is set, so a new Cover shows nothing in the sidebar.
- Image, Site Logo and Media & Text already have this section.

## How?
- Reuses the same media control those blocks use.
- Always shown, so an empty Cover can be given media from the sidebar.
- Goes through the same path as the toolbar, so the result is identical either way.

> The shared media control gains the featured image option, which also appears in #82593.

## Testing Instructions
1. Insert a **Cover** block and select it without adding media.
2. The inspector shows a **Media** section with **Add media**.
3. Add an image or video — the canvas updates and the filename appears.
4. Confirm it matches adding the same media from the toolbar.
5. Try **Use featured image** and **Reset**.

### Testing Instructions for Keyboard
Open the sidebar with `Ctrl+Shift+,`, tab to the Media section, and confirm it selects and resets media using the keyboard only.

## Screenshots or screencast


https://github.com/user-attachments/assets/a50954ef-d125-4709-8bc2-5ebc4b2ca497



## Use of AI Tools
Claude Code
