### PR TITLE
Query Loop: Add alphabetical pagination

### DIFF
--- a/docs/reference-guides/core-blocks/README.md
+++ b/docs/reference-guides/core-blocks/README.md
@@ -773,7 +773,7 @@ An advanced block that allows displaying post types based on different query par
 -	**Name:** [core/query](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/core-block-query/)
 -	**Category:** [theme](https://developer.wordpress.org/block-editor/reference-guides/core-blocks/core-blocks-theme/)
 -	**Supports:** align (full, wide), anchor, interactivity, layout, spacing (blockGap), ~~html~~
--	**Attributes:** enhancedPagination, namespace, query, queryId, tagName
+-	**Attributes:** enhancedPagination, namespace, query, queryId, tagName, useAlphabeticalPagination
 
 ## No Results
 

--- a/packages/block-library/src/post-template/README.md
+++ b/packages/block-library/src/post-template/README.md
@@ -55,6 +55,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `enhancedPagination`
 - `postType`
 - `postId`
+- `useAlphabeticalPagination`
 
 ## Block Markup
 

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -15,7 +15,8 @@
 		"previewPostType",
 		"enhancedPagination",
 		"postType",
-		"postId"
+		"postId",
+		"useAlphabeticalPagination"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/query-no-results/README.md
+++ b/packages/block-library/src/query-no-results/README.md
@@ -47,6 +47,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 
 - `queryId`
 - `query`
+- `useAlphabeticalPagination`
 
 ## Block Markup
 

--- a/packages/block-library/src/query-no-results/block.json
+++ b/packages/block-library/src/query-no-results/block.json
@@ -7,7 +7,7 @@
 	"description": "Contains the block elements used to render content when no query results are found.",
 	"ancestor": [ "core/query" ],
 	"textdomain": "default",
-	"usesContext": [ "queryId", "query" ],
+	"usesContext": [ "queryId", "query", "useAlphabeticalPagination" ],
 	"supports": {
 		"anchor": true,
 		"align": true,

--- a/packages/block-library/src/query-pagination-next/README.md
+++ b/packages/block-library/src/query-pagination-next/README.md
@@ -48,6 +48,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `paginationArrow`
 - `showLabel`
 - `enhancedPagination`
+- `useAlphabeticalPagination`
 
 ## Block Markup
 

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -17,7 +17,8 @@
 		"query",
 		"paginationArrow",
 		"showLabel",
-		"enhancedPagination"
+		"enhancedPagination",
+		"useAlphabeticalPagination"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/query-pagination-numbers/README.md
+++ b/packages/block-library/src/query-pagination-numbers/README.md
@@ -46,6 +46,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `queryId`
 - `query`
 - `enhancedPagination`
+- `useAlphabeticalPagination`
 
 ## Block Markup
 

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -13,7 +13,12 @@
 			"default": 2
 		}
 	},
