### PR TITLE
UI: Fix highlighted item indicator in forced-colors mode

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
--   `Autocomplete`, `Combobox`, `Menu`, and `Select`: Restore the highlighted item indicator in forced-colors mode, which wp-admin's global CSS was suppressing. ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX))
+-   `Autocomplete`, `Combobox`, `Menu`, and `Select`: Restore the highlighted item indicator in forced-colors mode, which wp-admin's global CSS was suppressing. ([#82772](https://github.com/WordPress/gutenberg/pull/82772))
 
 ### Internal
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `Checkbox`: Enlarge the hit target to 24px without changing the visual size. ([#82597](https://github.com/WordPress/gutenberg/pull/82597))
 
+### Bug Fixes
+
+-   `Autocomplete`, `Combobox`, `Menu`, and `Select`: Restore the highlighted item indicator in forced-colors mode, which wp-admin's global CSS was suppressing. ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX))
+
 ### Internal
 
 -   Run UI interaction tests in Vitest Browser Mode ([#80995](https://github.com/WordPress/gutenberg/pull/80995)).

--- a/packages/ui/src/form/primitives/autocomplete/item.tsx
+++ b/packages/ui/src/form/primitives/autocomplete/item.tsx
@@ -1,6 +1,7 @@
 import { Autocomplete as _Autocomplete } from '@base-ui/react/autocomplete';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
+import defenseStyles from '../../../utils/css/global-css-defense.module.css';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import resetStyles from '../../../utils/css/resets.module.css';
 import type { AutocompleteItemProps } from './types';
@@ -10,6 +11,7 @@ export const Item = forwardRef< HTMLDivElement, AutocompleteItemProps >(
 		return (
 			<_Autocomplete.Item
 				className={ clsx(
+					defenseStyles.div,
 					resetStyles[ 'box-sizing' ],
 					itemPopupStyles.item,
 					className

--- a/packages/ui/src/form/primitives/combobox/item.tsx
+++ b/packages/ui/src/form/primitives/combobox/item.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { check, plus } from '@wordpress/icons';
 import { Icon } from '../../../icon';
+import defenseStyles from '../../../utils/css/global-css-defense.module.css';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import resetStyles from '../../../utils/css/resets.module.css';
 import type { ComboboxItemProps } from './types';
@@ -15,6 +16,7 @@ export const Item = forwardRef< HTMLDivElement, ComboboxItemProps >(
 		return (
 			<_Combobox.Item
 				className={ clsx(
+					defenseStyles.div,
 					resetStyles[ 'box-sizing' ],
 					itemPopupStyles.item,
 					className

--- a/packages/ui/src/form/primitives/select/item.tsx
+++ b/packages/ui/src/form/primitives/select/item.tsx
@@ -2,6 +2,7 @@ import { Select as _Select } from '@base-ui/react/select';
 import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { check } from '@wordpress/icons';
+import defenseStyles from '../../../utils/css/global-css-defense.module.css';
 import itemPopupStyles from '../../../utils/css/item-popup.module.css';
 import resetStyles from '../../../utils/css/resets.module.css';
 import { Icon } from '../../../icon';
@@ -15,6 +16,7 @@ export const Item = forwardRef< HTMLDivElement, SelectItemProps >(
 		return (
 			<_Select.Item
 				className={ clsx(
+					defenseStyles.div,
 					resetStyles[ 'box-sizing' ],
 					itemPopupStyles.item,
 					size === 'small' && itemPopupStyles[ 'is-size-small' ],

--- a/packages/ui/src/menu/checkbox-item.tsx
+++ b/packages/ui/src/menu/checkbox-item.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { check } from '@wordpress/icons';
 import { Icon } from '../icon';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
 import { MenuItemContentContext } from './context';
@@ -46,6 +47,7 @@ const CheckboxItem = forwardRef< HTMLDivElement, CheckboxItemProps >(
 				ref={ ref }
 				{ ...itemAriaProps }
 				className={ clsx(
+					defenseStyles.div,
 					resetStyles[ 'box-sizing' ],
 					styles.item,
 					className

--- a/packages/ui/src/menu/item.tsx
+++ b/packages/ui/src/menu/item.tsx
@@ -8,6 +8,7 @@ import {
 	useId,
 } from '@wordpress/element';
 import type { ReactElement } from 'react';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
 import resetStyles from '../utils/css/resets.module.css';
 import {
 	KeyboardShortcutDescription,
@@ -237,6 +238,7 @@ const Item = forwardRef< HTMLDivElement, ItemProps >( function MenuItem(
 			ref={ ref }
 			{ ...itemAriaProps }
 			className={ clsx(
+				defenseStyles.div,
 				resetStyles[ 'box-sizing' ],
 				styles.item,
 				className

--- a/packages/ui/src/menu/radio-item.tsx
+++ b/packages/ui/src/menu/radio-item.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { Circle, SVG } from '@wordpress/primitives';
 import { Icon } from '../icon';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
 import { MenuItemContentContext } from './context';
@@ -52,6 +53,7 @@ const RadioItem = forwardRef< HTMLDivElement, RadioItemProps >(
 				ref={ ref }
 				{ ...itemAriaProps }
 				className={ clsx(
+					defenseStyles.div,
 					resetStyles[ 'box-sizing' ],
 					styles.item,
 					className

--- a/packages/ui/src/menu/style.module.css
+++ b/packages/ui/src/menu/style.module.css
@@ -162,8 +162,13 @@
 				color: var(--wpds-color-foreground-interactive-neutral);
 				outline: none;
 
+				/*
+				 * Set the outline through the global CSS defense bridge, since
+				 * wp-admin's unlayered `div { outline: 0 }` beats layered styles.
+				 */
 				@media ( forced-colors: active ) {
-					outline: var(--wpds-border-width-xs) solid Highlight;
+					--_gcd-div-outline: var(--wpds-border-width-xs) solid Highlight;
+					--_gcd-a-outline: var(--wpds-border-width-xs) solid Highlight;
 				}
 			}
 

--- a/packages/ui/src/menu/submenu-trigger.tsx
+++ b/packages/ui/src/menu/submenu-trigger.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { forwardRef } from '@wordpress/element';
 import { chevronRightSmall } from '@wordpress/icons';
 import { Icon } from '../icon';
+import defenseStyles from '../utils/css/global-css-defense.module.css';
 import resetStyles from '../utils/css/resets.module.css';
 import styles from './style.module.css';
 import { MenuItemContentContext } from './context';
@@ -46,6 +47,7 @@ const SubmenuTrigger = forwardRef< HTMLDivElement, SubmenuTriggerProps >(
 				ref={ ref }
 				{ ...itemAriaProps }
 				className={ clsx(
+					defenseStyles.div,
 					resetStyles[ 'box-sizing' ],
 					styles.item,
 					className

--- a/packages/ui/src/utils/css/item-popup.module.css
+++ b/packages/ui/src/utils/css/item-popup.module.css
@@ -147,8 +147,12 @@
 				color: var(--wpds-color-foreground-interactive-neutral);
 				outline: none; /* Disable user agent focus ring */
 
+				/*
+				 * Set the outline through the global CSS defense bridge, since
+				 * wp-admin's unlayered `div { outline: 0 }` beats layered styles.
+				 */
 				@media ( forced-colors: active ) {
-					outline: 1px solid Highlight;
+					--_gcd-div-outline: var(--wpds-border-width-xs) solid Highlight;
 				}
 			}
 


### PR DESCRIPTION
## What?

Closes #82771

Restores the highlighted item indicator in forced-colors mode for `Menu`, `Autocomplete`, `Combobox`, and `Select`.

## Why?

These components already define a `Highlight` outline for the highlighted item under `@media ( forced-colors: active )`, but the declaration lives in `@layer wp-ui`. In wp-admin, `common.css` ships an unlayered `a, div { outline: 0 }`, and unlayered declarations beat layered ones regardless of specificity — so the outline never rendered.

## How?

Uses the existing [global CSS defense](https://github.com/WordPress/gutenberg/blob/trunk/packages/ui/CONTRIBUTING.md#global-css-defense-wp-admin) bridge, which exists for exactly this cascade problem.

## Testing Instructions

1. Enable High Contrast Mode on Windows. On macOS, use Chrome DevTools → Rendering → "Emulate CSS media feature forced-colors" → `forced-colors: active`.
2. Open the [`Menu` story](https://wordpress.github.io/gutenberg/?path=/story/design-system-components-menu--default) in Storybook.
3. In the Storybook toolbar, set **Global CSS** to **WordPress**.
4. Open the menu and navigate with the <kbd>↑</kbd> / <kbd>↓</kbd> keys. The highlighted item should have a visible `Highlight` outline.
5. Repeat for the `Combobox`, `Select`, and `Autocomplete` stories.

## Screenshots or screencast

### Menu

http://localhost:50240/?path=/story/design-system-components-menu--default&globals=css:wordpress

<img width="385" height="179" alt="image" src="https://github.com/user-attachments/assets/8320c8e4-1fbd-4ee1-8041-3de914568cb1" />

### Combobox

http://localhost:50240/?path=/story/design-system-components-form-primitives-combobox--default&globals=css:wordpress

<img width="379" height="221" alt="image" src="https://github.com/user-attachments/assets/6a4c3304-9040-4f2b-baeb-6a6f45f8dbba" />

### Select

http://localhost:50240/?path=/story/design-system-components-form-primitives-select--default&globals=css:wordpress

<img width="377" height="212" alt="image" src="https://github.com/user-attachments/assets/f2dcf145-dc18-4347-a3a3-788c07c626d4" />

### Autocomplete

http://localhost:50240/?path=/story/design-system-components-form-primitives-autocomplete--default&globals=css:wordpress

<img width="379" height="146" alt="image" src="https://github.com/user-attachments/assets/352dfd0a-3e6c-4853-a38f-5641632a8667" />

## Use of AI Tools

This PR was authored with Claude Code. The cascade layer analysis, the fix, and the issue report were AI-assisted; I reviewed and verified the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
