### PR TITLE
Editor: Remove pass-through more menu Slot wrappers

### DIFF
--- a/packages/edit-widgets/src/components/more-menu/tools-more-menu-group.jsx
+++ b/packages/edit-widgets/src/components/more-menu/tools-more-menu-group.jsx
@@ -4,10 +4,6 @@ const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
 	'EditWidgetsToolsMoreMenuGroup'
 );
 
-ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
-	<Slot fillProps={ fillProps }>
-		{ ( fills ) => fills.length > 0 && fills }
-	</Slot>
-);
+ToolsMoreMenuGroup.Slot = Slot;
 
 export default ToolsMoreMenuGroup;

--- a/packages/editor/src/components/more-menu/tools-more-menu-group.jsx
+++ b/packages/editor/src/components/more-menu/tools-more-menu-group.jsx
@@ -4,6 +4,6 @@ const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
 	Symbol( 'ToolsMoreMenuGroup' )
 );
 
-ToolsMoreMenuGroup.Slot = ( { fillProps } ) => <Slot fillProps={ fillProps } />;
+ToolsMoreMenuGroup.Slot = Slot;
 
 export default ToolsMoreMenuGroup;

--- a/packages/editor/src/components/more-menu/view-more-menu-group.jsx
+++ b/packages/editor/src/components/more-menu/view-more-menu-group.jsx
@@ -4,6 +4,6 @@ const { Fill: ViewMoreMenuGroup, Slot } = createSlotFill(
 	Symbol( 'ViewMoreMenuGroup' )
 );
 
-ViewMoreMenuGroup.Slot = ( { fillProps } ) => <Slot fillProps={ fillProps } />;
+ViewMoreMenuGroup.Slot = Slot;
 
 export default ViewMoreMenuGroup;

--- a/tools/eslint/suppressions.json
+++ b/tools/eslint/suppressions.json
@@ -5838,11 +5838,6 @@
 			"count": 1
 		}
 	},
-	"packages/edit-widgets/src/components/more-menu/tools-more-menu-group.jsx": {
-		"react/jsx-filename-extension": {
-			"count": 1
-		}
-	},
 	"packages/edit-widgets/src/components/notices/index.jsx": {
 		"react/jsx-filename-extension": {
 			"count": 1
@@ -6191,16 +6186,6 @@
 		}
 	},
 	"packages/editor/src/components/more-menu/index.jsx": {
-		"react/jsx-filename-extension": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/more-menu/tools-more-menu-group.jsx": {
-		"react/jsx-filename-extension": {
-			"count": 1
-		}
-	},
-	"packages/editor/src/components/more-menu/view-more-menu-group.jsx": {
 		"react/jsx-filename-extension": {
 			"count": 1
 		}


### PR DESCRIPTION
## What?

Assigns the `createSlotFill` Slot directly to `ToolsMoreMenuGroup.Slot` and `ViewMoreMenuGroup.Slot` in `editor`, and to `ToolsMoreMenuGroup.Slot` in `edit-widgets`, instead of wrapping it in a component. No user-visible change.

## Why?
The wrappers originally passed a render function that hid the slot when empty and wrapped fills in a labeled `MenuGroup`. That render function was later removed, leaving wrappers that only forward `fillProps` and drop every other Slot prop and ref forwarding. The `fills.length > 0 && fills` render function left in `edit-widgets` has the same output as the default Slot, which renders nothing without fills.

Most importantly, it avoids an unwanted pattern from spearing.

## Testing Instructions
1. Open a post or page.
2. Open the Options menu. View and Tools groups render as on trunk (Fullscreen mode, Manage patterns, Welcome Guide).
3. Open the Site Editor, edit a template and open the Options menu. Tools group renders as on trunk.
4. Open Appearance > Widgets, open the Options menu. Tools group renders as on trunk.

### Testing Instructions for Keyboard
Same..

## Use of AI Tools
Assisted by Claude.
