### PR TITLE
CI: Scope the required trunk changes refresh to what a move can invalidate

### DIFF
--- a/.github/workflows/required-changes-from-trunk.yml
+++ b/.github/workflows/required-changes-from-trunk.yml
@@ -6,6 +6,9 @@ on:
         branches: [trunk]
     push:
         branches: [trunk]
+    schedule:
+        # Daily at 04:23 UTC, to stamp the pull requests nothing else reaches.
+        - cron: '23 4 * * *'
     workflow_dispatch:
         inputs:
             mode:
@@ -128,3 +131,44 @@ jobs:
               with:
                   name: required-trunk-changes-refresh-${{ github.run_id }}
                   path: ${{ steps.refresh.outputs.results-file }}
+
+    backfill:
+        name: Stamp the pull requests that have no status yet
+        # Every run Dependabot triggers gets a read-only token, so its pull requests
+        # are never stamped by their own events. This is what reaches them.
+        if: >
+            github.repository == 'WordPress/gutenberg' &&
+            github.event.schedule == '23 4 * * *'
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
+        permissions:
+            contents: read
+            statuses: write
+            pull-requests: read
+        # Shares the refresh's group: a backfill that read the baseline before a
+        # move would otherwise write a pass the move had already invalidated.
+        concurrency:
+            group: required-trunk-changes-refresh
+            cancel-in-progress: false
+            queue: max
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+              with:
+                  ref: trunk
+                  fetch-depth: 0
+                  filter: tree:0
+                  persist-credentials: false
+
+            - name: Stamp the unstamped pull requests
+              uses: mawesomedev/pr-baseline-action@cc4d934b8c7c8cd2fd965d8334849d8108321ab3 # v0.2.0
+              with:
+                  base: trunk
+                  baselines: ${{ env.PR_BASELINES }}
+                  status-context: ${{ env.STATUS_CONTEXT }}
+                  description-pass: ${{ env.DESCRIPTION_PASS }}
+                  description-fail: ${{ env.DESCRIPTION_FAIL }}
+                  mode: refresh-pr-statuses
+                  scope: unstamped
+                  # Well below the ceiling: a backfill must not starve the refresh.
+                  max-writes-per-run: 150

--- a/.github/workflows/required-changes-from-trunk.yml
+++ b/.github/workflows/required-changes-from-trunk.yml
@@ -2,7 +2,7 @@ name: Required changes from trunk
 
 on:
     pull_request_target:
-        types: [opened, synchronize, reopened, ready_for_review, edited, closed]
+        types: [opened, synchronize, reopened, ready_for_review, edited]
         branches: [trunk]
     push:
         branches: [trunk]
@@ -13,6 +13,11 @@ on:
                 type: choice
                 default: auto
                 options: [auto, move-baseline, refresh-pr-statuses]
+            scope:
+                description: 'Which open pull requests refresh-pr-statuses covers: corrections is the ones showing green, unstamped is the ones with no status yet, all is every one of them. The other modes pick their own.'
+                type: choice
+                default: corrections
+                options: [corrections, unstamped, all]
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -31,7 +36,7 @@ jobs:
         name: Report required trunk changes status
         if: >
             github.repository == 'WordPress/gutenberg' &&
-            github.event_name == 'pull_request_target' && github.event.action != 'closed'
+            github.event_name == 'pull_request_target'
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:
@@ -44,7 +49,7 @@ jobs:
             # The head SHA comes from the event. PR code is never checked out,
             # built, or executed.
             - name: Report the status for this pull request
-              uses: mawesomedev/pr-baseline-action@8c21a09691ccfdf5ea118cb60cee8ec8b99231a1 # v0.1.1
+              uses: mawesomedev/pr-baseline-action@cc4d934b8c7c8cd2fd965d8334849d8108321ab3 # v0.2.0
               with:
                   base: trunk
                   baselines: ${{ env.PR_BASELINES }}
@@ -54,13 +59,10 @@ jobs:
 
     refresh-pr-statuses:
         name: Move the required trunk baseline and refresh statuses
-        # The baseline moves only through explicit intent: a merged pull request
-        # carrying the label, or a dispatch with mode move-baseline. Every trunk
-        # push recovers a move whose own run was lost, and continues a refresh
-        # that stopped on its write budget.
+        # Every trunk push is the recovery path: it moves a baseline whose own
+        # run was lost, and continues a refresh that stopped on its write cap.
         if: >
             github.repository == 'WordPress/gutenberg' && (
-                (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged) ||
                 (github.event_name == 'push' && github.ref_name == 'trunk') ||
                 github.event_name == 'workflow_dispatch'
             )
@@ -87,21 +89,42 @@ jobs:
                   filter: tree:0
                   persist-credentials: false
 