-	"usesContext": [ "queryId", "query", "enhancedPagination" ],
+	"usesContext": [
+		"queryId",
+		"query",
+		"enhancedPagination",
+		"useAlphabeticalPagination"
+	],
 	"supports": {
 		"anchor": true,
 		"reusable": false,

--- a/packages/block-library/src/query-pagination-numbers/edit.jsx
+++ b/packages/block-library/src/query-pagination-numbers/edit.jsx
@@ -40,15 +40,37 @@ const previewPaginationNumbers = ( midSize ) => {
 	return <>{ paginationItems }</>;
 };
 
+/*
+ * On the front end the letters are derived from the titles the query actually
+ * matches, which the editor cannot know without running the query. Previewing
+ * the full alphabet keeps this in line with the synthetic page numbers above,
+ * and shows how much room the widest case takes up.
+ */
+const previewPaginationLetters = () => (
+	<>
+		{ createPaginationItem( __( 'All' ), 'span', 'current' ) }
+		{ 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+			.split( '' )
+			.map( ( letter ) => createPaginationItem( letter ) ) }
+	</>
+);
+
 export default function QueryPaginationNumbersEdit( {
 	attributes,
 	setAttributes,
+	context: { useAlphabeticalPagination },
 } ) {
 	const { midSize } = attributes;
-	const paginationNumbers = previewPaginationNumbers(
-		parseInt( midSize, 10 )
-	);
+	const paginationNumbers = useAlphabeticalPagination
+		? previewPaginationLetters()
+		: previewPaginationNumbers( parseInt( midSize, 10 ) );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const blockProps = useBlockProps();
+
+	// "Number of links" has no meaning when the block renders letters.
+	if ( useAlphabeticalPagination ) {
+		return <div { ...blockProps }>{ paginationNumbers }</div>;
+	}
 
 	return (
 		<>
@@ -82,7 +104,7 @@ export default function QueryPaginationNumbersEdit( {
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
-			<div { ...useBlockProps() }>{ paginationNumbers }</div>
+			<div { ...blockProps }>{ paginationNumbers }</div>
 		</>
 	);
 }

--- a/packages/block-library/src/query-pagination-numbers/index.php
+++ b/packages/block-library/src/query-pagination-numbers/index.php
@@ -6,6 +6,341 @@
  */
 
 /**
+ * Returns the query string key holding the selected letter of a Query Loop block.
+ *
+ * Mirrors the `query-{queryId}-page` convention of the pagination blocks so that
+ * several Query Loop blocks on one page stay independent of each other.
+ *
+ * @since 7.2.0
+ *
+ * @param WP_Block $block Block instance.
+ *
+ * @return string Returns the query string key.
+ */
+function block_core_query_pagination_numbers_get_letter_key( $block ) {
+	return isset( $block->context['queryId'] )
+		? 'query-' . $block->context['queryId'] . '-letter'
+		: 'query-letter';
+}
+
+/**
+ * Returns the letter currently selected for a Query Loop block, if any.
+ *
+ * @since 7.2.0
+ *
+ * @param WP_Block $block Block instance.
+ *
+ * @return string Returns the selected letter, or an empty string.
+ */
+function block_core_query_pagination_numbers_get_selected_letter( $block ) {
+	$letter_key = block_core_query_pagination_numbers_get_letter_key( $block );
+
+	if ( empty( $_GET[ $letter_key ] ) || ! is_string( $_GET[ $letter_key ] ) ) {
+		return '';
+	}
+
+	return sanitize_text_field( wp_unslash( $_GET[ $letter_key ] ) );
+}
+
+/**
+ * Returns the first letters that the posts matching a query actually start with.
+ *
+ * The alphabet is derived from the post titles rather than hardcoded, so a site
+ * in any locale gets a usable set of letters without configuration. Titles that
+ * do not start with a letter, such as "3M", are collected under a single "#".
+ *
+ * Both this and `block_core_query_pagination_numbers_filter_posts_where()` run
+ * under the collation of the posts table, so the letters offered and the posts
+ * matched always agree.
+ *
+ * @since 7.2.0
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param array $args Query vars as built by `build_query_vars_from_query_block()`.
+ *
+ * @return array Returns a list of buckets, each with a `label` string and the
+ *               `chars` it matches.
+ */
+function block_core_query_pagination_numbers_get_initials( $args ) {
+	global $wpdb;
+
+	// The letters describe the unfiltered result set.
+	unset( $args['query_loop_title_initials'] );
+
+	/*
+	 * Look at every matching post, not just the current page. `nopaging` makes
+	 * WP_Query drop the LIMIT clause, which also makes it ignore `offset`.
+	 */
+	$args['posts_per_page']         = -1;
+	$args['nopaging']               = true;
+	$args['paged']                  = 1;
+	$args['offset']                 = 0;
+	$args['no_found_rows']          = true;
+	$args['ignore_sticky_posts']    = true;
+	$args['update_post_meta_cache'] = false;
+	$args['update_post_term_cache'] = false;
+	$args['fields']                 = 'ids';
+
+	$cache_key = 'title_initials_' . md5( wp_json_encode( $args ) ) . ':' . wp_cache_get_last_changed( 'posts' );
+	$cached    = wp_cache_get( $cache_key, 'query-block' );
+	if ( false !== $cached ) {
+		return $cached;
+	}
+
+	$rows = array();
+
+	/*
+	 * Rewrite the query into a single `SELECT DISTINCT` of first characters.
+	 * Going through WP_Query keeps every other part of it - post type, status,
+	 * taxonomies, author, search - identical to what the loop itself renders,
+	 * without loading a single post.
+	 */
+	$select_initial  = static function () use ( $wpdb ) {
+		return "UPPER( LEFT( {$wpdb->posts}.post_title, 1 ) )";
+	};
+	$select_distinct = static function () {
+		return 'DISTINCT';
+	};
+	$select_nothing  = static function () {
+		return '';
+	};
+	$capture_rows    = static function ( $posts, $query ) use ( &$rows, $wpdb ) {
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Assembled by WP_Query itself.
+		$rows = $wpdb->get_col( $query->request );
+		// Returning an array short-circuits WP_Query's own execution.
+		return array();
+	};
+
+	add_filter( 'posts_fields', $select_initial, 99 );
+	add_filter( 'posts_distinct', $select_distinct, 99 );
+	add_filter( 'posts_groupby', $select_nothing, 99 );
+	add_filter( 'posts_orderby', $select_nothing, 99 );
+	add_filter( 'posts_pre_query', $capture_rows, 99, 2 );
+
+	new WP_Query( $args );
+
+	remove_filter( 'posts_fields', $select_initial, 99 );
+	remove_filter( 'posts_distinct', $select_distinct, 99 );
+	remove_filter( 'posts_groupby', $select_nothing, 99 );
+	remove_filter( 'posts_orderby', $select_nothing, 99 );
+	remove_filter( 'posts_pre_query', $capture_rows, 99 );
+
+	$letters     = array();
+	$non_letters = array();
+	foreach ( $rows as $initial ) {
+		if ( ! is_string( $initial ) || '' === $initial ) {
+			continue;
+		}
+		if ( preg_match( '/^\p{L}/u', $initial ) ) {
+			// Keyed to drop duplicates that the collation considers distinct.
+			$letters[ $initial ] = $initial;
+		} else {
+			$non_letters[ $initial ] = $initial;
+		}
+	}
+
+	$letters = array_values( $letters );
+	block_core_query_pagination_numbers_sort_initials( $letters );
+
+	$buckets = array();
+	if ( ! empty( $non_letters ) ) {
+		$buckets[] = array(
+			'label' => '#',
+			'chars' => array_values( $non_letters ),
+		);
+	}
+	foreach ( $letters as $letter ) {
+		$buckets[] = array(
+			'label' => $letter,
+			'chars' => array( $letter ),
+		);
+	}
+
+	wp_cache_set( $cache_key, $buckets, 'query-block' );
+
+	return $buckets;
+}
+
+/**
+ * Sorts a list of letters in the order of the current locale.
+ *
+ * @since 7.2.0
+ *
+ * @param array $initials List of single characters, sorted in place.
+ */
+function block_core_query_pagination_numbers_sort_initials( &$initials ) {
+	if ( class_exists( 'Collator' ) ) {
+		try {
+			$collator = new Collator( get_locale() );
+			$collator->sort( $initials );
+			return;
+		} catch ( Exception $e ) {
+			// Fall through to the code point order below.
+			unset( $e );
+		}
+	}
+
+	// Code point order, which is correct within a single script.
+	sort( $initials, SORT_STRING );
+}
+
+/**
+ * Filters the Query Loop block query vars by the letter selected in the URL.
+ *
+ * Applying this at the query var level means the post list, the result count and
+ * the page count all agree, because each of those blocks builds its query with
+ * `build_query_vars_from_query_block()`.
+ *
+ * The selected letter is validated against the letters actually present, so a
+ * hand-crafted URL cannot select anything a rendered link could not have.
+ *
+ * @since 7.2.0
+ *
+ * @param array    $query The current query vars.
+ * @param WP_Block $block The block instance.
+ *
+ * @return array Returns the modified query vars.
+ */
+function block_core_query_pagination_numbers_filter_query_vars( $query, $block ) {
+	if ( empty( $block->context['useAlphabeticalPagination'] ) ) {
+		return $query;
+	}
+
+	$selected = block_core_query_pagination_numbers_get_selected_letter( $block );
+	if ( '' === $selected ) {
+		return $query;
+	}
+
+	foreach ( block_core_query_pagination_numbers_get_initials( $query ) as $bucket ) {
+		if ( $bucket['label'] === $selected ) {
+			$query['query_loop_title_initials'] = $bucket['chars'];
+			break;
+		}
+	}
+
+	return $query;
+}
+
+add_filter( 'query_loop_block_query_vars', 'block_core_query_pagination_numbers_filter_query_vars', 10, 2 );
+
+/**
+ * Restricts a query to posts whose title starts with one of the given characters.
+ *
+ * WP_Query has no "title starts with" argument, so the characters travel as a
+ * custom query var that this turns into SQL. Queries without the var are left
+ * untouched.
+ *
+ * @since 7.2.0
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param string   $where The WHERE clause of the query.
+ * @param WP_Query $query The WP_Query instance.
+ *
+ * @return string Returns the modified WHERE clause.
+ */
+function block_core_query_pagination_numbers_filter_posts_where( $where, $query ) {
+	global $wpdb;
+
+	$initials = $query->get( 'query_loop_title_initials' );
+	if ( empty( $initials ) || ! is_array( $initials ) ) {
+		return $where;
+	}
+
+	$clauses = array();
+	foreach ( $initials as $initial ) {
+		if ( ! is_string( $initial ) || '' === $initial ) {
+			continue;
+		}
+		$clauses[] = $wpdb->prepare(
+			"{$wpdb->posts}.post_title LIKE %s",
+			$wpdb->esc_like( $initial ) . '%'
+		);
+	}
+
+	if ( empty( $clauses ) ) {
+		return $where;
+	}
+
+	return $where . ' AND ( ' . implode( ' OR ', $clauses ) . ' )';
+}
+
+add_filter( 'posts_where', 'block_core_query_pagination_numbers_filter_posts_where', 10, 2 );
+
+/**
+ * Renders the letters of an alphabetically paginated Query Loop block.
+ *
+ * Picking a letter resets the query to its first page. The Previous and Next
+ * blocks then page within the selected letter, because they build their links
+ * from the current URL and so carry the letter over.
+ *
+ * @since 7.2.0
+ *
+ * @param WP_Block $block    Block instance.
+ * @param string   $page_key Query string key holding the current page.
+ *
+ * @return string Returns the pagination letters for the Query, or an empty string.
+ */
+function block_core_query_pagination_numbers_render_letters( $block, $page_key ) {
+	$letter_key = block_core_query_pagination_numbers_get_letter_key( $block );
+	$selected   = block_core_query_pagination_numbers_get_selected_letter( $block );
+
+	$buckets = block_core_query_pagination_numbers_get_initials( build_query_vars_from_query_block( $block, 1 ) );
+	if ( empty( $buckets ) ) {
+		return '';
+	}
+
+	// Dropping the page key sends every letter back to the first page.
+	$base_url = remove_query_arg( array( $letter_key, $page_key ) );
+
+	$items = array();
+	if ( '' === $selected ) {
+		$items[] = sprintf(
+			'<span class="page-numbers current" aria-current="page">%s</span>',
+			esc_html__( 'All' )
+		);
+	} else {
+		$items[] = sprintf(
+			'<a class="page-numbers" href="%1$s">%2$s</a>',
+			esc_url( $base_url ),
+			esc_html__( 'All' )
+		);
+	}
+
+	foreach ( $buckets as $bucket ) {
+		$label = $bucket['label'];
+
+		if ( $label === $selected ) {
+			$items[] = sprintf(
+				'<span class="page-numbers current" aria-current="page">%s</span>',
+				esc_html( $label )
+			);
+			continue;
+		}
+
+		if ( '#' === $label ) {
+			$aria_label = __( 'Titles starting with a number or symbol' );
+		} else {
+			$aria_label = sprintf(
+				/* translators: %s: The first letter of a post title. */
+				__( 'Titles starting with %s' ),
+				$label
+			);
+		}
+
+		$items[] = sprintf(
+			'<a class="page-numbers" href="%1$s" aria-label="%2$s">%3$s</a>',
+			esc_url( add_query_arg( $letter_key, rawurlencode( $label ), $base_url ) ),
+			esc_attr( $aria_label ),
+			esc_html( $label )
+		);
+	}
+
+	return implode( "\n", $items );
+}
+
+/**
  * Renders the `core/query-pagination-numbers` block on the server.
  *
  * @since 5.8.0
@@ -23,12 +358,22 @@ function render_block_core_query_pagination_numbers( $attributes, $content, $blo
 	$enhanced_pagination = (bool) ( $block->context['enhancedPagination'] ?? false );
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 	$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
+	$is_inherited        = isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'];
 
 	$wrapper_attributes = get_block_wrapper_attributes();
 	$content            = '';
 	global $wp_query;
 	$mid_size = isset( $block->attributes['midSize'] ) ? (int) $block->attributes['midSize'] : null;
-	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
+
+	/*
+	 * Alphabetical pagination needs to filter the query, which is only possible
+	 * for custom queries: an inherited query is the global one, already run.
+	 */
+	$use_letters = ! $is_inherited && ! empty( $block->context['useAlphabeticalPagination'] );
+
+	if ( $use_letters ) {
+		$content = block_core_query_pagination_numbers_render_letters( $block, $page_key );
+	} elseif ( $is_inherited ) {
 		// Take into account if we have set a bigger `max page`
 		// than what the query has.
 		$total         = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;

--- a/packages/block-library/src/query-pagination-previous/README.md
+++ b/packages/block-library/src/query-pagination-previous/README.md
@@ -48,6 +48,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `paginationArrow`
 - `showLabel`
 - `enhancedPagination`
+- `useAlphabeticalPagination`
 
 ## Block Markup
 

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -17,7 +17,8 @@
 		"query",
 		"paginationArrow",
 		"showLabel",
-		"enhancedPagination"
+		"enhancedPagination",
+		"useAlphabeticalPagination"
 	],
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/query-total/README.md
+++ b/packages/block-library/src/query-total/README.md
@@ -47,6 +47,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 
 - `queryId`
 - `query`
+- `useAlphabeticalPagination`
 
 ## Block Markup
 

--- a/packages/block-library/src/query-total/block.json
+++ b/packages/block-library/src/query-total/block.json
@@ -13,7 +13,7 @@
 			"default": "total-results"
 		}
 	},
-	"usesContext": [ "queryId", "query" ],
+	"usesContext": [ "queryId", "query", "useAlphabeticalPagination" ],
 	"supports": {
 		"anchor": true,
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/query/README.md
+++ b/packages/block-library/src/query/README.md
@@ -20,6 +20,7 @@ _Defined via the [`attributes`](https://developer.wordpress.org/block-editor/ref
 | `tagName` | `string` | `"div"` | — |
 | `namespace` | `string` | — | — |
 | `enhancedPagination` | `boolean` | `false` | — |
+| `useAlphabeticalPagination` | `boolean` | `false` | — |
 
 ## Supports
 
@@ -48,6 +49,7 @@ _Defined via the [`usesContext` and `providesContext`](https://developer.wordpre
 - `query` → attribute `query`
 - `displayLayout` → attribute `displayLayout`
 - `enhancedPagination` → attribute `enhancedPagination`
+- `useAlphabeticalPagination` → attribute `useAlphabeticalPagination`
 
 ## Block Markup
 

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -41,6 +41,10 @@
 		"enhancedPagination": {
 			"type": "boolean",
 			"default": false
+		},
+		"useAlphabeticalPagination": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "templateSlug", "postType" ],
@@ -48,7 +52,8 @@
 		"queryId": "queryId",
 		"query": "query",
 		"displayLayout": "displayLayout",
-		"enhancedPagination": "enhancedPagination"
+		"enhancedPagination": "enhancedPagination",
+		"useAlphabeticalPagination": "useAlphabeticalPagination"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/query/edit/inspector-controls/index.jsx
+++ b/packages/block-library/src/query/edit/inspector-controls/index.jsx
@@ -34,9 +34,14 @@ import {
 import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 
 export default function QueryInspectorControls( props ) {
-	const { attributes, setQuery, isSingular, shouldExcludeCurrentPost } =
-		props;
-	const { query } = attributes;
+	const {
+		attributes,
+		setAttributes,
+		setQuery,
+		isSingular,
+		shouldExcludeCurrentPost,
+	} = props;
+	const { query, useAlphabeticalPagination } = attributes;
 	const {
 		order,
 		orderBy,
@@ -131,11 +136,36 @@ export default function QueryInspectorControls( props ) {
 		! inherit &&
 		showSticky &&
 		isControlAllowed( allowedControls, 'sticky' );
+	/*
+	 * Letters only line up with the list when it is sorted by title, and the
+	 * query has to be a custom one: an inherited query is the global query,
+	 * which the block cannot filter.
+	 */
+	const showAlphabeticalPaginationControl =
+		! inherit &&
+		orderBy === 'title' &&
+		isControlAllowed( allowedControls, 'useAlphabeticalPagination' );
+	const setAlphabeticalPagination = ( value ) => {
+		if ( !! useAlphabeticalPagination !== value ) {
+			setAttributes( { useAlphabeticalPagination: value } );
+		}
+	};
+	/*
+	 * Letters are meaningless once the list is no longer sorted by title, so
+	 * they are turned off rather than left on with the control out of sight.
+	 */
+	const onOrderChange = ( value ) => {
+		setQuery( value );
+		if ( value.orderBy !== 'title' ) {
+			setAlphabeticalPagination( false );
+		}
+	};
 	const showSettingsPanel =
 		showInheritControl ||
 		showPostTypeControl ||
 		showOrderControl ||
-		showStickyControl;
+		showStickyControl ||
+		showAlphabeticalPaginationControl;
 	const showTaxControl =
 		!! taxonomies?.length &&
 		isControlAllowed( allowedControls, 'taxQuery' );
@@ -214,6 +244,7 @@ export default function QueryInspectorControls( props ) {
 							sticky: '',
 							inherit: true,
 						} );
+						setAlphabeticalPagination( false );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
@@ -310,14 +341,15 @@ export default function QueryInspectorControls( props ) {
 								order !== 'desc' || orderBy !== 'date'
 							}
 							label={ __( 'Order by' ) }
-							onDeselect={ () =>
-								setQuery( { order: 'desc', orderBy: 'date' } )
-							}
+							onDeselect={ () => {
+								setQuery( { order: 'desc', orderBy: 'date' } );
+								setAlphabeticalPagination( false );
+							} }
 							isShownByDefault
 						>
 							<OrderControl
 								{ ...{ order, orderBy, orderByOptions } }
-								onChange={ setQuery }
+								onChange={ onOrderChange }
 							/>
 						</ToolsPanelItem>
 					) }
@@ -334,6 +366,25 @@ export default function QueryInspectorControls( props ) {
 								onChange={ ( value ) =>
 									setQuery( { sticky: value } )
 								}
+							/>
+						</ToolsPanelItem>
+					) }
+
+					{ showAlphabeticalPaginationControl && (
+						<ToolsPanelItem
+							hasValue={ () => !! useAlphabeticalPagination }
+							label={ __( 'Alphabetical pagination' ) }
+							onDeselect={ () =>
+								setAlphabeticalPagination( false )
+							}
+						>
+							<ToggleControl
+								label={ __( 'Alphabetical pagination' ) }
+								help={ __(
+									'Show letters instead of page numbers. Visitors filter the list by the first letter of each title.'
+								) }
+								checked={ !! useAlphabeticalPagination }
+								onChange={ setAlphabeticalPagination }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/phpunit/blocks/render-query-alphabetical-pagination-test.php
+++ b/phpunit/blocks/render-query-alphabetical-pagination-test.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Tests for alphabetical pagination in the `core/query` block.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests deriving the letters of a Query Loop block and filtering it by one.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderQueryAlphabeticalPagination extends WP_UnitTestCase {
+
+	/**
+	 * Post type used to keep these tests isolated from any other content.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'test_glossary';
+
+	/**
+	 * Created post IDs, keyed by post title.
+	 *
+	 * @var array
+	 */
+	private $post_ids = array();
+
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'public'   => true,
+				'label'    => 'Glossary',
+				'supports' => array( 'title', 'editor' ),
+			)
+		);
+
+		foreach ( array( 'Apple', 'Avocado', 'Banana', '3M' ) as $title ) {
+			$this->post_ids[ $title ] = self::factory()->post->create(
+				array(
+					'post_title'  => $title,
+					'post_type'   => self::POST_TYPE,
+					'post_status' => 'publish',
+				)
+			);
+		}
+	}
+
+	public function tear_down() {
+		unset( $_GET['query-0-letter'], $_GET['query-0-page'] );
+		unregister_post_type( self::POST_TYPE );
+		$this->post_ids = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Returns the query vars describing every post created for a test.
+	 *
+	 * @param array $extra Additional query vars.
+	 * @return array Query vars.
+	 */
+	private function get_query_args( $extra = array() ) {
+		return array_merge(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_status' => 'publish',
+				'post__in'    => array_values( $this->post_ids ),
+				'fields'      => 'ids',
+			),
+			$extra
+		);
+	}
+
+	/**
+	 * Renders a Query Loop block with alphabetical pagination turned on.
+	 *
+	 * @return string Rendered block output.
+	 */
+	private function render_query() {
+		$post_type = self::POST_TYPE;
+
+		$content = <<<HTML
+		<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"$post_type","order":"asc","orderBy":"title","inherit":false},"useAlphabeticalPagination":true} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template -->
+				<!-- wp:post-title /-->
+			<!-- /wp:post-template -->
+			<!-- wp:query-total {"displayType":"total-results"} /-->
+			<!-- wp:query-pagination -->
+				<!-- wp:query-pagination-numbers /-->
+			<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:query -->
+HTML;
+
+		return do_blocks( $content );
+	}
+
+	/**
+	 * The letters come from the post titles, with non-letters grouped under "#".
+	 */
+	public function test_initials_are_derived_from_post_titles() {
+		// The build system prefixes block functions, so tests call the built name.
+		$buckets = gutenberg_block_core_query_pagination_numbers_get_initials( $this->get_query_args() );
+
+		$this->assertSame( array( '#', 'A', 'B' ), wp_list_pluck( $buckets, 'label' ) );
+		$this->assertSame( array( '3' ), $buckets[0]['chars'] );
+		$this->assertSame( array( 'A' ), $buckets[1]['chars'] );
+	}
+
+	/**
+	 * The custom query var restricts a query to titles starting with a letter.
+	 */
+	public function test_posts_where_filters_by_initial() {
+		$query = new WP_Query(
+			$this->get_query_args(
+				array(
+					'query_loop_title_initials' => array( 'A' ),
+					'orderby'                   => 'title',
+					'order'                     => 'ASC',
+				)
+			)
+		);
+
+		$this->assertSame(
+			array( $this->post_ids['Apple'], $this->post_ids['Avocado'] ),
+			$query->posts
+		);
+	}
+
+	/**
+	 * The "#" bucket matches only the characters it was derived from.
+	 */
+	public function test_posts_where_filters_by_the_non_letter_bucket() {
+		$query = new WP_Query(
+			$this->get_query_args( array( 'query_loop_title_initials' => array( '3' ) ) )
+		);
+
+		$this->assertSame( array( $this->post_ids['3M'] ), $query->posts );
+	}
+
+	/**
+	 * A query that does not carry the query var is left untouched.
+	 */
+	public function test_posts_where_is_a_no_op_without_the_query_var() {
+		$query = new WP_Query( $this->get_query_args() );
+
+		$this->assertCount( 4, $query->posts );
+	}
+
+	/**
+	 * Rendering the block lists every derived letter alongside an "All" link.
+	 */
+	public function test_rendering_lists_the_derived_letters() {
+		$output = $this->render_query();
+
+		$processor = new WP_HTML_Tag_Processor( $output );
+		$labels    = array();
+		while ( $processor->next_tag( array( 'class_name' => 'page-numbers' ) ) ) {
+			$labels[] = $processor->get_attribute( 'aria-label' );
+		}
+
+		// "All" is current, so it renders as a span without an aria-label.
+		$this->assertSame(
+			array(
+				null,
+				'Titles starting with a number or symbol',
+				'Titles starting with A',
+				'Titles starting with B',
+			),
+			$labels
+		);
+	}
+
+	/**
+	 * Selecting a letter filters the posts, the count, and marks it current.
+	 */
+	public function test_selecting_a_letter_filters_the_query() {
+		$_GET['query-0-letter'] = 'B';
+
+		$output = $this->render_query();
+
+		$this->assertStringContainsString( 'Banana', $output );
+		$this->assertStringNotContainsString( 'Apple', $output );
+		$this->assertStringNotContainsString( 'Avocado', $output );
+		$this->assertStringContainsString( '1 result found', $output );
+		$this->assertStringContainsString(
+			'<span class="page-numbers current" aria-current="page">B</span>',
+			$output
+		);
+	}
+
+	/**
+	 * The "#" bucket selects the titles that do not start with a letter.
+	 */
+	public function test_selecting_the_non_letter_bucket_filters_the_query() {
+		$_GET['query-0-letter'] = '#';
+
+		$output = $this->render_query();
+
+		$this->assertStringContainsString( '3M', $output );
+		$this->assertStringNotContainsString( 'Apple', $output );
+		$this->assertStringContainsString( '1 result found', $output );
+	}
+
+	/**
+	 * A letter no post starts with is ignored rather than filtering everything out.
+	 */
+	public function test_an_unknown_letter_is_ignored() {
+		$_GET['query-0-letter'] = 'Z';
+
+		$output = $this->render_query();
+
+		$this->assertStringContainsString( 'Apple', $output );
+		$this->assertStringContainsString( '4 results found', $output );
+	}
+
+	/**
+	 * A crafted value cannot reach the SQL that builds the WHERE clause.
+	 */
+	public function test_a_crafted_letter_is_ignored() {
+		$_GET['query-0-letter'] = "%' OR 1=1 --";
+
+		$output = $this->render_query();
+
+		$this->assertStringContainsString( 'Apple', $output );
+		$this->assertStringContainsString( '4 results found', $output );
+	}
+}


