### PR TITLE
Upgrade React 19 to 19.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55948,35 +55948,35 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"react": "^19.2.8",
-				"react-dom": "^19.2.8"
+				"react": "^19.3.0",
+				"react-dom": "^19.3.0"
 			}
 		},
 		"tools/react-19/node_modules/react": {
-			"version": "19.2.8",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-			"integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+			"version": "19.3.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.3.0.tgz",
+			"integrity": "sha512-E8LUcbtBWt20bbl2YoHfx4ZDBdxVTfOKtCZn9cDSJ4l6/nuoApcpIBcj47t2wZoVX8g2ZHuMHbiShgCR1T5Sog==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"tools/react-19/node_modules/react-dom": {
-			"version": "19.2.8",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
-			"integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+			"version": "19.3.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.3.0.tgz",
+			"integrity": "sha512-JDk8dgif51OjFoDE70+OT9ICyYr+69HlmihNwp1+Nsfbna3t5sIiCa9ZJktDmQ4/1b/rn26hIAR2uYXDMr5r0Q==",
 			"license": "MIT",
 			"dependencies": {
-				"scheduler": "^0.27.0"
+				"scheduler": "^0.28.0"
 			},
 			"peerDependencies": {
-				"react": "^19.2.8"
+				"react": "^19.3.0"
 			}
 		},
 		"tools/react-19/node_modules/scheduler": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.28.0.tgz",
+			"integrity": "sha512-juorfCmIkIw8tT+p5BXSm6PJjQF/ycEYmKyzURCIt/RaZIhL+PulbQ9Yu2z1HdOJDdqDTlxA1+xKBmHXJsczAw==",
 			"license": "MIT"
 		},
 		"tools/release": {

--- a/tools/react-19/package.json
+++ b/tools/react-19/package.json
@@ -26,8 +26,8 @@
 		"./package.json": "./package.json"
 	},
 	"dependencies": {
-		"react": "^19.2.8",
-		"react-dom": "^19.2.8"
+		"react": "^19.3.0",
+		"react-dom": "^19.3.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Upgrades the React 19 packages from 19.2.8 to the [recently released](https://react.dev/blog/2026/09/09/react-19-3) 19.3.0.

Should be a very straightforward upgrade. There is handful of new features that we can't use anyway because of back-compat concerns, some new features that are related to server components and irrelevant for us, and a plenty of little bugfixes enumerated in detail in the [changelog](https://github.com/react/react/blob/main/CHANGELOG.md).