-            - name: Move the baseline and refresh open pull requests
-              id: pr-baseline
-              uses: mawesomedev/pr-baseline-action@8c21a09691ccfdf5ea118cb60cee8ec8b99231a1 # v0.1.1
+            # Moves only. The refresh below runs whether or not this moved
+            # anything, since a move that hits its write cap spills into later runs.
+            - name: Move the baseline
+              # An unforced move still moves when a labeled merge earned it, which
+              # is not what a maintainer asking for a refresh asked for.
+              if: ${{ inputs.mode != 'refresh-pr-statuses' }}
+              uses: mawesomedev/pr-baseline-action@cc4d934b8c7c8cd2fd965d8334849d8108321ab3 # v0.2.0
+              with:
+                  base: trunk
+                  baselines: ${{ env.PR_BASELINES }}
+                  status-context: ${{ env.STATUS_CONTEXT }}
+                  mode: move-baseline
+                  force: ${{ inputs.mode == 'move-baseline' }}
+                  refresh-pr-statuses-after-move: false
+
+            - name: Refresh the pull requests a move can invalidate
+              id: refresh
+              uses: mawesomedev/pr-baseline-action@cc4d934b8c7c8cd2fd965d8334849d8108321ab3 # v0.2.0
               with:
                   base: trunk
                   baselines: ${{ env.PR_BASELINES }}
                   status-context: ${{ env.STATUS_CONTEXT }}
                   description-pass: ${{ env.DESCRIPTION_PASS }}
                   description-fail: ${{ env.DESCRIPTION_FAIL }}
-                  mode: ${{ inputs.mode || 'auto' }}
-                  force: ${{ inputs.mode == 'move-baseline' }}
+                  mode: refresh-pr-statuses
+                  # A forced move can put the baseline anywhere, so it can turn a
+                  # failing pull request green, which only a full sweep sees. A scope
+                  # that skips the green ones is safe only when nothing moved.
+                  scope: ${{ inputs.mode == 'move-baseline' && 'all' || inputs.mode == 'refresh-pr-statuses' && inputs.scope || 'corrections' }}
+                  # Leaves headroom in the hourly write budget the whole repository
+                  # shares; later pushes continue a run that stops here.
+                  max-writes-per-run: 300
 
             - name: Upload the per-pull-request results
-              if: ${{ always() && steps.pr-baseline.outputs.results-file != '' }}
+              if: ${{ !cancelled() && steps.refresh.outputs.results-file != '' && (failure() || steps.refresh.outputs.written != '0') }}
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
-                  name: required-trunk-changes-refresh
-                  path: ${{ steps.pr-baseline.outputs.results-file }}
+                  name: required-trunk-changes-refresh-${{ github.run_id }}
+                  path: ${{ steps.refresh.outputs.results-file }}

--- a/docs/contributors/code/required-changes-from-trunk.md
+++ b/docs/contributors/code/required-changes-from-trunk.md
@@ -4,22 +4,22 @@ The `Required changes from trunk` status check ensures open pull requests contai
 
 ## How it works
 
-A movable git ref, `refs/baselines/required-trunk-changes`, points at the last `trunk` commit that every open pull request must contain. The check passes when that commit is an ancestor of the pull request head, and fails otherwise. While the ref does not exist, nothing is required and every pull request passes.
+A movable git ref, `refs/baselines/required-trunk-changes`, points at the last `trunk` commit that every open pull request must contain. The check passes when that commit is an ancestor of the pull request head, and fails otherwise. While the ref does not exist, nothing is required, and a pull request passes as soon as anything stamps it. Statuses written before it went missing stay as they are until a refresh at `scope: all` revisits them.
 
 The baseline moves only through explicit maintainer intent, in one of two ways:
 
 -   Merging a pull request that carries the `Require PR update` label, or
 -   Dispatching the `Required changes from trunk` workflow with `mode: move-baseline`.
 
-When the baseline moves, every open pull request is restamped with the verdict it now warrants.
+When the baseline moves, every open pull request ends up showing the verdict it now warrants.
 
 The ref lives outside `refs/heads/` and `refs/tags/` on purpose: nothing fetches it unless asked, so a move never disturbs a `git pull`, starts no workflow, and no branch cleanup tool removes it. `git ls-remote origin 'refs/baselines/*'` shows where it points.
 
 ## Limits
 
