### PR TITLE
Icon block: Don't render non-public icons on the frontend

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Icon: Don't render icons registered with `public: false` on the front end, matching the editor, where they aren't available through the icons REST API ([#82774](https://github.com/WordPress/gutenberg/pull/82774)).
+
 ### Bug Fixes
 
 -   Cover: Grow the block with its content in Safari when an aspect ratio is set, instead of clipping the overflow. WebKit locks the box to the ratio where other engines let content expand it ([#70152](https://github.com/WordPress/gutenberg/pull/70152)).

--- a/packages/block-library/src/icon/index.php
+++ b/packages/block-library/src/icon/index.php
@@ -19,6 +19,12 @@ function render_block_core_icon( $attributes ) {
 		return;
 	}
 
+	// Non-public icons are not available in the editor, so do not render them either.
+	$registered_icon = WP_Icons_Registry::get_instance()->get_registered_icon( $attributes['icon'] );
+	if ( false === ( $registered_icon['public'] ?? true ) ) {
+		return;
+	}
+
 	// Text color and background color.
 	$color_styles = array();
 

--- a/phpunit/blocks/render-block-icon-test.php
+++ b/phpunit/blocks/render-block-icon-test.php
@@ -42,6 +42,11 @@ class Block_Core_Icon_Render_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	public function test_does_not_render_non_public_icon() {
+		$this->assertNotEmpty( wp_get_icon( 'core/wordpress' ) );
+		$this->assertEmpty( gutenberg_render_block_core_icon( array( 'icon' => 'core/wordpress' ) ) );
+	}
+
 	public function test_preserves_intrinsic_svg_style_when_applying_block_styles() {
 		$output = gutenberg_render_block_core_icon(
 			array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

A follow-up to https://github.com/WordPress/gutenberg/pull/82634#discussion_r3988456352.

We allow icons to be available only through `wp_get_icon()` but not REST API / Icon block, by setting the `public` property to `false`.

A question was raised whether to allow rendering it at all, since the block in the frontend is rendered via `wp_get_icon()` in PHP. This proposes that we don't, so that it's consistent with the behavior in editor.

## Why?

Because non-public icons are meant for admin UI rather than post content, the block shouldn't render them anywhere. This also means no saved content depends on them, so Core can change or remove them later.

## Testing Instructions

1. Open/edit a post and switch to the Code editor.
2. Paste:

       <!-- wp:icon {"icon":"core/wordpress"} /-->
       <!-- wp:icon {"icon":"core/caution"} /-->

4. Switch back to the Visual editor. Verify that the first block renders the placeholder and the second shows the icon.
5. Save and view the post. Verify that only the `caution` icon renders.

## Use of AI Tools

Used Claud Opus 5. Reviewed and checked by me.
