### PR TITLE
E2E: Reset preferences in the post editor preload spec

### DIFF
--- a/test/e2e/specs/preload/post-editor.spec.js
+++ b/test/e2e/specs/preload/post-editor.spec.js
@@ -11,6 +11,8 @@ test.describe( 'Preload', () => {
 	let postId;
 
 	test.beforeAll( async ( { requestUtils } ) => {
+		// Panel open state is persisted, and open panels fetch.
+		await requestUtils.resetPreferences();
 		await setCollaboration( requestUtils, true );
 		const post = await requestUtils.createPost( {
 			content:


### PR DESCRIPTION
## What

PR fixes a potentially flaky test when `preload/post-editor.spec.js` runs after the taxonomy tests. Open taxonomy panels trigger REST API requests. This matches the `site-editor.spec.js` setup.