--   Each run writes at most 450 statuses. A run that stops on that budget, or on a rate limit, exits nonzero and says so; the next `trunk` push, or a dispatch, continues where it left off.
--   A pull request that never received a status shows as "Expected", which also blocks merging. The next refresh or its own next update gives it a real one.
--   A pull request whose head moves while a refresh is running is deferred to the next one rather than stamped at a stale head.
+-   Each refresh writes at most 300 statuses. A move rewrites the pull requests showing green, so a large one takes a few `trunk` pushes to land: a run that stops on that budget says so, and the next `trunk` push, or a dispatch, continues where it left off.
+-   A pull request that never received a status shows as "Expected", which also blocks merging. Its own next update gives it a real one, except on a Dependabot pull request: every run Dependabot triggers gets a read-only token, so those wait for a dispatch with `mode: refresh-pr-statuses` and `scope: unstamped`.
+-   A pull request whose head moves while a refresh is running is deferred rather than stamped at a stale head. The push that moved it reports its own status.
 
 ## My pull request has a red "Required changes from trunk" status. What do I do?
 
@@ -38,16 +38,20 @@ Committers apply the `Require PR update` label to a pull request whose change in
 
 The `Required changes from trunk` workflow exposes a `mode` dispatch input: `auto` behaves like a `trunk` push, moving the baseline only if a labeled merge earned it and then refreshing, `move-baseline` forces a move to the current `trunk` HEAD and then refreshes, and `refresh-pr-statuses` only refreshes open pull request statuses, which is the retry path after an interrupted run.
 
+A `scope` input picks which open pull requests `mode: refresh-pr-statuses` covers: `corrections` visits the ones showing green, the only ones a forward move can turn red; `unstamped` visits the ones carrying no status yet; and `all` visits every open pull request. The other two modes pick their own scope, `corrections` for `auto` and `all` for `move-baseline`.
+
+Moving the baseline backwards is the exception. It can turn a failing pull request green, so it refreshes at scope `all`, which a `trunk` push does not continue. Re-dispatch with `mode: refresh-pr-statuses` and `scope: all` until a run ends green with nothing remaining. A run that deferred or failed a pull request still reports it as accounted for, so it can say nothing remains while being red.
+
 ### Initial setup
 
 The workflow blocks nothing until these one-time steps are completed, in order:
 
 1. Create the `Require PR update` label.
-2. Let a refresh run with no baseline ref. Every open pull request receives a pass, which proves the token and permissions before anything can block.
+2. Let a refresh run with no baseline ref: dispatch with `mode: refresh-pr-statuses` and `scope: unstamped`. The passes it writes prove the token and permissions before anything can block. It stops on its write budget long before it reaches every pull request, which step 4 finishes.
 3. Seed the baseline: dispatch the workflow with `mode: move-baseline`, which seeds it at the current `trunk` HEAD. To seed at an earlier commit, push that commit to the ref directly: `git push origin <sha>:refs/baselines/required-trunk-changes`.
-4. Re-dispatch with `mode: refresh-pr-statuses` until a run reports no writes, so that no pull request is left unstamped.
+4. Re-dispatch with `mode: refresh-pr-statuses` and `scope: all` until a run ends green with nothing remaining. Step 3 writes nothing when it seeds the ref by direct push, so the passes from step 2 have to be revisited too, not only the pull requests still carrying no status.
 5. Ask a repository admin to add the `Required changes from trunk` commit status (source: GitHub Actions) to the trunk ruleset's required status checks.
 
