### PR TITLE
DataViews: replace `word-break` with `overflow-wrap: anywhere` on `DataForm` panel field control

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Internal
 
 -   Run rendered DataViews tests in Vitest Browser Mode ([#80995](https://github.com/WordPress/gutenberg/pull/80995)).
+-   DataForm panel layout: Replace deprecated `word-break: break-word` with `word-break: normal` and `overflow-wrap: anywhere` on field summary controls.
 
 ## 19.0.0 (2026-09-10)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Internal
 
 -   Run rendered DataViews tests in Vitest Browser Mode ([#80995](https://github.com/WordPress/gutenberg/pull/80995)).
--   DataForm panel layout: Replace deprecated `word-break: break-word` with `word-break: normal` and `overflow-wrap: anywhere` on field summary controls.
+-   DataForm panel layout: Replace deprecated `word-break: break-word` with `word-break: normal` and `overflow-wrap: anywhere` on field summary controls. ([#82776](https://github.com/WordPress/gutenberg/pull/82776)).
 
 ## 19.0.0 (2026-09-10)
 

--- a/packages/dataviews/src/components/dataform-layouts/panel/style.scss
+++ b/packages/dataviews/src/components/dataform-layouts/panel/style.scss
@@ -132,8 +132,8 @@
 	// clip boundary for focus rings of inner controls.
 	padding-inline: var(--wpds-border-width-focus);
 	margin-inline: calc(-1 * var(--wpds-border-width-focus));
-	// stylelint-disable-next-line declaration-property-value-keyword-no-deprecated -- Pending review of overflow-wrap alternative.
-	word-break: break-word;
+	word-break: normal;
+	overflow-wrap: anywhere;
 	font-weight: var(--wpds-typography-font-weight-emphasis);
 
 	// Keep summary links and buttons in front of the edit button's stretched


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #82293.

Replace deprecated `word-break: break-word` with `word-break: normal` and `overflow-wrap: anywhere` on the `DataForm` panel field summary control, and remove the related Stylelint suppression.

<!-- In a few words, what is the PR actually doing? -->

## Why?
`Stylelint` flags `word-break: break-word` as deprecated. Its replacement must preserve both intrinsic sizing and normal word grouping in each layout.

## How?
Swap `word-break: break-word` → `word-break: normal` + `overflow-wrap: anywhere` on `.dataforms-layouts-panel__field-control`.

## Testing Instructions
- Open the Site Editor → Pages (or Posts).
- Open the actions menu for a page/post → Quick Edit.
- Confirm the panel field rows (Title, Slug etc.) still render correctly.
- Set a very long unbroken Slug or Title (or narrow the modal) and confirm.
- The field value wraps inside the row.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="200"  alt="before" src="https://github.com/user-attachments/assets/0b6fe467-141a-4595-9399-2e5af3d4d689" />|<img width="200" alt="after" src="https://github.com/user-attachments/assets/e18eb1d1-dcfc-48d8-8f03-51d479c77157" />|

## Use of AI Tools
- Yes (For PR Description)