### PR TITLE
Commands: Avoid re-registering command loaders on every render

### DIFF
--- a/packages/commands/CHANGELOG.md
+++ b/packages/commands/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `useCommandLoader`: stop unregistering and re-registering the loader when the `hook` option changes identity between renders ([#82819](https://github.com/WordPress/gutenberg/pull/82819)).
+
 ## 1.55.0 (2026-09-10)
 
 ### Internal

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -134,6 +134,8 @@ _Parameters_
 
 Attach a command loader to the command palette. Used for dynamic commands.
 
+The palette always calls the most recent `hook`. Changing the `hook` instance doesn't re-render the palette.
+
 _Usage_
 
 ```js

--- a/packages/commands/src/hooks/use-command-loader.js
+++ b/packages/commands/src/hooks/use-command-loader.js
@@ -1,9 +1,12 @@
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as commandsStore } from '../store';
 
 /**
  * Attach a command loader to the command palette. Used for dynamic commands.
+ *
+ * The palette always calls the most recent `hook`. Changing the `hook` instance
+ * doesn't re-render the palette.
  *
  * @param {import('../store/actions').WPCommandLoaderConfig} loader command loader config.
  *
@@ -75,13 +78,25 @@ import { store as commandsStore } from '../store';
 export default function useCommandLoader( loader ) {
 	const { registerCommandLoader, unregisterCommandLoader } =
 		useDispatch( commandsStore );
+	const currentHookRef = useRef( loader.hook );
+	useEffect( () => {
+		currentHookRef.current = loader.hook;
+	}, [ loader.hook ] );
+
+	// Stable identity, so a hook rebuilt on every render does not re-register
+	// the loader.
+	const hook = useCallback(
+		( ...args ) => currentHookRef.current( ...args ),
+		[]
+	);
+
 	useEffect( () => {
 		if ( loader.disabled ) {
 			return;
 		}
 		registerCommandLoader( {
 			name: loader.name,
-			hook: loader.hook,
+			hook,
 			context: loader.context,
 			category: loader.category,
 		} );
@@ -90,7 +105,7 @@ export default function useCommandLoader( loader ) {
 		};
 	}, [
 		loader.name,
-		loader.hook,
+		hook,
 		loader.context,
 		loader.category,
 		loader.disabled,


### PR DESCRIPTION
## What?

`useCommandLoader` re-registers its command loader on every render of the calling component because the effect depends on the identity of the `hook` option, and callers commonly build that hook during render.

The hook is kept in a ref, and a stable wrapper is registered instead, mirroring what `useCommand` already does for its `callback` option. The registration effect now depends only on genuinely stable values, so the loader registers once.

## Testing Instructions
No user-facing behavior should change. The command palette should work exactly as before.

1. Open a post.
2. Press `Cmd/Ctrl + K` to open the command palette.
3. Confirm the editor commands still appear and run: "Keyboard shortcuts", "Open List View", "Editor preferences", "Enter Distraction-free".
4. Select a block, reopen the palette, and confirm the contextual commands still appear.
5. Repeat in the site editor and confirm navigation commands ("Pages", "Templates") and the global styles commands still appear.

### Testing Instructions for Keyboard
Same.

## Use of AI Tools

Assisted by Claude.
