### PR TITLE
Unit Tests: Resolve @ariakit/utils through its dependents

### DIFF
--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -38,13 +38,21 @@ const dependenciesToTransform = [
 process.env.TZ = 'UTC';
 
 /*
- * Resolved rather than hardcoded to `<rootDir>/node_modules`,
- * which is empty under non-hoisting installs.
+ * Resolved hop by hop through its dependents rather than hardcoded to
+ * `<rootDir>/node_modules`, which is empty under non-hoisting installs.
  */
-const ariakitUtilsDir = path.dirname(
-	require.resolve( '@ariakit/utils/package.json', {
-		paths: [ path.join( ROOT_DIR, 'packages/components' ) ],
-	} )
+const ariakitUtilsDir = [
+	'@ariakit/react',
+	'@ariakit/react-components',
+	'@ariakit/utils',
+].reduce(
+	( fromDir, packageName ) =>
+		path.dirname(
+			require.resolve( `${ packageName }/package.json`, {
+				paths: [ fromDir ],
+			} )
+		),
+	path.join( ROOT_DIR, 'packages/components' )
 );
 
 const commonProjectConfig = {


### PR DESCRIPTION
## What?
Follow up to #80995

Resolves `@ariakit/utils` in the Jest config through its dependents so it works under non-hoisting installs.

## Why?
#80995 dropped `@ariakit/test`, which `@ariakit/utils` used to be resolved through, and now resolves it directly from `packages/components`. That only works when dependencies are hoisted, since `@ariakit/utils` is two hops away (`@ariakit/react` → `@ariakit/react-components` → `@ariakit/utils`). Caught by the isolated dependencies PR #75814, where `npm run test:unit:routing` fails with `Cannot find module '@ariakit/utils/package.json'` ([failed run](https://github.com/WordPress/gutenberg/actions/runs/34572155497/job/103176394856?pr=75814)).

## How?
Walks the dependency chain one package at a time in [`test/unit/jest.config.js`](https://github.com/WordPress/gutenberg/blob/fix/jest-config-ariakit-utils-resolution/test/unit/jest.config.js#L40-L56). The mapping itself stays, as `@ariakit/utils` only exports an `import` condition.

## Testing Instructions
1. `npm run test:unit:routing` passes.
2. `npm run test:unit` passes.
3. Optionally, on #75814 with this cherry-picked, both pass under `install-strategy=linked`.

## Use of AI Tools
Claude Code diagnosed the failure and wrote the fix, reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
