### PR TITLE
Interface: Fix the ActionItem click handler and selector types

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -530,7 +530,7 @@ export function useEnableFloatingSidebar( enabled = false ) {
 			if (
 				getActiveComplementaryArea( 'core' ) === FLOATING_NOTES_SIDEBAR
 			) {
-				disableComplementaryArea( 'core', FLOATING_NOTES_SIDEBAR );
+				disableComplementaryArea( 'core' );
 			}
 		};
 	}, [ enabled, registry ] );

--- a/packages/interface/src/components/action-item/types.ts
+++ b/packages/interface/src/components/action-item/types.ts
@@ -1,4 +1,4 @@
-import type { ElementType, ReactNode } from 'react';
+import type { ElementType, MouseEventHandler, ReactNode } from 'react';
 
 export type ActionItemFillProps = {
 	/**
@@ -8,7 +8,7 @@ export type ActionItemFillProps = {
 	/**
 	 * A handler run on every item, in addition to the item's own `onClick`.
 	 */
-	onClick?: ( ...args: unknown[] ) => void;
+	onClick?: MouseEventHandler< HTMLElement >;
 };
 
 export type ActionItemSlotProps = {
@@ -54,7 +54,7 @@ export type ActionItemProps = {
 	 * Callback function executed when a click on the item happens. The slot's
 	 * `fillProps.onClick` runs as well, if set.
 	 */
-	onClick?: ( ...args: unknown[] ) => void;
+	onClick?: MouseEventHandler< HTMLElement >;
 	/**
 	 * The props not referred above are passed to the item component.
 	 */

--- a/packages/interface/src/store/selectors.ts
+++ b/packages/interface/src/store/selectors.ts
@@ -42,7 +42,7 @@ export const getActiveComplementaryArea = createRegistrySelector(
 export const isComplementaryAreaLoading = createRegistrySelector(
 	( select ) => ( state: StoreState, scope: string ) => {
 		scope = normalizeComplementaryAreaScope( scope );
-		const isVisible = select( preferencesStore ).get(
+		const isVisible: boolean | undefined = select( preferencesStore ).get(
 			scope,
 			'isComplementaryAreaVisible'
 		);
@@ -65,10 +65,9 @@ export const isItemPinned = createRegistrySelector(
 	( select ) => ( state: StoreState, scope: string, item: string ) => {
 		scope = normalizeComplementaryAreaScope( scope );
 		item = normalizeComplementaryAreaName( scope, item );
-		const pinnedItems = select( preferencesStore ).get(
-			scope,
-			'pinnedItems'
-		);
+		const pinnedItems: Record< string, boolean > | undefined = select(
+			preferencesStore
+		).get( scope, 'pinnedItems' );
 		return pinnedItems?.[ item ] ?? true;
 	}
 );

--- a/packages/interface/src/test/types.ts
+++ b/packages/interface/src/test/types.ts
@@ -1,0 +1,47 @@
+import type { ComponentProps, MouseEvent } from 'react';
+import type { CurriedSelectorsOf } from '@wordpress/data';
+import { describe, it } from 'vitest';
+import type { ActionItem, store } from '..';
+
+/**
+ * Resolves to `true` only when `A` and `B` are mutually assignable, so a
+ * widened type such as `any` fails `true satisfies Expect< A, B >`.
+ */
+type Expect< A, B > = 0 extends 1 & A
+	? never
+	: [ A ] extends [ B ]
+	? [ B ] extends [ A ]
+		? true
+		: never
+	: never;
+
+type Selectors = CurriedSelectorsOf< typeof store >;
+type ActionItemOnClick = ComponentProps< typeof ActionItem >[ 'onClick' ];
+type FillPropsOnClick = NonNullable<
+	ComponentProps< typeof ActionItem.Slot >[ 'fillProps' ]
+>[ 'onClick' ];
+
+describe( 'Interface types', () => {
+	// eslint-disable-next-line jest/expect-expect -- compile-time assertions only.
+	it( 'types the selector return values', () => {
+		true satisfies Expect<
+			ReturnType< Selectors[ 'isComplementaryAreaLoading' ] >,
+			boolean | undefined
+		>;
+		true satisfies Expect<
+			ReturnType< Selectors[ 'isItemPinned' ] >,
+			boolean
+		>;
+	} );
+
+	// eslint-disable-next-line jest/expect-expect -- compile-time assertions only.
+	it( 'accepts typed and inline click handlers', () => {
+		const onButtonClick = ( event: MouseEvent< HTMLButtonElement > ) =>
+			event.currentTarget;
+
+		onButtonClick satisfies ActionItemOnClick;
+		onButtonClick satisfies FillPropsOnClick;
+		( ( event ) => event.currentTarget ) satisfies ActionItemOnClick;
+		( ( event ) => event.currentTarget ) satisfies FillPropsOnClick;
+	} );
+} );


### PR DESCRIPTION
## What?

Follow-up to #82753. Addresses [this review](https://github.com/WordPress/gutenberg/pull/82753#pullrequestreview-5176353324).

Fixes the `ActionItem` click handler types and the `any` return types of two interface selectors.

## Why?

- `onClick` and `fillProps.onClick` were typed `( ...args: unknown[] ) => void`, which rejects handlers such as `( event: MouseEvent< HTMLButtonElement > ) => void` and gives inline handlers `event: unknown`.
- `isComplementaryAreaLoading` and `isItemPinned` were declared as returning `any`.

## How?

- Types both `onClick` props as React's `MouseEventHandler< HTMLElement >` in [action-item/types.ts](https://github.com/WordPress/gutenberg/blob/fix/interface-review-types/packages/interface/src/components/action-item/types.ts).
- Types the preference values the two selectors read, so their returns infer `boolean | undefined` and `boolean`.
- Drops the ignored second argument passed to `disableComplementaryArea` in [collab-sidebar/hooks.js](https://github.com/WordPress/gutenberg/blob/fix/interface-review-types/packages/editor/src/components/collab-sidebar/hooks.js), found by a Codex review of #82753.
- Adds compile-time assertions in [src/test/types.ts](https://github.com/WordPress/gutenberg/blob/fix/interface-review-types/packages/interface/src/test/types.ts). They check against the emitted declarations and fail on the previous types.

No changelog entry: the types from #82753 are still unreleased.

## Testing Instructions

1. `npm run typecheck` passes.
2. `npm run test:unit:vitest -- packages/interface` passes.

### Testing Instructions for Keyboard

No UI changes.

## Use of AI Tools

Authored with Claude Code (Claude Opus) and reviewed with Codex, then reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
