### PR TITLE
Test: Add public Vitest packages

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -362,6 +362,14 @@
     - changed-files:
           - any-glob-to-any-file: 'packages/stylelint-config/**'
 
+'[Tool] Vitest console':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/vitest-console/**'
+
+'[Tool] Vitest preset':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/vitest-preset-default/**'
+
 '[Tool] WP Scripts':
     - changed-files:
           - any-glob-to-any-file: 'packages/scripts/**'

--- a/.github/workflows/vitest-packages.yml
+++ b/.github/workflows/vitest-packages.yml
@@ -1,0 +1,67 @@
+name: Vitest packages
+
+on:
+    pull_request:
+        paths:
+            - 'packages/vitest-*/**'
+            - 'packages/jest-*/**'
+            - 'packages/scripts/**'
+            - 'packages/eslint-plugin/**'
+            - 'packages/wp-build/**'
+            - 'packages/style-runtime/**'
+            - 'test/unit/scripts/validate-vitest-package-consumer.mjs'
+            - 'test/unit/package.json'
+            - 'package-lock.json'
+            - '.github/workflows/vitest-packages.yml'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    consumers:
+        name: Packed consumers (Node ${{ matrix.node }}, Vite ${{ matrix.vite }})
+        runs-on: ubuntu-24.04
+        timeout-minutes: 20
+        strategy:
+            fail-fast: false
+            matrix:
+                node: ['22.12.0', '24', '26']
+                vite: ['7.3.6', '8.2.2']
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  persist-credentials: false
+
+            - name: Install and build repository packages on the repository Node version
+              uses: ./.github/setup-node
+              with:
+                  node-version: '24'
+
+            - run: npm run build
+
+            - name: Record the npm CLI for isolated installs
+              run: echo "VITEST_CONSUMER_NPM=$(command -v npm)" >> "$GITHUB_ENV"
+
+            - uses: ./.github/setup-playwright
+              with:
+                  workspace: '@wordpress/unit-tests'
+                  browsers: chromium
+
+            - name: Select the public consumer Node version
+              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+              with:
+                  node-version: ${{ matrix.node }}
+                  package-manager-cache: false
+
+            - name: Verify packed packages in isolated consumers
+              env:
+                  npm_execpath: ${{ env.VITEST_CONSUMER_NPM }}
+                  VITEST_CONSUMER_VITE: ${{ matrix.vite }}
+                  # The unchanged wp-scripts engine range is narrower than the new preset's.
+                  VITEST_CONSUMER_JEST: ${{ matrix.node == '24' && matrix.vite == '8.2.2' && '1' || '' }}
+              run: node test/unit/scripts/validate-vitest-package-consumer.mjs

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2880,6 +2880,18 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/vitest-console",
+		"slug": "packages-vitest-console",
+		"markdown_source": "../packages/vitest-console/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/vitest-preset-default",
+		"slug": "packages-vitest-preset-default",
+		"markdown_source": "../packages/vitest-preset-default/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/warning",
 		"slug": "packages-warning",
 		"markdown_source": "../packages/warning/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14775,6 +14775,7 @@
 			"version": "16.0.0",
 			"resolved": "https://registry.npmjs.org/@swc/plugin-emotion/-/plugin-emotion-16.0.0.tgz",
 			"integrity": "sha512-1W9za9u6MidXiVy4a8jiy27RouSRTyhDsn+RSrULQlDXAagbg4z07oOEDmUAJCwCRhlzKSr8AJKYVRn+N0mTLw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
@@ -54416,7 +54417,6 @@
 			"version": "1.0.0-prerelease",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@swc/plugin-emotion": "^16.0.0",
 				"@vitejs/plugin-react-swc": "^4.3.3",
 				"@vitest/browser-playwright": "^5.0.0",
 				"@wordpress/vitest-console": "file:../vitest-console",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2337,7 +2337,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.10.0.tgz",
 			"integrity": "sha512-AOQff0zgR7cGsZL+4E7hVkmujoPUpm0J9xzWGWZj5wCjd3gmxESXAPfKyuzs93VdpQNFhHlBhfOjrcZ+XTERtQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@braidai/lang": {
@@ -13149,7 +13148,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -14521,7 +14519,6 @@
 			"version": "1.16.2",
 			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.16.2.tgz",
 			"integrity": "sha512-95I4kiSMeveI/Mhi+tE4fiWcWLUMfzfKrk0jtr8LRMqHgOgq+xHS+zExkDqoO4b5OeeuXHMWVdD5MeP3X6sULw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -14565,7 +14562,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14582,7 +14578,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14599,7 +14594,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -14616,7 +14610,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -14636,7 +14629,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -14656,7 +14648,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -14676,7 +14667,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -14696,7 +14686,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"libc": [
 				"glibc"
 			],
@@ -14716,7 +14705,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"libc": [
 				"musl"
 			],
@@ -14736,7 +14724,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14753,7 +14740,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14770,7 +14756,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -14784,14 +14769,12 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
 			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/plugin-emotion": {
 			"version": "16.0.0",
 			"resolved": "https://registry.npmjs.org/@swc/plugin-emotion/-/plugin-emotion-16.0.0.tgz",
 			"integrity": "sha512-1W9za9u6MidXiVy4a8jiy27RouSRTyhDsn+RSrULQlDXAagbg4z07oOEDmUAJCwCRhlzKSr8AJKYVRn+N0mTLw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
@@ -14801,7 +14784,6 @@
 			"version": "0.1.28",
 			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
 			"integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"
@@ -16955,7 +16937,6 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-4.3.3.tgz",
 			"integrity": "sha512-bti8ZAcvz4Lh6/e4Uk2k3aa1TiUXbbMsahuqOHvd3MveFTkKDZOA6wQVkpj7J/+tepX/wGfe+lsGh/t24HTXMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@rolldown/pluginutils": "^1.0.1",
@@ -16972,7 +16953,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-5.0.0.tgz",
 			"integrity": "sha512-JC9FG5xIRxPHXJPcdCaluIJcEoeM0IwGQ3xneuJk09LXKHRNs40BqWDWymQikbb20yOpYvzpKzmYgPRuSzKmvg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@blazediff/core": "1.10.0",
@@ -16996,7 +16976,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-5.0.0.tgz",
 			"integrity": "sha512-N+gED9y4/8pypaHjz/x0ah3CjoBr+N0hWWT+Gq4VXtMzyB+rUIdHni0ulzpD1j4H77iWy5Jg8PRMlVn6kjxo6g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/browser": "5.0.0",
@@ -17020,7 +16999,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
 			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -17030,7 +17008,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-5.0.0.tgz",
 			"integrity": "sha512-PVRNuB3wpReb4SQEs4zTKM4KWFhQ5pw3spE8naoDJNB5T5aWRzGKHwXcLUllr0WeOTXpB6bSr3CJLo5+7XQSSQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tinyrainbow": "^3.1.1"
@@ -17043,7 +17020,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-5.0.0.tgz",
 			"integrity": "sha512-dO++xL3vDfvhTAVimfkuQUA3k+JClIF1i1vAkPqpcGAthRmeWnXmHB7YPViPvgCwviX8u7Y5W1u2N//AaQr3fw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "5.0.0",
@@ -17058,14 +17034,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vitest/browser/node_modules/magic-string": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
 			"integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -17075,7 +17049,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
 			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@polka/url": "^1.0.0-next.24",
@@ -17090,7 +17063,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
 			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -17117,7 +17089,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
 			"integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.31",
@@ -17145,7 +17116,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
 			"integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -17155,7 +17125,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
@@ -17165,7 +17134,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
 			"integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -17201,7 +17169,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-5.0.0.tgz",
 			"integrity": "sha512-h2FIFwggCY2GxUd2UdQoYNVQkOIqEQLPhNREcl3FUiRsdzQep7NWwYbSmhGEA9nFLPDq5pXzRMcBZQU8Py83sg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/utils": "5.0.0",
@@ -17222,7 +17189,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-5.0.0.tgz",
 			"integrity": "sha512-PVRNuB3wpReb4SQEs4zTKM4KWFhQ5pw3spE8naoDJNB5T5aWRzGKHwXcLUllr0WeOTXpB6bSr3CJLo5+7XQSSQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tinyrainbow": "^3.1.1"
@@ -17235,7 +17201,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-5.0.0.tgz",
 			"integrity": "sha512-dO++xL3vDfvhTAVimfkuQUA3k+JClIF1i1vAkPqpcGAthRmeWnXmHB7YPViPvgCwviX8u7Y5W1u2N//AaQr3fw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@vitest/pretty-format": "5.0.0",
@@ -17250,14 +17215,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@vitest/ui/node_modules/sirv": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
 			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@polka/url": "^1.0.0-next.24",
@@ -17272,7 +17235,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
 			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -18209,6 +18171,14 @@
 		},
 		"node_modules/@wordpress/vips": {
 			"resolved": "packages/vips",
+			"link": true
+		},
+		"node_modules/@wordpress/vitest-console": {
+			"resolved": "packages/vitest-console",
+			"link": true
+		},
+		"node_modules/@wordpress/vitest-preset-default": {
+			"resolved": "packages/vitest-preset-default",
 			"link": true
 		},
 		"node_modules/@wordpress/warning": {
@@ -40167,7 +40137,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pathval": {
@@ -40423,7 +40392,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
 			"integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.19.0"
@@ -54428,6 +54396,48 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"packages/vitest-console": {
+			"name": "@wordpress/vitest-console",
+			"version": "1.0.0-prerelease",
+			"license": "GPL-2.0-or-later",
+			"devDependencies": {
+				"vitest": "^5.0.0"
+			},
+			"engines": {
+				"node": "^22.12.0 || ^24.0.0 || >=26.0.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"vitest": "^5.0.0"
+			}
+		},
+		"packages/vitest-preset-default": {
+			"name": "@wordpress/vitest-preset-default",
+			"version": "1.0.0-prerelease",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@swc/plugin-emotion": "^16.0.0",
+				"@vitejs/plugin-react-swc": "^4.3.3",
+				"@vitest/browser-playwright": "^5.0.0",
+				"@wordpress/vitest-console": "file:../vitest-console",
+				"change-case": "^4.1.2",
+				"jsdom": "^26.1.0",
+				"playwright": "^1.63.0"
+			},
+			"devDependencies": {
+				"clsx": "^2.1.1",
+				"vite": "^8.2.2",
+				"vitest": "^5.0.0"
+			},
+			"engines": {
+				"node": "^22.12.0 || ^24.0.0 || >=26.0.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"vite": "^7.0.0 || ^8.0.0",
+				"vitest": "^5.0.0"
+			}
+		},
 		"packages/warning": {
 			"name": "@wordpress/warning",
 			"version": "3.55.0",
@@ -55309,10 +55319,13 @@
 			"version": "0.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@babel/core": "^7.25.7",
+				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.1",
 				"@flakiness/jest": "^1.3.1",
 				"@flakiness/vitest": "^1.9.2",
 				"@swc/plugin-emotion": "^16.0.0",
+				"@testing-library/dom": "^10.4.1",
 				"@testing-library/jest-dom": "^7.0.1",
 				"@testing-library/react": "^16.3.3",
 				"@testing-library/user-event": "^14.6.1",
@@ -55339,6 +55352,7 @@
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vite": "^8.2.2",
 				"vitest": "^5.0.0",
+				"vitest-browser-react": "^2.3.0",
 				"yargs": "^17.3.0"
 			}
 		},

