### PR TITLE
Editor: run the header, notices and footer in async mode

### DIFF
--- a/packages/editor/src/components/editor-interface/index.jsx
+++ b/packages/editor/src/components/editor-interface/index.jsx
@@ -237,12 +237,9 @@ export default function EditorInterface( {
 			}
 			secondarySidebar={
 				! isPreviewMode &&
-				mode === 'visual' && (
-					<AsyncModeProvider value>
-						{ ( isInserterOpened && <InserterSidebar /> ) ||
-							( isListViewOpened && <ListViewSidebar /> ) }
-					</AsyncModeProvider>
-				)
+				mode === 'visual' &&
+				( ( isInserterOpened && <InserterSidebar /> ) ||
+					( isListViewOpened && <ListViewSidebar /> ) )
 			}
 			sidebar={
 				! isPreviewMode &&

--- a/packages/editor/src/components/editor-interface/index.jsx
+++ b/packages/editor/src/components/editor-interface/index.jsx
@@ -1,6 +1,11 @@
 import clsx from 'clsx';
 import { InterfaceSkeleton, ComplementaryArea } from '@wordpress/interface';
-import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import {
+	AsyncModeProvider,
+	useSelect,
+	useDispatch,
+	useRegistry,
+} from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import {
@@ -213,22 +218,31 @@ export default function EditorInterface( {
 			} }
 			header={
 				! isPreviewMode && (
-					<Header
-						forceIsDirty={ forceIsDirty }
-						setEntitiesSavedStatesCallback={
-							setEntitiesSavedStatesCallback
-						}
-						customSaveButton={ customSaveButton }
-						forceDisableBlockTools={ forceDisableBlockTools }
-					/>
+					<AsyncModeProvider value>
+						<Header
+							forceIsDirty={ forceIsDirty }
+							setEntitiesSavedStatesCallback={
+								setEntitiesSavedStatesCallback
+							}
+							customSaveButton={ customSaveButton }
+							forceDisableBlockTools={ forceDisableBlockTools }
+						/>
+					</AsyncModeProvider>
 				)
 			}
-			editorNotices={ <Notices /> }
+			editorNotices={
+				<AsyncModeProvider value>
+					<Notices />
+				</AsyncModeProvider>
+			}
 			secondarySidebar={
 				! isPreviewMode &&
-				mode === 'visual' &&
-				( ( isInserterOpened && <InserterSidebar /> ) ||
-					( isListViewOpened && <ListViewSidebar /> ) )
+				mode === 'visual' && (
+					<AsyncModeProvider value>
+						{ ( isInserterOpened && <InserterSidebar /> ) ||
+							( isListViewOpened && <ListViewSidebar /> ) }
+					</AsyncModeProvider>
+				)
 			}
 			sidebar={
 				! isPreviewMode &&
@@ -236,7 +250,11 @@ export default function EditorInterface( {
 			}
 			content={
 				<>
-					{ ! isDistractionFree && ! isPreviewMode && <Notices /> }
+					{ ! isDistractionFree && ! isPreviewMode && (
+						<AsyncModeProvider value>
+							<Notices />
+						</AsyncModeProvider>
+					) }
 					{ shouldShowStylesCanvas && <StylesCanvas /> }
 					{ shouldShowBlockEditor && (
 						<>
@@ -276,13 +294,15 @@ export default function EditorInterface( {
 				isLargeViewport &&
 				showBlockBreadcrumbs &&
 				mode === 'visual' && (
-					<BlockBreadcrumb
-						rootLabelText={
-							postTypeLabel
-								? decodeEntities( postTypeLabel )
-								: undefined
-						}
-					/>
+					<AsyncModeProvider value>
+						<BlockBreadcrumb
+							rootLabelText={
+								postTypeLabel
+									? decodeEntities( postTypeLabel )
+									: undefined
+							}
+						/>
+					</AsyncModeProvider>
 				)
 			}
 			actions={


### PR DESCRIPTION
## What?

Wraps the editor header, the notices and the footer breadcrumb in `AsyncModeProvider`, so their `useSelect` subscriptions update on idle time instead of inside the input event of every keystroke.

## Why?

Every `useSelect` subscription in these regions re-runs its selector synchronously on each store change, before the browser can paint. While typing, that is the publish button label, the document bar, the saved state, the preview dropdown and more, all recomputing to produce the same result. The block list already defers the non selected blocks this way.

Post editor typing test, local run, per character:

| trunk | this branch |
| --- | --- |
| 6.10 ms | 5.78 ms |

## How?

1. **`AsyncModeProvider`** around the three regions in `EditorInterface`.
2. **Sync regions stay sync**: the content (the block list already forces sync for the root and for the selected block), the settings sidebar and the publish panel, which hold inputs bound to store state, and the secondary sidebar, since the List View acts on the selection and the block order from its handlers. A controlled input in async mode drops typed characters until the next idle tick.

## Testing Instructions

1. Type in a post: the Save button, the document bar and the breadcrumb still update, a moment later.
2. Performance job: the `type` metrics in the post editor and site editor.

## Use of AI Tools

Written with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrG35JQKJBX1iNof5wtfjN