### PR DESCRIPTION
## What?
Closes #67421

Adds an "Alphabetical pagination" option to the Query Loop block. When it's on, the Page Numbers block shows the first letters of the titles in the query instead of page numbers, and picking a letter filters the list to titles starting with it.

## Why?
Sites that use the Query Loop for glossaries, documentation indexes, or catalogs have no way to let visitors jump to entries by letter. A 400-term glossary becomes 40 numbered pages with nothing to go on.

The issue raised two open challenges, and this PR addresses both:

- **Different locales use different letters.** Nothing is hardcoded. The letters come from the titles the query actually matches, so Latin, Cyrillic, Greek, and other scripts work without configuration, and letters with no posts never appear.
- **Combining letters with standard pagination.** The Previous and Next blocks page *within* the selected letter, so a letter with more posts than fit on one page is still fully reachable.

This follows **Option A** from the issue: the toggle lives on the Query Loop block and appears once the query is sorted by title.

## Testing Instructions
1. Create several published posts with varied titles, for example: Alpha, Apricot, Almond, Anise, Banana, Cherry, 3M, Zucchini.
2. Create a new page and insert a Query Loop block. Use a pattern that includes pagination, or add a Pagination block inside the loop.
3. In the block's Settings panel, set **Query type** to **Custom** and **Order by** to **A → Z**.
4. Open the Settings panel's options menu (⋮) and enable **Alphabetical pagination**, then turn the toggle on.
5. Confirm the Page Numbers preview in the canvas changes to `All A B C … Z`, and that selecting the Page Numbers block no longer shows "Number of links".
6. Change **Order by** to "Newest to oldest". The toggle disappears and the preview goes back to numbers. Switch back to **A → Z**; the toggle is now off.
7. Turn it back on, then set **Items per page** to 2 in the Display panel.
8. Save the page and view it on the front end:
   - The letters match your titles: `All # A B C Z`.
   - Clicking **A** shows only the A titles, the result count updates, and **A** is marked current.
   - **Next Page** goes to the second page of A titles, and the URL keeps `query-N-letter=A`.
   - **#** shows only "3M".
   - **All** clears the filter.
9. In the Query Loop's **Advanced** panel, turn **Reload full page** off. Clicking letters now updates the list without a full page reload.
10. Check that a Query Loop without the option still shows standard page numbers.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/c5ffeae6-a5dd-4b0d-9d06-23124cf5f845

## Use of AI Tools
This PR was helped with Claude Opus 5.