### PR TITLE
Notice: add custom icon Storybook example

### DIFF
--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -163,7 +163,6 @@ export const CustomIcon: Story = {
 			<Notice.Title key="title">
 				Parent block is hidden on Desktop
 			</Notice.Title>,
-			<Notice.CloseIcon key="closeIcon" />,
 		],
 	},
 };

--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -160,9 +160,9 @@ export const CustomIcon: Story = {
 		intent: 'info',
 		icon: unseen,
 		children: [
-			<Notice.Title key="title">
+			<Notice.Description key="description">
 				Parent block is hidden on Desktop
-			</Notice.Title>,
+			</Notice.Description>,
 		],
 	},
 };

--- a/packages/ui/src/notice/stories/index.story.tsx
+++ b/packages/ui/src/notice/stories/index.story.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { unseen } from '@wordpress/icons';
 import * as Notice from '../index';
 
 const meta: Meta< typeof Notice.Root > = {
@@ -146,6 +147,22 @@ export const DescriptionOnly: Story = {
 			<Notice.Description key="description">
 				Just a description without title or actions.
 			</Notice.Description>,
+			<Notice.CloseIcon key="closeIcon" />,
+		],
+	},
+};
+
+/**
+ * Pass a custom icon via the `icon` prop to override the default intent icon.
+ */
+export const CustomIcon: Story = {
+	args: {
+		intent: 'info',
+		icon: unseen,
+		children: [
+			<Notice.Title key="title">
+				Parent block is hidden on Desktop
+			</Notice.Title>,
 			<Notice.CloseIcon key="closeIcon" />,
 		],
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Follow-up from https://github.com/WordPress/gutenberg/pull/82670

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Adds "custom icon" Notice story.

<img width="590" height="295" alt="Screenshot 2026-09-11 at 12 44 14" src="https://github.com/user-attachments/assets/0d5a5ccb-df57-4cf7-a914-d9ce99bea18c" />


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Showcase how folks might use custom icons with Notice to emphasize semantics of the message. 

An example came up at https://github.com/WordPress/gutenberg/pull/82670 and Storybook was missing custom icon case.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run `npm run storybook:dev` and see `http://localhost:50240/?path=/docs/design-system-components-notice--docs`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
