### PR TITLE
Editor: Honor post types in `post-thumbnails` theme support when registering the featured image field

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+-   Featured image field: Only register it for the post types a theme lists in its `post-thumbnails` support, matching the classic panel. ([#82773](https://github.com/WordPress/gutenberg/pull/82773))
 -   `MediaUpload`: Coerce `multiple` to a boolean before passing it to the experimental media modal; callers such as the playlist block and the inserter media tab pass the legacy media frame's `'add'` mode. ([#82715](https://github.com/WordPress/gutenberg/pull/82715))
 -   Document bar: Preserve the subdued template-preview icon color after the icon became stroke-based. ([#82540](https://github.com/WordPress/gutenberg/pull/82540))
 

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -245,10 +245,17 @@ export const registerPostTypeSchema =
 			const postTypeSlug = postTypeConfig.slug;
 			const isDesignPostType = DESIGN_POST_TYPES.includes( postTypeSlug );
 			const isPattern = postTypeSlug === 'wp_block';
+			// `post-thumbnails` is `true` or the list of post types the theme
+			// opted in.
+			const postThumbnails =
+				currentTheme?.theme_supports?.[ 'post-thumbnails' ];
+			const themeSupportsThumbnails = Array.isArray( postThumbnails )
+				? postThumbnails.includes( postTypeSlug )
+				: !! postThumbnails;
 
 			fields = [
 				postTypeConfig.supports?.thumbnail &&
-					currentTheme?.theme_supports?.[ 'post-thumbnails' ] &&
+					themeSupportsThumbnails &&
 					featuredImageField,
 				! isDesignPostType &&
 					postTypeConfig.supports?.author &&


### PR DESCRIPTION


## What?
Part of: https://github.com/WordPress/gutenberg/issues/76076

A theme can add `post-thumbnails` support only for some post types (`add_theme_support( 'post-thumbnails', array( 'post' ) )`). The classic sidebar handles this in `ThemeSupportCheck`, but when we register the fields for a post type we only check if the value is truthy, so the featured image field shows up for every post type that supports thumbnails.

This PR add the checks for the post type against that list, like the old panel does.

## Testing Instructions
1. Add this snippet in a mu-plugin (or your theme's `functions.php`). Block themes get the support automatically, that's why we need to remove it first:
```php
add_action( 'after_setup_theme', function () {
      remove_theme_support( 'post-thumbnails' );
      add_theme_support( 'post-thumbnails', array( 'post' ) );
}, 100 );
```
2. Enable the `Editor Inspector: Use DataForm` experiment.
3. Create a new page. The featured image row should not be in the summary (in trunk it is).
4. Create a new post. The featured image row should be there.
5. Everything else around featured image field should work as before.

Use of AI Tools

Fable 5.1 with direction, changes and review