-Rulesets cannot cover `refs/baselines/`, so anyone with write access can move or delete the ref; the tooling itself only ever fast-forwards it. To roll the check back, remove `Required changes from trunk` from the required status checks; existing statuses become informational immediately.
+Rulesets cannot cover `refs/baselines/`, so anyone with write access can move or delete the ref. The tooling only ever fast-forwards it, apart from a forced move, which is also how a baseline left pointing off `trunk` is repaired; in that state the refresh passes the pull requests it reaches rather than blocking them, and the statuses already written stay until it reaches them. To roll the check back, remove `Required changes from trunk` from the required status checks; existing statuses become informational immediately.
 
 The workflow lives in `.github/workflows/required-changes-from-trunk.yml` and runs the [`pr-baseline` action](https://github.com/marketplace/actions/pr-baseline), whose [documentation](https://github.com/mawesomedev/mawesome/tree/main/packages/pr-baseline/docs) covers permissions, rate limits and edge cases in full.

--- a/docs/contributors/code/required-changes-from-trunk.md
+++ b/docs/contributors/code/required-changes-from-trunk.md
@@ -18,7 +18,7 @@ The ref lives outside `refs/heads/` and `refs/tags/` on purpose: nothing fetches
 ## Limits
 
 -   Each refresh writes at most 300 statuses. A move rewrites the pull requests showing green, so a large one takes a few `trunk` pushes to land: a run that stops on that budget says so, and the next `trunk` push, or a dispatch, continues where it left off.
--   A pull request that never received a status shows as "Expected", which also blocks merging. Its own next update gives it a real one, except on a Dependabot pull request: every run Dependabot triggers gets a read-only token, so those wait for a dispatch with `mode: refresh-pr-statuses` and `scope: unstamped`.
+-   A pull request that never received a status shows as "Expected", which also blocks merging. Its own next update gives it a real one, except on a Dependabot pull request: every run Dependabot triggers gets a read-only token, so those wait for the daily backfill, which stamps whatever still carries no status.
 -   A pull request whose head moves while a refresh is running is deferred rather than stamped at a stale head. The push that moved it reports its own status.
 
 ## My pull request has a red "Required changes from trunk" status. What do I do?
@@ -38,7 +38,7 @@ Committers apply the `Require PR update` label to a pull request whose change in
 
 The `Required changes from trunk` workflow exposes a `mode` dispatch input: `auto` behaves like a `trunk` push, moving the baseline only if a labeled merge earned it and then refreshing, `move-baseline` forces a move to the current `trunk` HEAD and then refreshes, and `refresh-pr-statuses` only refreshes open pull request statuses, which is the retry path after an interrupted run.
 
-A `scope` input picks which open pull requests `mode: refresh-pr-statuses` covers: `corrections` visits the ones showing green, the only ones a forward move can turn red; `unstamped` visits the ones carrying no status yet; and `all` visits every open pull request. The other two modes pick their own scope, `corrections` for `auto` and `all` for `move-baseline`.
+A `scope` input picks which open pull requests `mode: refresh-pr-statuses` covers: `corrections` visits the ones showing green, the only ones a forward move can turn red; `unstamped` visits the ones carrying no status yet, which is what the daily backfill runs; and `all` visits every open pull request. The other two modes pick their own scope, `corrections` for `auto` and `all` for `move-baseline`.
 
 Moving the baseline backwards is the exception. It can turn a failing pull request green, so it refreshes at scope `all`, which a `trunk` push does not continue. Re-dispatch with `mode: refresh-pr-statuses` and `scope: all` until a run ends green with nothing remaining. A run that deferred or failed a pull request still reports it as accounted for, so it can say nothing remains while being red.
 


### PR DESCRIPTION
## What?

Follow up to #82725, which put this repository on [`mawesomedev/pr-baseline-action`](https://github.com/marketplace/actions/pr-baseline). That landed the mechanism; this tunes it for 2,400 open pull requests. The refresh now visits only the pull requests a baseline move can invalidate, a run that hits its write cap is no longer a red run, and a merge stops doing the same work twice.

## Why?

Measured on 2026-09-11. Of the 2,421 open pull requests, 52 show a passing status. A forward baseline move can only turn a passing status into a failing one, so the other 2,369 need no visit at all: the refresh has been fetching 2,421 heads to correct at most 52 of them.

It does that 82 times a day, once per `trunk` push and again per merged pull request, at about 7 minutes of runner time each, and almost always writes one status. One run in three ends red, not because anything is wrong but because a single pull request was mid-push when the scan reached it.

The move itself, the event this check exists for, is the case that works worst. The move of 2026-09-10 needed 638 writes, hit the cap at 450, and [ended red](https://github.com/WordPress/gutenberg/actions/runs/34499035061) waiting for a maintainer to dispatch [the rest](https://github.com/WordPress/gutenberg/actions/runs/34503126631).

## How?

`scope: corrections`, new in `v0.2.0`, selects from the pull request listing before any head is fetched, so the head fetch drops from 2,421 to 52 and the window for a mid-push deferral shrinks with it. A run that stops on its cap now reports `paused` and stays green, and the next `trunk` push continues it.

`closed` leaves the `pull_request_target` types. Merging fires `push` on `trunk` in the same second and both events matched the job, which is the second scan per merge.

Moving and refreshing become separate steps. `v0.2.0` skips a push's refresh when no baseline ref changed, which is right for `mode: auto` but would leave a capped run with nothing to continue it. A dispatch asking only to refresh skips the move step, and a forced move refreshes at `all`, since it can put the baseline anywhere and so turn a failing pull request green.

The refresh needs no schedule, since `trunk` sees 41 pushes a day. One job does: a daily `scope: unstamped` backfill, because every run Dependabot triggers gets a read-only token, so those pull requests never stamp themselves and would sit at "Expected" indefinitely.

## Testing Instructions

1. Push to `trunk` with no labeled merge: the move step reports the baseline unchanged and the refresh visits the passing pull requests, writing nothing.
2. Merge a pull request carrying `Require PR update`: the move step moves the baseline, the refresh turns up to 300 passing pull requests red and ends green, and the next pushes finish the rest.
3. Dispatch with `mode: refresh-pr-statuses` and `scope: all`: every open pull request is revisited, and the baseline does not move.
4. Dispatch with `scope: unstamped`, which is what the daily backfill runs: any pull request carrying no status gets one.

## Use of AI Tools

Claude Code for writing code and Codex for reviewing it.