--- a/packages/vitest-console/CHANGELOG.md
+++ b/packages/vitest-console/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+Initial release.

--- a/packages/vitest-console/CHANGELOG.md
+++ b/packages/vitest-console/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unreleased
 
-Initial release.
+Initial release. ([#82765](https://github.com/WordPress/gutenberg/pull/82765))

--- a/packages/vitest-console/README.md
+++ b/packages/vitest-console/README.md
@@ -1,0 +1,49 @@
+# Vitest Console
+
+Custom [Vitest](https://vitest.dev/) matchers for the
+[Console](https://developer.mozilla.org/docs/Web/API/Console) object.
+
+The package spies on `console.error`, `console.info`, `console.log`, and
+`console.warn`. A test fails when one of those methods is called without a
+corresponding assertion, which helps expose unexpected warnings and errors.
+
+Calls are acknowledged per method and per test, as in `@wordpress/jest-console`. A matcher does not require every call to match. Tests that share these console spies must not run concurrently within a file.
+
+## Installation
+
+Requires Vitest 5 and Node `^22.12.0 || ^24.0.0 || >=26.0.0`.
+
+```bash
+npm install --save-dev @wordpress/vitest-console vitest@^5
+```
+
+Add the package to a Vitest setup file:
+
+```js
+import '@wordpress/vitest-console';
+```
+
+```js
+import { expect, test } from 'vitest';
+
+test( 'reports an invalid value', () => {
+	validateValue( 'invalid' );
+	expect( console ).toHaveErroredWith( 'Invalid value.' );
+} );
+```
+
+The available matcher pairs are:
+
+-   `toHaveErrored()` and `toHaveErroredWith()`
+-   `toHaveInformed()` and `toHaveInformedWith()`
+-   `toHaveLogged()` and `toHaveLoggedWith()`
+-   `toHaveWarned()` and `toHaveWarnedWith()`
+
+## Contributing
+
+This package is part of the Gutenberg monorepo. See the
+[contributor guide](https://github.com/WordPress/gutenberg/blob/HEAD/CONTRIBUTING.md).
+
+The TypeScript declarations preserve synchronous `void` and asynchronous `Promise<void>` assertion results. Include this package in a TypeScript setup file or your `compilerOptions.types` when setup uses JavaScript. Await `.resolves`, `.rejects`, and `expect.poll` assertions.
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/vitest-console/index.d.ts
+++ b/packages/vitest-console/index.d.ts
@@ -1,0 +1,49 @@
+import 'vitest';
+
+declare module 'vitest' {
+	interface Matchers<
+		R extends void | Promise< void > = void | Promise< void >,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Match Vitest's generic interface.
+		T = unknown,
+	> {
+		/**
+		 * Ensure that `console.error` was called.
+		 */
+		toHaveErrored: () => R;
+
+		/**
+		 * Ensure that `console.error` was called with specific arguments.
+		 */
+		toHaveErroredWith: ( ...args: unknown[] ) => R;
+
+		/**
+		 * Ensure that `console.info` was called.
+		 */
+		toHaveInformed: () => R;
+
+		/**
+		 * Ensure that `console.info` was called with specific arguments.
+		 */
+		toHaveInformedWith: ( ...args: unknown[] ) => R;
+
+		/**
+		 * Ensure that `console.log` was called.
+		 */
+		toHaveLogged: () => R;
+
+		/**
+		 * Ensure that `console.log` was called with specific arguments.
+		 */
+		toHaveLoggedWith: ( ...args: unknown[] ) => R;
+
+		/**
+		 * Ensure that `console.warn` was called.
+		 */
+		toHaveWarned: () => R;
+
+		/**
+		 * Ensure that `console.warn` was called with specific arguments.
+		 */
+		toHaveWarnedWith: ( ...args: unknown[] ) => R;
+	}
+}

--- a/packages/vitest-console/index.js
+++ b/packages/vitest-console/index.js
@@ -1,0 +1,125 @@
+import { aroundEach, beforeAll, beforeEach, expect, vi } from 'vitest';
+
+const supportedMatchers = {
+	error: 'toHaveErrored',
+	info: 'toHaveInformed',
+	log: 'toHaveLogged',
+	warn: 'toHaveWarned',
+};
+
+function createErrorMessage( state, spyInfo ) {
+	const { spy, pass, calls, matcherName, methodName, expected } = spyInfo;
+	const hint = pass ? `.not${ matcherName }` : matcherName;
+	const message = pass
+		? `Expected mock function not to be called but it was called with:\n${ calls.map(
+				state.utils.printReceived
+		  ) }`
+		: `Expected mock function to be called${
+				expected
+					? ` with:\n${ state.utils.printExpected( expected ) }\n`
+					: '.'
+		  }\nbut it was called with:\n${ calls.map(
+				state.utils.printReceived
+		  ) }`;
+
+	return () =>
+		`${ state.utils.matcherHint( hint, spy.getMockName() ) }` +
+		'\n\n' +
+		message +
+		'\n\n' +
+		`console.${ methodName }() should not be used unless explicitly expected\n` +
+		'See https://www.npmjs.com/package/@wordpress/vitest-console for details.';
+}
+
+function createSpyInfo( state, spy, matcherName, methodName, expected ) {
+	const calls = spy.mock.calls;
+	const pass = expected
+		? calls.some( ( call ) => state.equals( call, expected ) )
+		: calls.length > 0;
+
+	return {
+		pass,
+		message: createErrorMessage( state, {
+			spy,
+			pass,
+			calls,
+			matcherName,
+			methodName,
+			expected,
+		} ),
+	};
+}
+
+expect.extend(
+	Object.entries( supportedMatchers ).reduce(
+		( result, [ methodName, matcherName ] ) => {
+			const matcherNameWith = `${ matcherName }With`;
+
+			return {
+				...result,
+				[ matcherName ]( received ) {
+					const spy = received[ methodName ];
+					const spyInfo = createSpyInfo(
+						this,
+						spy,
+						`.${ matcherName }`,
+						methodName
+					);
+					spy.assertionsNumber += 1;
+					return spyInfo;
+				},
+				[ matcherNameWith ]( received, ...expected ) {
+					const spy = received[ methodName ];
+					const spyInfo = createSpyInfo(
+						this,
+						spy,
+						`.${ matcherNameWith }`,
+						methodName,
+						expected
+					);
+					spy.assertionsNumber += 1;
+					return spyInfo;
+				},
+			};
+		},
+		{}
+	)
+);
+
+function setConsoleMethodSpy( [ methodName, matcherName ] ) {
+	let spy;
+
+	function resetSpy() {
+		// eslint-disable-next-line no-console
+		if ( console[ methodName ] !== spy ) {
+			spy = vi.fn().mockName( `console.${ methodName }` );
+			// eslint-disable-next-line no-console
+			console[ methodName ] = spy;
+		}
+
+		spy.mockReset();
+		spy.mockImplementation( () => undefined );
+		spy.assertionsNumber = 0;
+	}
+
+	function assertExpectedCalls() {
+		if ( spy.assertionsNumber === 0 && spy.mock.calls.length > 0 ) {
+			expect( console ).not[ matcherName ]();
+		}
+	}
+
+	beforeAll( resetSpy );
+	beforeEach( () => {
+		assertExpectedCalls();
+		resetSpy();
+	} );
+	aroundEach( async ( runTest ) => {
+		try {
+			await runTest();
+		} finally {
+			assertExpectedCalls();
+		}
+	} );
+}
+
+Object.entries( supportedMatchers ).forEach( setConsoleMethodSpy );

--- a/packages/vitest-console/package.json
+++ b/packages/vitest-console/package.json
@@ -1,0 +1,56 @@
+{
+	"name": "@wordpress/vitest-console",
+	"version": "1.0.0-prerelease",
+	"description": "Custom Vitest matchers for the Console object.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"vitest",
+		"matchers",
+		"console"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/vitest-console/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/vitest-console"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": "^22.12.0 || ^24.0.0 || >=26.0.0",
+		"npm": ">=8.19.2"
+	},
+	"files": [
+		"CHANGELOG.md",
+		"README.md",
+		"index.d.ts",
+		"index.js"
+	],
+	"type": "module",
+	"main": "index.js",
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"default": "./index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"types": "index.d.ts",
+	"sideEffects": true,
+	"devDependencies": {
+		"vitest": "^5.0.0"
+	},
+	"peerDependencies": {
+		"vitest": "^5.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"lint:package-contents": "wp-validate-package-contents ."
+	}
+}

--- a/packages/vitest-console/test/index.test.js
+++ b/packages/vitest-console/test/index.test.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+
+import { describe, expect, test } from 'vitest';
+import '../index.js';
+
+describe.each( [
+	[ 'error', 'toHaveErrored' ],
+	[ 'info', 'toHaveInformed' ],
+	[ 'log', 'toHaveLogged' ],
+	[ 'warn', 'toHaveWarned' ],
+] )( 'console.%s', ( methodName, matcherName ) => {
+	const matcherNameWith = `${ matcherName }With`;
+	const message = `This is ${ methodName }!`;
+
+	test( `${ matcherName } accepts an observed call`, () => {
+		console[ methodName ]( message );
+		expect( console )[ matcherName ]();
+	} );
+
+	test( `${ matcherName } rejects a missing call`, () => {
+		expect( console ).not[ matcherName ]();
+		expect( () => expect( console )[ matcherName ]() ).toThrow(
+			'Expected mock function to be called.'
+		);
+	} );
+
+	test( `${ matcherNameWith } accepts matching arguments`, () => {
+		console[ methodName ]( message );
+		expect( console )[ matcherNameWith ]( message );
+	} );
+
+	test( `${ matcherNameWith } supports asymmetric matchers`, () => {
+		console[ methodName ]( message, { status: 400 } );
+		expect( console )[ matcherNameWith ](
+			expect.stringContaining( methodName ),
+			expect.objectContaining( { status: 400 } )
+		);
+	} );
+
+	test( `${ matcherNameWith } rejects a missing call`, () => {
+		expect( console ).not[ matcherNameWith ]( message );
+		expect( () => expect( console )[ matcherNameWith ]( message ) ).toThrow(
+			/Expected mock function to be called with:.*but it was called with:/s
+		);
+	} );
+
+	test( `${ matcherNameWith } rejects non-matching arguments`, () => {
+		console[ methodName ]( 'Unknown message.' );
+		console[ methodName ]( message, 'Unknown param.' );
+
+		expect( console ).not[ matcherNameWith ]( message );
+		expect( () => expect( console )[ matcherNameWith ]( message ) ).toThrow(
+			/Expected mock function to be called with:.*but it was called with:.*Unknown param./s
+		);
+	} );
+
+	test( 'counts matcher assertions', () => {
+		const spy = console[ methodName ];
+
+		expect( spy.assertionsNumber ).toBe( 0 );
+		console[ methodName ]( message );
+		expect( console )[ matcherName ]();
+		expect( console )[ matcherNameWith ]( message );
+		expect( spy.assertionsNumber ).toBe( 2 );
+	} );
+
+	test( 'registers the console spy before test execution', () => {
+		expect( console[ methodName ].assertionsNumber ).toBeGreaterThanOrEqual(
+			0
+		);
+	} );
+} );
+
+/* eslint-enable no-console */

--- a/packages/vitest-preset-default/CHANGELOG.md
+++ b/packages/vitest-preset-default/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+Initial release.

--- a/packages/vitest-preset-default/CHANGELOG.md
+++ b/packages/vitest-preset-default/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unreleased
 
-Initial release. ([#82765](https://github.com/WordPress/gutenberg/pull/82765))
+Initial release, with consumer-configured Emotion transforms. ([#82765](https://github.com/WordPress/gutenberg/pull/82765))

--- a/packages/vitest-preset-default/CHANGELOG.md
+++ b/packages/vitest-preset-default/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unreleased
 
-Initial release.
+Initial release. ([#82765](https://github.com/WordPress/gutenberg/pull/82765))

--- a/packages/vitest-preset-default/README.md
+++ b/packages/vitest-preset-default/README.md
@@ -1,0 +1,95 @@
+# Default Vitest Preset
+
+[Vitest 5](https://vitest.dev/) configuration for WordPress projects, with explicit imports, isolated tests, React and Emotion compilation, and console matchers.
+
+## Installation
+
+Requires Node `^22.12.0 || ^24.0.0 || >=26.0.0`, npm `>=8.19.2`, Vitest 5 and Vite 7 or 8.
+
+```bash
+npm install --save-dev @wordpress/vitest-preset-default vitest@^5 vite@^8
+```
+
+Create `vitest.config.mjs`:
+
+```js
+export { default } from '@wordpress/vitest-preset-default';
+```
+
+Run `npm exec --no -- vitest run`. For Browser Mode, first install Chromium with `npm exec --no -- playwright install chromium`.
+
+## Test environments
+
+The filename selects the environment:
+
+-   Ordinary test names run in Node, without a DOM. Tests in `test/`, `__tests__/`, and `*.test.*` files are discovered.
+-   `*.jsdom.test.*` files run in jsdom.
+-   `*.browser.test.*` files run in Chromium with Vitest Browser Mode.
+
+The supported extensions are `js`, `jsx`, `ts`, `tsx`, `mjs`, `mts`, `cjs`, and `cts`. Dependencies and `vendor/` are excluded. Keep helper files outside discovered test paths.
+
+Node and jsdom replace CSS and SCSS imports with a proxy. For example, `styles.primaryAction` returns `style-primary-action`. Browser Mode loads real CSS and preserves native APIs such as `matchMedia`, `ResizeObserver`, and `CSS.supports`.
+
+Rebuilt packages using `@wordpress/build` also preserve this boundary. Its merged guard is `typeof process === 'undefined' || process.env.NODE_ENV !== 'test'`. Node and jsdom skip automatic style injection in test mode. Browser Mode injects styles because it does not define `process`. Ordinary CSS also checks for `document`. Do not add a `process` shim to Browser Mode. Older generated output must be rebuilt with a published build version containing [#82154](https://github.com/WordPress/gutenberg/pull/82154); the preset cannot repair old emitted code. Version `0.23.0` contains the fix.
+
+The preset does not install browser mocks in jsdom. Use a local mock that the owning suite restores when browser signals are controlled test inputs. Use Browser Mode to test CSS, layout, geometry, observers, media queries, animation, or scrolling.
+
+## Setup and compilation
+
+Tests import APIs explicitly:
+
+```js
+import { expect, test, vi } from 'vitest';
+```
+
+Vite compiles JavaScript and TypeScript. SWC compiles JSX and applies the Emotion plugin with local labels. Browser dependencies compile with `NODE_ENV=test` without adding a `process` global. Babel configuration is not used. Use `.jsx` or `.tsx` for JSX.
+
+The preset enables `SCRIPT_DEBUG` and supplies `tinyMCEPreInit` and `userSettings` in DOM environments. It installs [`@wordpress/vitest-console`](../vitest-console/README.md), resets mocks, restores spies and stubbed globals/environment variables, and restores real timers before each test. Test files remain isolated. Console assertions share per-test state, so tests that use them must not run concurrently within a file.
+
+To extend the preset, merge project configuration:
+
+```js
+import wordpressConfig from '@wordpress/vitest-preset-default';
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+export default mergeConfig(
+	wordpressConfig,
+	defineConfig( {
+		test: {
+			setupFiles: [ './test-setup.js' ],
+		},
+	} )
+);
+```
+
+Setup applies to all projects. Keep environment-specific setup in the corresponding project's `test.setupFiles`. For jsdom React tests, use Testing Library React and register cleanup explicitly because globals are disabled:
+
+```js
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach( cleanup );
+```
+
+For Browser React tests, use `vitest-browser-react` and Browser Mode's `userEvent`. The browser renderer handles cleanup. Tests can use Vitest's native DOM assertions.
+
+## Migrating from Jest
+
+Install the new packages and add the configuration above. Rename DOM tests to `*.jsdom.test.*` and tests that need browser behavior to `*.browser.test.*`. Replace Jest globals with explicit Vitest imports and review mock hoisting, timers, snapshots, and asynchronous assertions against the [Vitest migration guide](https://vitest.dev/guide/migration/). Await asynchronous assertions, including `expect.poll` and `.resolves`.
+
+This release is additive. `@wordpress/jest-preset-default`, `@wordpress/jest-console`, existing Jest ESLint defaults, and `wp-scripts test-unit-js` remain available. Run Vitest directly to opt in. This package does not change lint defaults or switch existing commands.
+
+## Release verification
+
+Before public tooling adopts these packages, publish and verify `@wordpress/vitest-console`, then `@wordpress/vitest-preset-default`. Verify the actual registry artifacts in isolated consumers. Also confirm that a published `@wordpress/build` contains #82154 and rebuild affected CSS-module and regular-CSS output. The source fix is merged; no further build-fix PR is required. Publishing these packages does not require switching `wp-scripts` or removing Jest.
+
+In this repository, `npm run --workspace @wordpress/unit-tests test:unit:vitest:packages` packs the packages and tests an isolated consumer. Set `VITEST_CONSUMER_JEST=1` to also verify the unchanged packed Jest tooling on its supported Node versions. Set `VITEST_CONSUMER_VITE` to an exact supported Vite version and run under each supported Node major. The validator checks generated CSS, public types, console matchers, setup configuration, failure output, and browser values. It does not publish packages.
+
+Vitest 5.0.0's `vitest/config` declaration entry still imports the undeclared `@vitest/expect` package. Use the `.mjs` configuration above until that upstream declaration issue is fixed. This preset's public declarations use `vite` and `vitest/node`; its matcher types compile without that retired package.
+
+## Contributing
+
+See the [contributor guide](https://github.com/WordPress/gutenberg/blob/HEAD/CONTRIBUTING.md).
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/vitest-preset-default/README.md
+++ b/packages/vitest-preset-default/README.md
@@ -1,6 +1,6 @@
 # Default Vitest Preset
 
-[Vitest 5](https://vitest.dev/) configuration for WordPress projects, with explicit imports, isolated tests, React and Emotion compilation, and console matchers.
+[Vitest 5](https://vitest.dev/) configuration for WordPress projects, with explicit imports, isolated tests, React compilation, and console matchers.
 
 ## Installation
 
@@ -42,7 +42,7 @@ Tests import APIs explicitly:
 import { expect, test, vi } from 'vitest';
 ```
 
-Vite compiles JavaScript and TypeScript. SWC compiles JSX and applies the Emotion plugin with local labels. Browser dependencies compile with `NODE_ENV=test` without adding a `process` global. Babel configuration is not used. Use `.jsx` or `.tsx` for JSX.
+Vite compiles JavaScript and TypeScript. SWC compiles JSX. Emotion transforms are consumer-configured; the preset does not install Emotion or its compiler plugin. Browser dependencies compile with `NODE_ENV=test` without adding a `process` global. Babel configuration is not used. Use `.jsx` or `.tsx` for JSX.
 
 The preset enables `SCRIPT_DEBUG` and supplies `tinyMCEPreInit` and `userSettings` in DOM environments. It installs [`@wordpress/vitest-console`](../vitest-console/README.md), resets mocks, restores spies and stubbed globals/environment variables, and restores real timers before each test. Test files remain isolated. Console assertions share per-test state, so tests that use them must not run concurrently within a file.
 
@@ -73,6 +73,39 @@ afterEach( cleanup );
 ```
 
 For Browser React tests, use `vitest-browser-react` and Browser Mode's `userEvent`. The browser renderer handles cleanup. Tests can use Vitest's native DOM assertions.
+
+### Emotion
+
+Projects using Emotion can install `@vitejs/plugin-react-swc@^4` and
+`@swc/plugin-emotion@^16` as development dependencies alongside their existing
+Emotion runtime. Configure the transform in `vitest.config.mjs`:
+
+```js
+import { createRequire } from 'node:module';
+import react from '@vitejs/plugin-react-swc';
+import wordpressConfig from '@wordpress/vitest-preset-default';
+
+const require = createRequire( import.meta.url );
+
+export default {
+	...wordpressConfig,
+	plugins: [
+		react( {
+			plugins: [
+				[
+					require.resolve( '@swc/plugin-emotion' ),
+					{ autoLabel: 'always', labelFormat: '[local]' },
+				],
+			],
+		} ),
+	],
+};
+```
+
+This replaces the preset's React plugin with the consumer's configured instance.
+Use `/** @jsxImportSource @emotion/react */` in files using Emotion's `css` prop.
+Projects can remove this configuration and its dependencies when they stop using
+Emotion. Plain React JSX needs no additional configuration.
 
 ## Migrating from Jest
 

--- a/packages/vitest-preset-default/index.d.ts
+++ b/packages/vitest-preset-default/index.d.ts
@@ -1,0 +1,5 @@
+import type { UserConfig } from 'vite';
+import type { TestUserConfig } from 'vitest/node';
+
+declare const config: UserConfig & { test: TestUserConfig };
+export default config;

--- a/packages/vitest-preset-default/index.js
+++ b/packages/vitest-preset-default/index.js
@@ -1,0 +1,124 @@
+import { createRequire } from 'node:module';
+import react from '@vitejs/plugin-react-swc';
+import { playwright } from '@vitest/browser-playwright';
+import { configDefaults, defineConfig } from 'vitest/config';
+import { version as viteVersion } from 'vite';
+
+const require = createRequire( import.meta.url );
+const emotionPlugin = require.resolve( '@swc/plugin-emotion' );
+const usesRolldown = Number( viteVersion.split( '.' )[ 0 ] ) >= 8;
+// Compile browser dependencies against React's test runtime before tree shaking.
+// A top-level define would make Vitest install a process global in the browser.
+const browserDefine = { 'process.env.NODE_ENV': JSON.stringify( 'test' ) };
+
+const TEST_EXTENSIONS = '{js,jsx,ts,tsx,mjs,mts,cjs,cts}';
+const DEFAULT_TEST_PATTERNS = [
+	`**/__tests__/**/*.${ TEST_EXTENSIONS }`,
+	`**/test/*.${ TEST_EXTENSIONS }`,
+	`**/*.test.${ TEST_EXTENSIONS }`,
+];
+const JSDOM_TEST_PATTERN = `**/*.jsdom.test.${ TEST_EXTENSIONS }`;
+const BROWSER_TEST_PATTERN = `**/*.browser.test.${ TEST_EXTENSIONS }`;
+const exclude = [ ...configDefaults.exclude, '**/vendor/**' ];
+const setupGlobals = '@wordpress/vitest-preset-default/setup-globals';
+const setupTestFramework =
+	'@wordpress/vitest-preset-default/setup-test-framework';
+const styleMock = '@wordpress/vitest-preset-default/style-mock';
+const styleMockAlias = {
+	find: /^.*\.(?:css|scss)$/,
+	replacement: styleMock,
+};
+
+export default defineConfig( {
+	...( usesRolldown
+		? { oxc: { jsx: { runtime: 'automatic' } } }
+		: { esbuild: { jsx: 'automatic' } } ),
+	plugins: [
+		react( {
+			plugins: [
+				[
+					emotionPlugin,
+					{
+						autoLabel: 'always',
+						labelFormat: '[local]',
+					},
+				],
+			],
+		} ),
+	],
+	test: {
+		setupFiles: [ setupGlobals, setupTestFramework ],
+		projects: [
+			{
+				extends: true,
+				resolve: {
+					alias: [ styleMockAlias ],
+				},
+				test: {
+					name: 'node',
+					environment: 'node',
+					exclude: [
+						...exclude,
+						JSDOM_TEST_PATTERN,
+						BROWSER_TEST_PATTERN,
+					],
+					include: DEFAULT_TEST_PATTERNS,
+				},
+			},
+			{
+				extends: true,
+				resolve: {
+					alias: [ styleMockAlias ],
+				},
+				test: {
+					name: 'jsdom',
+					environment: 'jsdom',
+					environmentOptions: {
+						jsdom: {
+							url: 'http://localhost/',
+						},
+					},
+					exclude,
+					include: [ JSDOM_TEST_PATTERN ],
+				},
+			},
+			{
+				extends: true,
+				optimizeDeps: usesRolldown
+					? {
+							rolldownOptions: {
+								transform: { define: browserDefine },
+							},
+					  }
+					: { esbuildOptions: { define: browserDefine } },
+				test: {
+					name: 'browser',
+					exclude,
+					include: [ BROWSER_TEST_PATTERN ],
+					browser: {
+						enabled: true,
+						headless: true,
+						instances: [ { browser: 'chromium' } ],
+						provider: playwright(),
+					},
+				},
+			},
+		],
+		globals: false,
+		isolate: true,
+		clearMocks: false,
+		mockReset: true,
+		restoreMocks: true,
+		unstubEnvs: true,
+		unstubGlobals: true,
+		includeTaskLocation: true,
+		sequence: {
+			hooks: 'list',
+			setupFiles: 'list',
+		},
+		snapshotFormat: {
+			escapeString: false,
+			printBasicPrototype: false,
+		},
+	},
+} );

--- a/packages/vitest-preset-default/index.js
+++ b/packages/vitest-preset-default/index.js
@@ -1,11 +1,8 @@
-import { createRequire } from 'node:module';
 import react from '@vitejs/plugin-react-swc';
 import { playwright } from '@vitest/browser-playwright';
 import { configDefaults, defineConfig } from 'vitest/config';
 import { version as viteVersion } from 'vite';
 
-const require = createRequire( import.meta.url );
-const emotionPlugin = require.resolve( '@swc/plugin-emotion' );
 const usesRolldown = Number( viteVersion.split( '.' )[ 0 ] ) >= 8;
 // Compile browser dependencies against React's test runtime before tree shaking.
 // A top-level define would make Vitest install a process global in the browser.
@@ -33,19 +30,7 @@ export default defineConfig( {
 	...( usesRolldown
 		? { oxc: { jsx: { runtime: 'automatic' } } }
 		: { esbuild: { jsx: 'automatic' } } ),
-	plugins: [
-		react( {
-			plugins: [
-				[
-					emotionPlugin,
-					{
-						autoLabel: 'always',
-						labelFormat: '[local]',
-					},
-				],
-			],
-		} ),
-	],
+	plugins: [ react() ],
 	test: {
 		setupFiles: [ setupGlobals, setupTestFramework ],
 		projects: [

--- a/packages/vitest-preset-default/package.json
+++ b/packages/vitest-preset-default/package.json
@@ -45,7 +45,6 @@
 	},
 	"types": "index.d.ts",
 	"dependencies": {
-		"@swc/plugin-emotion": "^16.0.0",
 		"@vitejs/plugin-react-swc": "^4.3.3",
 		"@vitest/browser-playwright": "^5.0.0",
 		"@wordpress/vitest-console": "file:../vitest-console",

--- a/packages/vitest-preset-default/package.json
+++ b/packages/vitest-preset-default/package.json
@@ -1,0 +1,71 @@
+{
+	"name": "@wordpress/vitest-preset-default",
+	"version": "1.0.0-prerelease",
+	"description": "Default Vitest configuration for WordPress development.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gutenberg",
+		"vitest",
+		"preset",
+		"react"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/vitest-preset-default/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/vitest-preset-default"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"engines": {
+		"node": "^22.12.0 || ^24.0.0 || >=26.0.0",
+		"npm": ">=8.19.2"
+	},
+	"files": [
+		"CHANGELOG.md",
+		"README.md",
+		"index.js",
+		"scripts",
+		"index.d.ts"
+	],
+	"type": "module",
+	"main": "index.js",
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"default": "./index.js"
+		},
+		"./package.json": "./package.json",
+		"./setup-globals": "./scripts/setup-globals.js",
+		"./setup-test-framework": "./scripts/setup-test-framework.js",
+		"./style-mock": "./scripts/style-mock.js"
+	},
+	"types": "index.d.ts",
+	"dependencies": {
+		"@swc/plugin-emotion": "^16.0.0",
+		"@vitejs/plugin-react-swc": "^4.3.3",
+		"@vitest/browser-playwright": "^5.0.0",
+		"@wordpress/vitest-console": "file:../vitest-console",
+		"change-case": "^4.1.2",
+		"jsdom": "^26.1.0",
+		"playwright": "^1.63.0"
+	},
+	"devDependencies": {
+		"clsx": "^2.1.1",
+		"vite": "^8.2.2",
+		"vitest": "^5.0.0"
+	},
+	"peerDependencies": {
+		"vite": "^7.0.0 || ^8.0.0",
+		"vitest": "^5.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"lint:package-contents": "wp-validate-package-contents ."
+	}
+}

--- a/packages/vitest-preset-default/scripts/setup-globals.js
+++ b/packages/vitest-preset-default/scripts/setup-globals.js
@@ -1,0 +1,10 @@
+// Run all tests with development tools enabled.
+// eslint-disable-next-line @wordpress/wp-global-usage
+globalThis.SCRIPT_DEBUG = true;
+
+if ( typeof globalThis.window !== 'undefined' ) {
+	globalThis.window.tinyMCEPreInit = {
+		baseURL: 'about:blank',
+	};
+	globalThis.window.userSettings = { uid: 1 };
+}

--- a/packages/vitest-preset-default/scripts/setup-test-framework.js
+++ b/packages/vitest-preset-default/scripts/setup-test-framework.js
@@ -1,0 +1,6 @@
+import '@wordpress/vitest-console';
+import { beforeEach, vi } from 'vitest';
+
+beforeEach( () => {
+	vi.useRealTimers();
+} );

--- a/packages/vitest-preset-default/scripts/style-mock.js
+++ b/packages/vitest-preset-default/scripts/style-mock.js
@@ -1,0 +1,17 @@
+import changeCase from 'change-case';
+
+const { paramCase: kebabCase } = changeCase;
+const styles = new Proxy(
+	{},
+	{
+		get( target, property ) {
+			if ( typeof property === 'string' && property !== '__esModule' ) {
+				return `style-${ kebabCase( property ) }`;
+			}
+
+			return Reflect.get( target, property );
+		},
+	}
+);
+
+export default styles;

--- a/packages/vitest-preset-default/test/index.test.js
+++ b/packages/vitest-preset-default/test/index.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import preset from '../index.js';
+
+describe( '@wordpress/vitest-preset-default', () => {
+	const projects = Object.fromEntries(
+		preset.test.projects.map( ( project ) => [
+			project.test.name,
+			project,
+		] )
+	);
+
+	test( 'uses Node unless a filename selects another environment', () => {
+		expect( preset.test.globals ).toBe( false );
+		expect( projects.node.test.environment ).toBe( 'node' );
+		expect( projects.node.test.exclude ).toContain(
+			'**/*.jsdom.test.{js,jsx,ts,tsx,mjs,mts,cjs,cts}'
+		);
+		expect( projects.node.test.exclude ).toContain(
+			'**/*.browser.test.{js,jsx,ts,tsx,mjs,mts,cjs,cts}'
+		);
+		expect( projects.jsdom.test ).toMatchObject( {
+			name: 'jsdom',
+			environment: 'jsdom',
+		} );
+		expect( projects.browser.test ).toMatchObject( {
+			name: 'browser',
+			browser: {
+				enabled: true,
+				headless: true,
+				instances: [ { browser: 'chromium' } ],
+			},
+		} );
+	} );
+
+	test( 'mocks styles outside Browser Mode only', () => {
+		expect( projects.node.resolve.alias ).toHaveLength( 1 );
+		expect( projects.jsdom.resolve.alias ).toHaveLength( 1 );
+		expect( projects.browser.resolve ).toBeUndefined();
+	} );
+
+	test( 'loads setup files in a deterministic order', () => {
+		expect( preset.test.sequence ).toEqual( {
+			hooks: 'list',
+			setupFiles: 'list',
+		} );
+		expect( preset.test.setupFiles ).toHaveLength( 2 );
+	} );
+} );

--- a/packages/vitest-preset-default/test/style-mock.test.js
+++ b/packages/vitest-preset-default/test/style-mock.test.js
@@ -1,0 +1,29 @@
+import clsx from 'clsx';
+import { describe, expect, test } from 'vitest';
+import styles from '../scripts/style-mock.js';
+
+describe( 'style mock', () => {
+	test( 'returns prefixed kebab-case class names', () => {
+		expect( styles.root ).toBe( 'style-root' );
+		expect( styles.className ).toBe( 'style-class-name' );
+		expect( styles.singleLineClamp ).toBe( 'style-single-line-clamp' );
+		expect( styles.Content ).toBe( 'style-content' );
+		expect( styles[ 'already-kebab' ] ).toBe( 'style-already-kebab' );
+	} );
+
+	test( 'supports clsx object syntax', () => {
+		expect(
+			clsx( {
+				[ styles.conditionalClass ]: true,
+			} )
+		).toBe( 'style-conditional-class' );
+	} );
+
+	test( 'does not mark the mock as an ES module', () => {
+		expect( styles.__esModule ).toBeUndefined();
+	} );
+
+	test( 'ignores symbol property access', () => {
+		expect( styles[ Symbol.toStringTag ] ).toBeUndefined();
+	} );
+} );

--- a/test/unit/VITEST_MIGRATION.md
+++ b/test/unit/VITEST_MIGRATION.md
@@ -79,7 +79,7 @@ assigns the published versions. Existing Jest packages, public lint defaults,
 and `wp-scripts test-unit-js` remain available.
 
 The packed-consumer validator runs against Node 22.12.0, 24 and 26 with Vite 7
-and 8 in `.github/workflows/vitest-packages.yml`. It verifies JSX and Emotion,
+and 8 in `.github/workflows/vitest-packages.yml`. It verifies plain JSX without Emotion installed, consumer-configured Emotion,
 console matcher types and failure output, setup inheritance, native browser
 values, CSS-module proxies, and rebuilt CSS-module and ordinary-CSS output.
 The Node 24/Vite 8 combination also checks packed Jest tooling.

--- a/test/unit/VITEST_MIGRATION.md
+++ b/test/unit/VITEST_MIGRATION.md
@@ -69,3 +69,36 @@ between tests. Tests must configure required mock implementations in their own
 setup hooks. Mutable state held by an imported module is not reset
 automatically; reset it explicitly or use `vi.resetModules()` when a fresh
 module instance is required.
+
+## Additive public package release
+
+`@wordpress/vitest-console` and `@wordpress/vitest-preset-default` provide the
+public Vitest 5 setup. See the [preset migration guide](../../packages/vitest-preset-default/README.md).
+They start at `1.0.0-prerelease` under the new-package policy. The release workflow
+assigns the published versions. Existing Jest packages, public lint defaults,
+and `wp-scripts test-unit-js` remain available.
+
+The packed-consumer validator runs against Node 22.12.0, 24 and 26 with Vite 7
+and 8 in `.github/workflows/vitest-packages.yml`. It verifies JSX and Emotion,
+console matcher types and failure output, setup inheritance, native browser
+values, CSS-module proxies, and rebuilt CSS-module and ordinary-CSS output.
+The Node 24/Vite 8 combination also checks packed Jest tooling.
+
+Before adopting these packages in released public tooling:
+
+1. Publish `@wordpress/vitest-console`, then `@wordpress/vitest-preset-default`
+   through the protected package-release workflow. Verify that their published
+   exports, declarations and dependency versions match the reviewed artifacts.
+2. Repeat isolated consumer verification using the actual published versions.
+3. Use a published `@wordpress/build` containing #82154 and rebuild affected
+   generated CSS. Published version `0.23.0` contains both browser-safe guards.
+   No additional build-fix PR is planned.
+4. Switch public commands and lint defaults only at the separately documented
+   tooling release boundary. Retire active Jest support after that replacement
+   has shipped and its supported consumers have migrated.
+
+The September 11, 2026 audit found no advisories in the isolated install of the
+two new packages with Vitest 5.0.0 and Vite 8.2.2. The repository audit found 47
+advisories, unchanged from base `351883676c6`: 5 low, 27 moderate and 15 high.
+The published-dependency audit found no undeclared imports in either package.
+Refresh these checks before publication.

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -20,10 +20,13 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.25.7",
+		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.1",
 		"@flakiness/jest": "^1.3.1",
 		"@flakiness/vitest": "^1.9.2",
 		"@swc/plugin-emotion": "^16.0.0",
+		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^7.0.1",
 		"@testing-library/react": "^16.3.3",
 		"@testing-library/user-event": "^14.6.1",
@@ -50,6 +53,7 @@
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vite": "^8.2.2",
 		"vitest": "^5.0.0",
+		"vitest-browser-react": "^2.3.0",
 		"yargs": "^17.3.0"
 	},
 	"publishConfig": {
@@ -65,6 +69,7 @@
 		"test:unit:profile": "wp-scripts --cpu-prof test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
 		"test:unit:watch": "npm run test:unit -- --watch",
 		"test:unit:debug": "wp-scripts --inspect-brk test-unit-js --runInBand --no-cache --verbose --config jest.config.js",
-		"test:unit:routing": "node scripts/validate-test-routing.mjs"
+		"test:unit:routing": "node scripts/validate-test-routing.mjs",
+		"test:unit:vitest:packages": "node scripts/validate-vitest-package-consumer.mjs"
 	}
 }

--- a/test/unit/scripts/validate-vitest-package-consumer.mjs
+++ b/test/unit/scripts/validate-vitest-package-consumer.mjs
@@ -37,7 +37,6 @@ const stagedPackages = path.join( tempDirectory, 'staged-packages' );
 const installedPackages = path.join( tempDirectory, 'node_modules' );
 const CONSUMER_DEPENDENCIES = [
 	'@babel/core',
-	'@emotion/react',
 	'@testing-library/dom',
 	'@testing-library/jest-dom',
 	'@testing-library/react',
@@ -182,6 +181,15 @@ function packPackage( packageName, workspaceVersions ) {
 }
 
 function getInstalledVersion( packageName ) {
+	// The React plugin exports its root entry, but not package.json.
+	if ( packageName === '@vitejs/plugin-react-swc' ) {
+		return readJson(
+			path.join(
+				path.dirname( require.resolve( packageName ) ),
+				'package.json'
+			)
+		).version;
+	}
 	return readJson( require.resolve( `${ packageName }/package.json` ) )
 		.version;
 }
@@ -267,6 +275,12 @@ function installPackedPackages( packedPackages ) {
 		assertIsolatedResolution( isolatedRequire, packageName );
 	}
 
+	for ( const packageName of [ '@emotion/react', '@swc/plugin-emotion' ] ) {
+		assert.throws( () => isolatedRequire.resolve( packageName ), {
+			code: 'MODULE_NOT_FOUND',
+		} );
+	}
+
 	// The staged source includes package self-tests which are intentionally not
 	// part of the published tarballs. Remove it before consumer test discovery.
 	rmSync( stagedPackages, { force: true, recursive: true } );
@@ -350,21 +364,18 @@ function createDefaultConsumer() {
 	);
 	writeFileSync(
 		path.join( fixture, 'default.test.tsx' ),
-		`import { css } from '@emotion/react';
-import { expect, test } from 'vitest';
+		`import { expect, test } from 'vitest';
 import builtStyles from '@wordpress/test-style-fixture';
 import styles from './styles.module.css';
 
 test( 'uses Node and native transforms by default', () => {
 \tconst count: number = 2;
-\tconst nodeStyle = css( { color: 'red' } );
-\tconst element = <button css={ nodeStyle }>Save { count }</button>;
+\tconst element = <button>Save { count }</button>;
 
 \texpect( typeof document ).toBe( 'undefined' );
 \texpect( styles.primaryAction ).toBe( 'style-primary-action' );
 \texpect( builtStyles.fixture ).toBeTruthy();
 \texpect( element.props.children ).toEqual( [ 'Save ', 2 ] );
-\texpect( nodeStyle.name ).toMatch( /nodeStyle/ );
 \texpect( globalThis.SCRIPT_DEBUG ).toBe( true );
 \tconsole.warn( 'expected warning' );
 \texpect( console ).toHaveWarnedWith( 'expected warning' );
@@ -425,20 +436,17 @@ test( 'uses real CSS and native browser values', async () => {
 	);
 
 	writeFileSync(
-		path.join( fixture, 'emotion.browser.test.jsx' ),
-		`/** @jsxImportSource @emotion/react */
-import { css } from '@emotion/react';
+		path.join( fixture, 'react.browser.test.jsx' ),
+		`
 import { render } from 'vitest-browser-react';
 import { expect, test } from 'vitest';
 import styles from './styles.module.css';
 
-test( 'renders JSX, Emotion and CSS modules in Chromium', async () => {
-	const buttonStyle = css( { color: 'rgb(11, 22, 33)' } );
-	const screen = await render( <button className={ styles.primaryAction } css={ buttonStyle }>Save</button> );
+test( 'renders JSX and CSS modules in Chromium', async () => {
+	const screen = await render( <button className={ styles.primaryAction }>Save</button> );
 	const button = screen.getByRole( 'button', { name: 'Save' } );
 	await expect.element( button ).toBeVisible();
 	expect( styles.primaryAction ).not.toBe( 'style-primary-action' );
-	expect( getComputedStyle( button.element() ).color ).toBe( 'rgb(11, 22, 33)' );
 	expect( button.element().getBoundingClientRect().width ).toBe( 127 );
 } );`
 	);
@@ -483,6 +491,96 @@ test( 'reports unasserted teardown output', () => {} );`
 		/console\.error\(\) should not be used unless explicitly expected/
 	);
 	return fixture;
+}
+
+function createEmotionConsumer() {
+	const fixture = tempDirectory;
+	run(
+		process.execPath,
+		[
+			process.env.npm_execpath,
+			'install',
+			'--ignore-scripts',
+			'--no-audit',
+			'--no-fund',
+			'--package-lock=false',
+			...[
+				'@emotion/react',
+				'@swc/plugin-emotion',
+				'@vitejs/plugin-react-swc',
+			].map( ( name ) => `${ name }@${ getConsumerSpecifier( name ) }` ),
+		],
+		{ cwd: fixture }
+	);
+	// npm prunes the generated fixture when the consumer installs Emotion.
+	createBuiltStylePackage();
+	// Start with a fresh dependency graph after adding the optional transform.
+	rmSync( path.join( installedPackages, '.vite' ), {
+		recursive: true,
+		force: true,
+	} );
+	writeFileSync(
+		path.join( fixture, 'vitest-emotion.config.mjs' ),
+		`import { createRequire } from 'node:module';
+import react from '@vitejs/plugin-react-swc';
+import wordpressConfig from '@wordpress/vitest-preset-default';
+
+const require = createRequire( import.meta.url );
+
+export default {
+	...wordpressConfig,
+	plugins: [
+		react( {
+			plugins: [ [ require.resolve( '@swc/plugin-emotion' ), {
+				autoLabel: 'always',
+				labelFormat: '[local]',
+			} ] ],
+		} ),
+	],
+};`
+	);
+	writeFileSync(
+		path.join( fixture, 'emotion.test.tsx' ),
+		`import { css } from '@emotion/react';
+import { expect, test } from 'vitest';
+
+test( 'applies the consumer Emotion transform in Node', () => {
+	const nodeStyle = css( { color: 'red' } );
+	const element = <button css={ nodeStyle }>Save</button>;
+	expect( typeof document ).toBe( 'undefined' );
+	expect( element.props.children ).toBe( 'Save' );
+	expect( nodeStyle.name ).toContain( 'nodeStyle' );
+} );`
+	);
+	writeFileSync(
+		path.join( fixture, 'emotion.browser.test.jsx' ),
+		`/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { render } from 'vitest-browser-react';
+import { expect, test } from 'vitest';
+import styles from './styles.module.css';
+
+test( 'renders JSX, Emotion and CSS modules in Chromium', async () => {
+	const buttonStyle = css( { color: 'rgb(11, 22, 33)' } );
+	const screen = await render( <button className={ styles.primaryAction } css={ buttonStyle }>Save</button> );
+	const button = screen.getByRole( 'button', { name: 'Save' } );
+	await expect.element( button ).toBeVisible();
+	expect( buttonStyle.name ).toContain( 'buttonStyle' );
+	expect( styles.primaryAction ).not.toBe( 'style-primary-action' );
+	expect( getComputedStyle( button.element() ).color ).toBe( 'rgb(11, 22, 33)' );
+	expect( button.element().getBoundingClientRect().width ).toBe( 127 );
+} );`
+	);
+
+	const output = runVitest( fixture, [
+		'--config=vitest-emotion.config.mjs',
+		'--run',
+		'emotion.test.tsx',
+		'emotion.browser.test.jsx',
+		'--reporter=verbose',
+	] );
+	assert.match( output, /applies the consumer Emotion transform in Node/ );
+	assert.match( output, /renders JSX, Emotion and CSS modules in Chromium/ );
 }
 
 function createConfiguredConsumer() {
@@ -708,6 +806,7 @@ try {
 	createDefaultConsumer();
 	createConfiguredConsumer();
 	createCustomJsdomConsumer();
+	createEmotionConsumer();
 	if ( process.env.VITEST_CONSUMER_JEST ) {
 		verifyJestTooling();
 	}

--- a/test/unit/scripts/validate-vitest-package-consumer.mjs
+++ b/test/unit/scripts/validate-vitest-package-consumer.mjs
@@ -1,0 +1,724 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire( import.meta.url );
+const ROOT_DIR = path.resolve(
+	path.dirname( fileURLToPath( import.meta.url ) ),
+	'../../..'
+);
+const PACKAGES = [
+	'wp-build',
+	'style-runtime',
+	'vitest-console',
+	'vitest-preset-default',
+	...( process.env.VITEST_CONSUMER_JEST
+		? [ 'scripts', 'jest-console', 'jest-preset-default', 'eslint-plugin' ]
+		: [] ),
+];
+const tempDirectory = realpathSync(
+	mkdtempSync( path.join( tmpdir(), 'wordpress-vitest-consumer-' ) )
+);
+const stagedPackages = path.join( tempDirectory, 'staged-packages' );
+const installedPackages = path.join( tempDirectory, 'node_modules' );
+const CONSUMER_DEPENDENCIES = [
+	'@babel/core',
+	'@emotion/react',
+	'@testing-library/dom',
+	'@testing-library/jest-dom',
+	'@testing-library/react',
+	'@types/node',
+	'vitest-browser-react',
+	'vitest',
+	'vite',
+	'typescript',
+	'playwright',
+	'react',
+	'react-dom',
+];
+
+function run( command, args, options = {} ) {
+	const result = spawnSync( command, args, {
+		cwd: options.cwd ?? ROOT_DIR,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			...options.env,
+		},
+		maxBuffer: 20 * 1024 * 1024,
+	} );
+
+	if ( options.expectedStatus !== undefined ) {
+		assert.equal(
+			result.status,
+			options.expectedStatus,
+			[
+				`Expected exit status ${ options.expectedStatus }, received ${ result.status }.`,
+				result.stdout,
+				result.stderr,
+			].join( '\n' )
+		);
+	} else if ( result.status !== 0 ) {
+		throw new Error(
+			[
+				`Command failed: ${ command } ${ args.join( ' ' ) }`,
+				result.stdout,
+				result.stderr,
+			].join( '\n' )
+		);
+	}
+
+	return `${ result.stdout ?? '' }\n${ result.stderr ?? '' }`;
+}
+
+function readJson( filePath ) {
+	return JSON.parse( readFileSync( filePath, 'utf8' ) );
+}
+
+function writeJson( filePath, value ) {
+	writeFileSync( filePath, JSON.stringify( value, null, '\t' ) + '\n' );
+}
+
+function getWorkspaceVersions() {
+	return new Map(
+		readdirSync( path.join( ROOT_DIR, 'packages' ), {
+			withFileTypes: true,
+		} )
+			.filter( ( entry ) => entry.isDirectory() )
+			.map( ( entry ) =>
+				path.join( ROOT_DIR, 'packages', entry.name, 'package.json' )
+			)
+			.filter( existsSync )
+			.map( ( packageJsonPath ) => {
+				const packageJson = readJson( packageJsonPath );
+				return [ packageJson.name, packageJson.version ];
+			} )
+	);
+}
+
+function rewritePublishedDependencies( packageJson, workspaceVersions ) {
+	for ( const dependencyType of [
+		'dependencies',
+		'optionalDependencies',
+		'peerDependencies',
+	] ) {
+		for ( const [ name, specifier ] of Object.entries(
+			packageJson[ dependencyType ] ?? {}
+		) ) {
+			if ( ! specifier.startsWith( 'file:' ) ) {
+				continue;
+			}
+
+			const version = workspaceVersions.get( name );
+			assert.ok(
+				version,
+				`Unable to resolve the workspace version for ${ name }.`
+			);
+			// Lerna uses its default save prefix when it replaces local
+			// directory links immediately before publishing.
+			packageJson[ dependencyType ][ name ] = `^${ version }`;
+		}
+	}
+}
+
+function packPackage( packageName, workspaceVersions ) {
+	const sourceDirectory = path.join( ROOT_DIR, 'packages', packageName );
+	const stageDirectory = path.join( stagedPackages, packageName );
+	const tarballDirectory = path.join( tempDirectory, 'tarballs' );
+
+	cpSync( sourceDirectory, stageDirectory, { recursive: true } );
+	const packageJsonPath = path.join( stageDirectory, 'package.json' );
+	const packageJson = readJson( packageJsonPath );
+	rewritePublishedDependencies( packageJson, workspaceVersions );
+	writeJson( packageJsonPath, packageJson );
+	mkdirSync( tarballDirectory, { recursive: true } );
+
+	const output = run(
+		process.execPath,
+		[
+			process.env.npm_execpath,
+			'pack',
+			'--json',
+			'--pack-destination',
+			tarballDirectory,
+		],
+		{
+			cwd: stageDirectory,
+		}
+	);
+	const [ packed ] = JSON.parse( output.trim() );
+	const tarballPath = path.join( tarballDirectory, packed.filename );
+
+	assert.ok( existsSync( tarballPath ), `${ tarballPath } was not created.` );
+	for ( const dependencyType of [
+		'dependencies',
+		'optionalDependencies',
+		'peerDependencies',
+	] ) {
+		assert.equal(
+			Object.values( packageJson[ dependencyType ] ?? {} ).some(
+				( specifier ) => specifier.startsWith( 'file:' )
+			),
+			false,
+			`${ packageJson.name } contains a local ${ dependencyType } link.`
+		);
+	}
+
+	return { packageJson, tarballPath };
+}
+
+function getInstalledVersion( packageName ) {
+	return readJson( require.resolve( `${ packageName }/package.json` ) )
+		.version;
+}
+
+function getConsumerSpecifier( packageName ) {
+	const version = getInstalledVersion( packageName );
+
+	if ( packageName === 'vite' ) {
+		return process.env.VITEST_CONSUMER_VITE ?? version;
+	}
+	if ( packageName === 'typescript' ) {
+		return `npm:@typescript/typescript6@${ version }`;
+	}
+
+	return version;
+}
+
+function assertIsolatedResolution( isolatedRequire, packageName ) {
+	const resolvedPath = isolatedRequire.resolve(
+		`${ packageName }/package.json`
+	);
+	const relativePath = path.relative(
+		realpathSync( installedPackages ),
+		realpathSync( resolvedPath )
+	);
+
+	assert.equal(
+		path.isAbsolute( relativePath ) ||
+			relativePath === '..' ||
+			relativePath.startsWith( `..${ path.sep }` ),
+		false,
+		`${ packageName } resolved outside the isolated install: ${ resolvedPath }`
+	);
+}
+
+function installPackedPackages( packedPackages ) {
+	writeJson( path.join( tempDirectory, 'package.json' ), {
+		name: 'wordpress-vitest-packed-consumer',
+		private: true,
+		type: 'module',
+		dependencies: Object.fromEntries( [
+			...Array.from( packedPackages.values(), ( packedPackage ) => [
+				packedPackage.packageJson.name,
+				`file:${ packedPackage.tarballPath }`,
+			] ),
+			...CONSUMER_DEPENDENCIES.map( ( packageName ) => [
+				packageName,
+				getConsumerSpecifier( packageName ),
+			] ),
+		] ),
+	} );
+
+	run(
+		process.execPath,
+		[
+			process.env.npm_execpath,
+			'install',
+			'--ignore-scripts',
+			'--no-audit',
+			'--no-fund',
+			'--package-lock=false',
+		],
+		{
+			cwd: tempDirectory,
+			env: {
+				PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
+			},
+		}
+	);
+
+	const isolatedRequire = createRequire(
+		path.join( tempDirectory, 'package.json' )
+	);
+	for ( const packageName of [
+		...Array.from(
+			packedPackages.values(),
+			( packedPackage ) => packedPackage.packageJson.name
+		),
+		...CONSUMER_DEPENDENCIES,
+		'vite',
+		'vitest',
+	] ) {
+		assertIsolatedResolution( isolatedRequire, packageName );
+	}
+
+	// The staged source includes package self-tests which are intentionally not
+	// part of the published tarballs. Remove it before consumer test discovery.
+	rmSync( stagedPackages, { force: true, recursive: true } );
+}
+
+function runVitest( fixture, args, options = {} ) {
+	return run(
+		process.execPath,
+		[ path.join( installedPackages, 'vitest/vitest.mjs' ), ...args ],
+		{
+			cwd: fixture,
+			expectedStatus: options.expectedStatus,
+		}
+	);
+}
+
+function createBuiltStylePackage() {
+	const packageDirectory = path.join(
+		tempDirectory,
+		'packages/test-style-fixture'
+	);
+	const sourceDirectory = path.join( packageDirectory, 'src' );
+
+	mkdirSync( sourceDirectory, { recursive: true } );
+	writeJson( path.join( packageDirectory, 'package.json' ), {
+		name: '@wordpress/test-style-fixture',
+		version: '1.0.0',
+		type: 'module',
+		main: 'build/index.cjs',
+		module: 'build-module/index.mjs',
+	} );
+	writeFileSync(
+		path.join( sourceDirectory, 'index.js' ),
+		`import styles from './style.module.css';
+import './ordinary.css';
+
+export default styles;
+`
+	);
+	writeFileSync(
+		path.join( sourceDirectory, 'style.module.css' ),
+		`@layer wp-build-test {
+	.fixture {
+		--wp-build-style-injection-test: true;
+		color: var(--fixture-color, rgb(1, 2, 3));
+	}
+}
+`
+	);
+
+	writeFileSync(
+		path.join( sourceDirectory, 'ordinary.css' ),
+		`.ordinary-fixture { background-color: rgb(4, 5, 6); }`
+	);
+	run(
+		process.execPath,
+		[ path.join( installedPackages, '@wordpress/build/lib/build.mjs' ) ],
+		{ cwd: tempDirectory }
+	);
+
+	const installedFixture = path.join(
+		installedPackages,
+		'@wordpress/test-style-fixture'
+	);
+	cpSync( packageDirectory, installedFixture, { recursive: true } );
+	cpSync(
+		path.join( installedFixture, 'build-module/index.mjs' ),
+		path.join( installedFixture, 'build-module/duplicate.mjs' )
+	);
+	assert.ok(
+		existsSync( path.join( installedFixture, 'build-module/index.mjs' ) ),
+		'wp-build did not create the style fixture module.'
+	);
+}
+
+function createDefaultConsumer() {
+	const fixture = tempDirectory;
+	writeFileSync(
+		path.join( fixture, 'vitest.config.mjs' ),
+		`export { default } from '@wordpress/vitest-preset-default';`
+	);
+	writeFileSync(
+		path.join( fixture, 'default.test.tsx' ),
+		`import { css } from '@emotion/react';
+import { expect, test } from 'vitest';
+import builtStyles from '@wordpress/test-style-fixture';
+import styles from './styles.module.css';
+
+test( 'uses Node and native transforms by default', () => {
+\tconst count: number = 2;
+\tconst nodeStyle = css( { color: 'red' } );
+\tconst element = <button css={ nodeStyle }>Save { count }</button>;
+
+\texpect( typeof document ).toBe( 'undefined' );
+\texpect( styles.primaryAction ).toBe( 'style-primary-action' );
+\texpect( builtStyles.fixture ).toBeTruthy();
+\texpect( element.props.children ).toEqual( [ 'Save ', 2 ] );
+\texpect( nodeStyle.name ).toMatch( /nodeStyle/ );
+\texpect( globalThis.SCRIPT_DEBUG ).toBe( true );
+\tconsole.warn( 'expected warning' );
+\texpect( console ).toHaveWarnedWith( 'expected warning' );
+} );
+`
+	);
+	writeFileSync(
+		path.join( fixture, 'styles.module.css' ),
+		'.primaryAction { width: 127px; }'
+	);
+	writeFileSync(
+		path.join( fixture, 'environment.jsdom.test.js' ),
+		`import { expect, test } from 'vitest';
+import builtStyles from '@wordpress/test-style-fixture';
+import styles from './styles.module.css';
+
+test( 'selects jsdom and the stylesheet mock by filename', () => {
+\texpect( styles.primaryAction ).toBe( 'style-primary-action' );
+\texpect( document ).toBeDefined();
+\texpect( window.matchMedia ).toBeUndefined();
+\texpect( window.requestIdleCallback ).toBeUndefined();
+\texpect( builtStyles.fixture ).toBeTruthy();
+\texpect( document.head.textContent ).not.toContain( 'ordinary-fixture' );
+\texpect( document.head.textContent ).not.toContain(
+\t\t'--wp-build-style-injection-test'
+\t);
+} );
+`
+	);
+	writeFileSync(
+		path.join( fixture, 'values.browser.test.js' ),
+		`import { expect, test } from 'vitest';
+import styles from '@wordpress/test-style-fixture';
+
+test( 'uses real CSS and native browser values', async () => {
+\tconst element = document.createElement( 'div' );
+\telement.className = styles.fixture + ' ordinary-fixture';
+\tdocument.body.append( element );
+\tawait new Promise( requestAnimationFrame );
+
+\texpect( getComputedStyle( element ).color ).toBe( 'rgb(1, 2, 3)' );
+\texpect( getComputedStyle( element ).backgroundColor ).toBe( 'rgb(4, 5, 6)' );
+\texpect( typeof process ).toBe( 'undefined' );
+\texpect( typeof ResizeObserver ).toBe( 'function' );
+\texpect( CSS.supports( 'display', 'grid' ) ).toBe( true );
+\texpect( window.matchMedia( '(min-width: 1px)' ).matches ).toBe( true );
+\telement.style.setProperty( '--fixture-color', 'rgb(7, 8, 9)' );
+\texpect( getComputedStyle( element ).color ).toBe( 'rgb(7, 8, 9)' );
+\tconst injectedStyles = document.head.querySelectorAll( 'style[data-wp-hash]' ).length;
+\texpect( injectedStyles ).toBe( 2 );
+\tawait import( '@wordpress/test-style-fixture/build-module/duplicate.mjs' );
+\texpect( document.head.querySelectorAll( 'style[data-wp-hash]' ).length ).toBe( injectedStyles );
+\tconsole.warn( 'browser warning' );
+\tawait expect( Promise.resolve( console ) ).resolves.toHaveWarnedWith( 'browser warning' );
+\telement.remove();
+} );
+`
+	);
+
+	writeFileSync(
+		path.join( fixture, 'emotion.browser.test.jsx' ),
+		`/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { render } from 'vitest-browser-react';
+import { expect, test } from 'vitest';
+import styles from './styles.module.css';
+
+test( 'renders JSX, Emotion and CSS modules in Chromium', async () => {
+	const buttonStyle = css( { color: 'rgb(11, 22, 33)' } );
+	const screen = await render( <button className={ styles.primaryAction } css={ buttonStyle }>Save</button> );
+	const button = screen.getByRole( 'button', { name: 'Save' } );
+	await expect.element( button ).toBeVisible();
+	expect( styles.primaryAction ).not.toBe( 'style-primary-action' );
+	expect( getComputedStyle( button.element() ).color ).toBe( 'rgb(11, 22, 33)' );
+	expect( button.element().getBoundingClientRect().width ).toBe( 127 );
+} );`
+	);
+
+	const output = runVitest( fixture, [ '--run', '--reporter=verbose' ] );
+	assert.match( output, /uses Node and native transforms by default/ );
+	assert.match( output, /selects jsdom and the stylesheet mock by filename/ );
+	assert.match( output, /uses real CSS and native browser values/ );
+
+	writeFileSync(
+		path.join( fixture, 'failure.test.js' ),
+		`import { expect, test } from 'vitest';
+
+test( 'shows useful failure output', () => {
+\texpect( 'actual' ).toBe( 'expected' );
+} );
+`
+	);
+	const failureOutput = runVitest(
+		fixture,
+		[ '--run', 'failure.test.js', '--project=node', '--reporter=verbose' ],
+		{ expectedStatus: 1 }
+	);
+	assert.match( failureOutput, /failure\.test\.js/ );
+	assert.match( failureOutput, /expected/ );
+	assert.match( failureOutput, /actual/ );
+
+	writeFileSync(
+		path.join( fixture, 'console-failure.test.js' ),
+		`import { afterEach, test } from 'vitest';
+afterEach( () => console.error( 'unexpected teardown error' ) );
+test( 'reports unasserted teardown output', () => {} );`
+	);
+	const consoleFailure = runVitest(
+		fixture,
+		[ '--run', 'console-failure.test.js', '--project=node' ],
+		{ expectedStatus: 1 }
+	);
+	assert.match( consoleFailure, /unexpected teardown error/ );
+	assert.match(
+		consoleFailure,
+		/console\.error\(\) should not be used unless explicitly expected/
+	);
+	return fixture;
+}
+
+function createConfiguredConsumer() {
+	const fixture = tempDirectory;
+	writeFileSync(
+		path.join( fixture, 'vitest.config.mjs' ),
+		`import wordpressConfig from '@wordpress/vitest-preset-default';
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+export default mergeConfig(
+\twordpressConfig,
+\tdefineConfig( {
+\t\ttest: {
+\t\t\tsetupFiles: [ './setup.js' ],
+\t\t},
+\t} )
+);
+`
+	);
+	writeFileSync(
+		path.join( fixture, 'setup.js' ),
+		`import '@testing-library/jest-dom/vitest';
+globalThis.consumerSetup = true;
+import { cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, expect, vi } from 'vitest';
+
+expect( globalThis.SCRIPT_DEBUG ).toBe( true );
+beforeEach( () => vi.useFakeTimers() );
+afterEach( cleanup );
+`
+	);
+	writeFileSync(
+		path.join( fixture, 'custom.jsdom.test.jsx' ),
+		`import { render, screen } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+
+test( 'keeps Testing Library in a discovered consumer config', () => {
+\trender( <button>Save</button> );
+
+\texpect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeInTheDocument();
+\texpect( globalThis.SCRIPT_DEBUG ).toBe( true );
+\texpect( globalThis.consumerSetup ).toBe( true );
+\texpect( vi.isFakeTimers() ).toBe( true );
+\tconsole.info( 'configured warning' );
+\texpect( console ).toHaveInformedWith( 'configured warning' );
+} );
+`
+	);
+	writeFileSync(
+		path.join( fixture, 'types-check.ts' ),
+		`import '@wordpress/vitest-console';
+import { expect } from 'vitest';
+import config from '@wordpress/vitest-preset-default';
+import type { UserConfig } from 'vite';
+
+const typedConfig: UserConfig = config;
+void typedConfig;
+const sync: void = expect( console ).toHaveWarnedWith( 'typed warning' );
+const negated: void = expect( console ).not.toHaveErrored();
+const resolved: Promise<void> = expect( Promise.resolve( console ) ).resolves.toHaveLogged();
+const rejected: Promise<void> = expect( Promise.reject( console ) ).rejects.toHaveInformedWith( 'info' );
+const polled: Promise<void> = expect.poll( () => console ).toHaveWarned();
+// @ts-expect-error synchronous matchers do not return a promise
+const invalidAsync: Promise<void> = expect( console ).toHaveLoggedWith( 'log' );
+// @ts-expect-error asynchronous matchers do not return void
+const invalidSync: void = expect( Promise.resolve( console ) ).resolves.toHaveErroredWith( 'error' );
+void [ sync, negated, resolved, rejected, polled, invalidAsync, invalidSync ];
+`
+	);
+	writeJson( path.join( fixture, 'tsconfig.json' ), {
+		compilerOptions: {
+			lib: [ 'DOM', 'ES2022' ],
+			module: 'NodeNext',
+			moduleResolution: 'NodeNext',
+			noEmit: true,
+			strict: true,
+			target: 'ES2022',
+		},
+		include: [ 'types-check.ts' ],
+	} );
+
+	const output = runVitest( fixture, [
+		'--run',
+		'--project=jsdom',
+		'--reporter=verbose',
+	] );
+	assert.match(
+		output,
+		/keeps Testing Library in a discovered consumer config/
+	);
+	run(
+		process.execPath,
+		[
+			path.join( installedPackages, 'typescript/bin/tsc6' ),
+			'--project',
+			path.join( fixture, 'tsconfig.json' ),
+		],
+		{ cwd: fixture }
+	);
+}
+
+function createCustomJsdomConsumer() {
+	const fixture = tempDirectory;
+	writeFileSync(
+		path.join( fixture, 'vitest-custom.config.mjs' ),
+		`import { defineConfig } from 'vitest/config';
+
+
+
+export default defineConfig( {
+	test: {
+		environment: 'jsdom',
+		globals: false,
+		include: [ 'custom-style.jsdom.test.js' ],
+	},
+} );
+`
+	);
+	writeFileSync(
+		path.join( fixture, 'custom-style.jsdom.test.js' ),
+		`import { expect, test } from 'vitest';
+import builtStyles from '@wordpress/test-style-fixture';
+
+test( 'keeps generated style injection disabled in a custom jsdom setup', () => {
+
+	expect( builtStyles.fixture ).toBeTruthy();
+	expect( document.head.textContent ).not.toContain( 'ordinary-fixture' );
+	expect( document.head.textContent ).not.toContain(
+		'--wp-build-style-injection-test'
+	);
+} );
+`
+	);
+
+	const output = runVitest( fixture, [
+		'--config=vitest-custom.config.mjs',
+		'--run',
+		'--reporter=verbose',
+	] );
+	assert.match(
+		output,
+		/keeps generated style injection disabled in a custom jsdom setup/
+	);
+}
+
+function verifyJestTooling() {
+	const fixture = path.join( tempDirectory, 'jest-consumer' );
+	mkdirSync( fixture );
+	writeJson( path.join( fixture, 'package.json' ), {
+		private: true,
+		type: 'commonjs',
+	} );
+	writeFileSync(
+		path.join( fixture, 'legacy.test.js' ),
+		`test( 'keeps the Jest runner, DOM, JSX and console matchers', () => {
+	const button = <button>Save</button>;
+	expect( button.props.children ).toBe( 'Save' );
+	expect( document.createElement( 'button' ).tagName ).toBe( 'BUTTON' );
+	expect( jest.fn() ).not.toHaveBeenCalled();
+	console.warn( 'legacy warning' );
+	expect( console ).toHaveWarnedWith( 'legacy warning' );
+} );`
+	);
+	const output = run(
+		process.execPath,
+		[
+			path.join(
+				installedPackages,
+				'@wordpress/scripts/bin/wp-scripts.js'
+			),
+			'test-unit-js',
+			'--runInBand',
+			'--watch=false',
+		],
+		{ cwd: fixture }
+	);
+	assert.match( output, /1 passed/ );
+	const isolatedRequire = createRequire(
+		path.join( tempDirectory, 'package.json' )
+	);
+	const lintConfig = isolatedRequire( '@wordpress/eslint-plugin' ).configs[
+		'test-unit'
+	];
+	const rules = lintConfig.flatMap( ( config ) =>
+		Object.keys( config.rules ?? {} )
+	);
+	assert.ok( rules.includes( 'jest/expect-expect' ) );
+	assert.ok( ! rules.some( ( name ) => name.startsWith( 'vitest/' ) ) );
+}
+
+try {
+	assert.ok(
+		process.env.npm_execpath,
+		'Run this validator through npm so npm_execpath is available.'
+	);
+	mkdirSync( stagedPackages, { recursive: true } );
+	const workspaceVersions = getWorkspaceVersions();
+	const packedPackages = new Map(
+		PACKAGES.map( ( packageName ) => [
+			packageName,
+			packPackage( packageName, workspaceVersions ),
+		] )
+	);
+
+	assert.equal(
+		packedPackages.get( 'vitest-console' ).packageJson.exports[ '.' ].types,
+		'./index.d.ts'
+	);
+	assert.equal(
+		packedPackages.get( 'vitest-preset-default' ).packageJson.type,
+		'module'
+	);
+	assert.equal(
+		packedPackages.get( 'vitest-preset-default' ).packageJson.exports[
+			'./setup-test-framework'
+		],
+		'./scripts/setup-test-framework.js'
+	);
+
+	installPackedPackages( packedPackages );
+	createBuiltStylePackage();
+
+	createDefaultConsumer();
+	createConfiguredConsumer();
+	createCustomJsdomConsumer();
+	if ( process.env.VITEST_CONSUMER_JEST ) {
+		verifyJestTooling();
+	}
+
+	console.log(
+		'Validated packed @wordpress/build, @wordpress/style-runtime, @wordpress/vitest-console, @wordpress/vitest-preset-default consumer fixtures.'
+	);
+} finally {
+	if ( process.env.VITEST_CONSUMER_KEEP ) {
+		console.log( tempDirectory );
+	} else {
+		rmSync( tempDirectory, { force: true, recursive: true } );
+	}
+}


### PR DESCRIPTION
Part of #80855. Follows #82761 and uses the build guard merged in #82154.

## What?

Add `@wordpress/vitest-console` and `@wordpress/vitest-preset-default` for Vitest 5, with public exports, matcher types, package registration, changelogs and migration guidance. Prepare their additive release.

## Why?

The replacement packages must ship and pass consumer verification before released tooling adopts them. Existing Jest packages, Jest lint defaults and `wp-scripts test-unit-js` remain available.

## How?

The preset uses Node by default, filename-selected jsdom and Chromium projects, explicit imports and isolated tests. Node/jsdom use CSS proxies; Browser Mode loads real styles and preserves native browser APIs. Consumer setup runs after preset setup. Plain React JSX works without Emotion installed. Consumers install and configure the Emotion transform explicitly on Vite 7 and 8.

Add isolated packed-consumer checks and a separate public Node/Vite CI matrix. The existing repository test matrix is unchanged.

## Testing Instructions

1. Build packages, then run `npm run --workspace @wordpress/unit-tests test:unit:vitest:packages`.
2. Set `VITEST_CONSUMER_VITE=7.3.6` to check Vite 7. Set `VITEST_CONSUMER_JEST=1` on Node 24 to include the unchanged packed Jest tooling.
3. Follow the new preset README in a consumer. Ordinary tests should use Node, `*.jsdom.test.*` should use jsdom, and `*.browser.test.*` should use Chromium with real styles.

<details>
<summary>Verification and release notes</summary>

- Packed consumers passed on Node 22.12.0, 24.20.0 and 26.8.2 with Vite 7.3.6 and 8.2.2.
- Coverage includes plain JSX without Emotion installed, consumer-configured Emotion, synchronous and asynchronous matcher types, setup inheritance, failure output, native browser values, CSS proxies, and both rebuilt CSS-module and regular-CSS output, including token fallbacks and deduplication.
- Package tests passed 39 tests. Existing Jest package checks passed 34 tests; the packed Jest command and public Jest lint defaults also passed.
- Full build, typecheck, relevant lint, package contents, dependency checks, routing and conventions passed.
- The isolated new-package install has zero security advisories. The repository audit remains at 47, unchanged from base `351883676c6`: 5 low, 27 moderate and 15 high.
- Vitest 5.0.0's `vitest/config` declaration entry references the undeclared `@vitest/expect` package. The documented `.mjs` config works; this preset's public types use `vite` and `vitest/node` and compile without that retired package.
- Rebased once onto #82761 at `351883676c606bdefc0a8b4fd140833511ec03c1`.

</details>

### Testing Instructions for Keyboard

Not applicable; this changes test tooling.

## Follow-ups

Publish and verify `@wordpress/vitest-console`, then `@wordpress/vitest-preset-default`, before adopting them in released public tooling. The packages use the repository's `1.0.0-prerelease` convention until release processing.

Published `@wordpress/build@0.23.0` contains the required guard. Rebuild affected generated CSS with that version or later. No additional build-fix PR is planned. Publishing these packages does not require switching `wp-scripts` or removing Jest.

## Use of AI Tools

Codex implemented the changes, ran verification and performed an independent review.
