### PR TITLE
Block Supports: Allow CSS custom properties in block gap sanitization

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -315,6 +315,11 @@ function gutenberg_sanitize_block_gap_value( $gap_value ) {
 		return null;
 	}
 
+	// Allow valid CSS custom property references, e.g. var(--wp--preset--spacing--32).
+	if ( preg_match( '/^var\(--[a-zA-Z0-9_-]+\)$/', $gap_value ) ) {
+		return $gap_value;
+	}
+
 	return $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 }
 

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -88,22 +88,37 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	 */
 	public function data_sanitize_block_gap_value() {
 		return array(
-			'string value'           => array( '1rem', '1rem' ),
-			'empty string'           => array( '', null ),
-			'whitespace-only string' => array( " \t\n", null ),
-			'integer zero'           => array( 0, '0' ),
-			'floating-point zero'    => array( 0.0, '0' ),
-			'non-zero integer'       => array( 1, null ),
-			'boolean value'          => array( true, null ),
-			'object value'           => array( new stdClass(), null ),
-			'nested array value'     => array(
+			'string value'                         => array( '1rem', '1rem' ),
+			'empty string'                         => array( '', null ),
+			'whitespace-only string'               => array( " \t\n", null ),
+			'integer zero'                         => array( 0, '0' ),
+			'floating-point zero'                  => array( 0.0, '0' ),
+			'non-zero integer'                     => array( 1, null ),
+			'boolean value'                        => array( true, null ),
+			'object value'                         => array( new stdClass(), null ),
+			'nested array value'                   => array(
 				array(
 					'top'  => array( '1rem' ),
 					'left' => '2rem',
 				),
 				array( 'left' => '2rem' ),
 			),
-			'empty sanitized array'  => array( array( array( '1rem' ) ), null ),
+			'empty sanitized array'                => array( array( array( '1rem' ) ), null ),
+			'valid CSS variable preset'            => array( 'var(--wp--preset--spacing--32)', 'var(--wp--preset--spacing--32)' ),
+			'valid CSS variable with hyphens'      => array( 'var(--wp--preset--spacing--sm-32)', 'var(--wp--preset--spacing--sm-32)' ),
+			'valid CSS custom property'            => array( 'var(--custom-gap)', 'var(--custom-gap)' ),
+			'malformed CSS variable injection'     => array( 'var(--wp--preset--spacing--32); background: red;', null ),
+			'malformed CSS variable with function' => array( 'var(--wp--preset--spacing--32, url(evil))', null ),
+			'nested array with CSS variable'       => array(
+				array(
+					'top'  => 'var(--wp--preset--spacing--32)',
+					'left' => '2rem',
+				),
+				array(
+					'top'  => 'var(--wp--preset--spacing--32)',
+					'left' => '2rem',
+				),
+			),
 		);
 	}
 
@@ -554,6 +569,19 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 					'fallback_gap_value'    => '1.2rem',
 				),
 				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(max(min(12rem, 100%), (100% - (1.2rem * (3 - 1))) /3), 1fr));container-type:inline-size;gap:2rem 1.2rem;}',
+			),
+			'grid layout uses preset CSS variable fallback when horizontal gap is missing' => array(
+				'args'            => array(
+					'selector'              => '.wp-layout',
+					'layout'                => array(
+						'type'               => 'grid',
+						'columnCount'        => 2,
+						'minimumColumnWidth' => '20rem',
+					),
+					'has_block_gap_support' => true,
+					'fallback_gap_value'    => 'var(--wp--preset--spacing--32)',
+				),
+				'expected_output' => '.wp-layout{grid-template-columns:repeat(auto-fill, minmax(max(min(20rem, 100%), (100% - (var(--wp--preset--spacing--32) * (2 - 1))) /2), 1fr));container-type:inline-size;}',
 			),
 			'grid layout preserves zero horizontal gap'    => array(
 				'args'            => array(


### PR DESCRIPTION
## What?

Closes #82747

Allows valid CSS custom property references (such as `var(--wp--preset--spacing--32)`) in `gutenberg_sanitize_block_gap_value()`.

## Why?

When a theme defines a preset block gap in `theme.json` (such as `styles.spacing.blockGap: "var:preset|spacing|32"`):
1. `gutenberg_get_global_styles()` resolves the preset to its CSS variable format: `var(--wp--preset--spacing--32)`.
2. Candidate values for the global block gap in `gutenberg_render_layout_support_flag()` are passed through `gutenberg_sanitize_block_gap_value()`.
3. Because `gutenberg_sanitize_block_gap_value()` disallows parentheses `(`, `)` to prevent CSS injection, the resolved preset was rejected and returned `null`.
4. As a result, the Grid layout calculation in `gutenberg_get_layout_style()` fell back to `0.5em` instead of using the theme's preset gap value.
5. In Grid blocks with `columnCount` and `minimumColumnWidth`, the column calculation formula `max(min(..., 100%), (100% - (gap * (n - 1))) / n)` was computed against `0.5em`, causing grid items to overflow or stack into a single column.

## How?

- Updated `gutenberg_sanitize_block_gap_value()` in `lib/block-supports/layout.php` to accept valid CSS custom property references matching `/^var\(--[a-zA-Z0-9_-]+\)$/`.
- Added unit test cases in `phpunit/block-supports/layout-test.php` covering `gutenberg_sanitize_block_gap_value()` with valid and invalid CSS variables, including nested array handling.
- Added a test case in `data_gutenberg_get_layout_style()` verifying that Grid layout with a preset CSS variable fallback correctly computes the `grid-template-columns` declaration.

## Testing Instructions

1. Run the PHPUnit test suite:
   ```bash
   npm run wp-env-test run -- --env-cwd='wp-content/plugins/gutenberg' wordpress vendor/bin/phpunit -c phpunit.xml.dist --filter test_sanitize_block_gap_value
   npm run wp-env-test run -- --env-cwd='wp-content/plugins/gutenberg' wordpress vendor/bin/phpunit -c phpunit.xml.dist --filter test_gutenberg_get_layout_style
   ```
2. Verify all tests pass.
3. Test with a block theme setting a preset block gap in `theme.json`:
   ```json
   "styles": {
     "spacing": {
       "blockGap": "var:preset|spacing|32"
     }
   }
   ```
4. Insert a Grid block with `columnCount: 2` and `minimumColumnWidth: "20rem"`.
5. Check the rendered front-end CSS output for the grid container; verify `grid-template-columns` uses `var(--wp--preset--spacing--32)` rather than falling back to `0.5em`.

## Use of AI Tools

AI assistance: Yes  
Model(s): Gemini 3.8 Flash High

Assisted by Gemini 3.8 Flash High to investigate the root cause in `layout.php` and compose the PHPUnit test cases.