### PR TITLE
Enable editableRoot for the list item block

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -482,7 +482,9 @@ export default function useSelectionObserver() {
 			defaultView.addEventListener( 'mouseup', onMouseUp );
 			node.addEventListener( 'mousedown', onMouseDown );
 			node.addEventListener( 'keydown', onKeyDown );
-			ownerDocument.addEventListener(
+			// On the window, so it runs before any document listener that
+			// reads the store on keydown, whatever order they were added in.
+			defaultView.addEventListener(
 				'keydown',
 				ensureMultiBlockSelectionSync,
 				true
@@ -510,7 +512,7 @@ export default function useSelectionObserver() {
 				defaultView.removeEventListener( 'mouseup', onMouseUp );
 				node.removeEventListener( 'mousedown', onMouseDown );
 				node.removeEventListener( 'keydown', onKeyDown );
-				ownerDocument.removeEventListener(
+				defaultView.removeEventListener(
 					'keydown',
 					ensureMultiBlockSelectionSync,
 					true

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -433,9 +433,9 @@ export default function useSelectionObserver() {
 			}
 
 			// Native `selectionchange` events are asynchronous: a clipboard
-			// event may fire before the store has been updated with a cross
-			// block selection that was just made. Sync it before the clipboard
-			// handlers (bubble phase) read the store.
+			// event or a keydown may fire before the store has been updated
+			// with a cross block selection that was just made. Sync it before
+			// the handlers that read the store run.
 			function ensureMultiBlockSelectionSync( event ) {
 				const selection = defaultView.getSelection();
 
@@ -452,9 +452,22 @@ export default function useSelectionObserver() {
 					extractSelectionEndNode( selection, isTripleClick )
 				);
 
-				if ( startClientId !== endClientId ) {
-					onSelectionChange( event );
+				if ( startClientId === endClientId ) {
+					return;
 				}
+
+				// Skip when the store already reflects the block range. The
+				// sync runs on every keydown, and a `multiSelect` dispatch
+				// announces itself to screen readers, so an unchanged range
+				// must not be dispatched again.
+				if (
+					getSelectionStart().clientId === startClientId &&
+					getSelectionEnd().clientId === endClientId
+				) {
+					return;
+				}
+
+				onSelectionChange( event );
 			}
 
 			ownerDocument.addEventListener(
@@ -469,6 +482,11 @@ export default function useSelectionObserver() {
 			defaultView.addEventListener( 'mouseup', onMouseUp );
 			node.addEventListener( 'mousedown', onMouseDown );
 			node.addEventListener( 'keydown', onKeyDown );
+			ownerDocument.addEventListener(
+				'keydown',
+				ensureMultiBlockSelectionSync,
+				true
+			);
 			ownerDocument.addEventListener(
 				'copy',
 				ensureMultiBlockSelectionSync,
@@ -492,6 +510,11 @@ export default function useSelectionObserver() {
 				defaultView.removeEventListener( 'mouseup', onMouseUp );
 				node.removeEventListener( 'mousedown', onMouseDown );
 				node.removeEventListener( 'keydown', onKeyDown );
+				ownerDocument.removeEventListener(
+					'keydown',
+					ensureMultiBlockSelectionSync,
+					true
+				);
 				ownerDocument.removeEventListener(
 					'copy',
 					ensureMultiBlockSelectionSync,

--- a/packages/block-library/src/list-item/hooks/use-multi-select-tab.js
+++ b/packages/block-library/src/list-item/hooks/use-multi-select-tab.js
@@ -6,18 +6,24 @@ import { indentListItems, outdentListItems } from '../utils';
 
 export default function useMultiSelectTab( clientId ) {
 	const registry = useRegistry();
-	// Only the first item of an all-list-item multi selection attaches the
-	// listener, so there is a single handler regardless of how many list items
-	// are rendered, and only while such a selection exists.
+	// Only one item attaches the listener, so there is a single handler
+	// regardless of how many list items are rendered: the first item of an
+	// all-list-item multi selection, or the selected item. The selected item
+	// listens because a multi selection made from it can receive a Tab before
+	// the selection is rendered: a native selection in an editing host syncs
+	// to the store outside React, so the handler of the first selected item
+	// may not be attached yet when the key arrives. The handler reads the
+	// selection from the store at event time.
 	const isActive = useSelect(
 		( select ) => {
 			const {
 				hasMultiSelection,
 				getMultiSelectedBlockClientIds,
+				getSelectedBlockClientId,
 				getBlockName,
 			} = select( blockEditorStore );
 			if ( ! hasMultiSelection() ) {
-				return false;
+				return getSelectedBlockClientId() === clientId;
 			}
 			const clientIds = getMultiSelectedBlockClientIds();
 			return (
@@ -45,6 +51,21 @@ export default function useMultiSelectTab( clientId ) {
 					altKey ||
 					metaKey ||
 					ctrlKey
+				) {
+					return;
+				}
+
+				const {
+					hasMultiSelection,
+					getMultiSelectedBlockClientIds,
+					getBlockName,
+				} = registry.select( blockEditorStore );
+
+				if (
+					! hasMultiSelection() ||
+					! getMultiSelectedBlockClientIds().every(
+						( id ) => getBlockName( id ) === 'core/list-item'
+					)
 				) {
 					return;
 				}

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -1,5 +1,6 @@
 import { listItem as icon } from '@wordpress/icons';
 import { privateApis } from '@wordpress/block-editor';
+import { privateApis as blocksPrivateApis } from '@wordpress/blocks';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
@@ -7,12 +8,16 @@ import save from './save';
 import transforms from './transforms';
 import { unlock } from '../lock-unlock';
 
+const { editableRootKey } = unlock( blocksPrivateApis );
+
 const { name } = metadata;
 
 export { metadata, name };
 
 export const settings = {
 	icon,
+	// Opt into the editing host behaviour privately, like the paragraph.
+	[ editableRootKey ]: true,
 	edit,
 	save,
 	merge( attributes, attributesToMerge ) {

--- a/test/e2e/specs/editor/various/editable-root.spec.js
+++ b/test/e2e/specs/editor/various/editable-root.spec.js
@@ -36,6 +36,36 @@ test.describe( 'editableRoot host mode', () => {
 			.toBe( true );
 	} );
 
+	test( 'wrapper becomes the editing host for a list item with siblings', async ( {
+		editor,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/list',
+			innerBlocks: [
+				{ name: 'core/list-item', attributes: { content: 'a' } },
+				{ name: 'core/list-item', attributes: { content: 'b' } },
+			],
+		} );
+		await editor.selectBlocks(
+			editor.canvas
+				.getByRole( 'document', { name: 'Block: List item' } )
+				.first()
+		);
+
+		await expect
+			.poll( () =>
+				editor.canvas
+					.locator( ':root' )
+					.evaluate(
+						( root ) =>
+							!! root.ownerDocument.querySelector(
+								'[contenteditable="true"] [data-block]'
+							)
+					)
+			)
+			.toBe( true );
+	} );
+
 	test( 'a heading (no support) is not hosted', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?

Opts the list item block into the editing host behaviour, the same private setting the paragraph block uses since #81542. While a list item with sibling items is selected, the canvas wrapper is the `contenteditable` element, so a native selection can extend from one item into another.

## Why?

Lists are the second most common text block. Without the opt-in, selecting across two items still falls back to the block level multi selection, and on mobile web a drag from one item into the next selects whole blocks instead of text.

## How?

1. **Opt in.** `packages/block-library/src/list-item/index.js` sets the private `editableRoot` key on the block settings. The list item's Enter, Tab and merge handlers already listen through `subscribeOwnedListener`, which fires for the owning element when the editing host is the event target, so no handler changes are needed.
2. **Sync a cross block selection before Tab acts on it.** With items hosted, a shift+arrow selection across items is a native selection first and reaches the store through the asynchronous `selectionchange` event. A Tab pressed right after could arrive before the store knew about it, so the multi selection Tab handler either was not attached yet or read a single selection. The selection observer now syncs the store on keydown, the way it does for copy, cut and paste, and the list item's multi selection Tab handler also listens while the item is the single selected block and reads the selection at event time. The keydown listener sits on the window in the capture phase, so it runs before the list item's document listener whatever order the two were added in.
3. **Test.** A host test for a list item with siblings, next to the paragraph one in `editable-root.spec.js`.

## Testing Instructions

- Insert a list with two items, select the first, and check the canvas body is `contenteditable`.
- Select across two items with shift+ArrowUp or a drag, press Tab and Shift+Tab: both items indent and outdent together.
- The list, editable root, multi selection, splitting and merging, and writing flow specs pass.

## Use of AI Tools

Written with Claude Code; reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrG35JQKJBX1iNof5wtfjN
