### PR TITLE
Writing flow: respect text fields inside open shadow roots

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 
+-   Writing flow: Use the composed event target for select-all and clipboard handling so text fields inside open shadow roots keep native Cmd/Ctrl+A and paste behaviour. ([#82755](https://github.com/WordPress/gutenberg/issues/82755))
 -   `InnerBlocks`: Resolve a container's legacy layout markup (`inherit: true`, or a bare `contentSize` / `wideSize` with no `type`) to a constrained layout for its inner blocks, so they are offered the wide and full alignments. Previously only the container's styles honoured the legacy form, and the inner blocks resolved to the flow layout ([#82637](https://github.com/WordPress/gutenberg/pull/82637)).
 -   Block Patterns and Block Visibility: Preserve the intended colors of icons converted to strokes. ([#82540](https://github.com/WordPress/gutenberg/pull/82540))
 

--- a/packages/block-editor/src/components/writing-flow/get-event-target.js
+++ b/packages/block-editor/src/components/writing-flow/get-event-target.js
@@ -1,0 +1,14 @@
+/**
+ * Returns the originating event target, including through open shadow roots.
+ *
+ * Keyboard and clipboard events cross the shadow boundary, but `event.target`
+ * is retargeted to the host. `composedPath()[0]` exposes the original node.
+ *
+ * @param {Event} event Event object.
+ * @return {EventTarget} Originating target, or `event.target` as a fallback.
+ */
+export function getEventTarget( event ) {
+	const path =
+		typeof event.composedPath === 'function' && event.composedPath();
+	return ( path && path[ 0 ] ) || event.target;
+}

--- a/packages/block-editor/src/components/writing-flow/test/index.jsdom.test.js
+++ b/packages/block-editor/src/components/writing-flow/test/index.jsdom.test.js
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { isNavigationCandidate } from '../use-arrow-nav';
+import { getEventTarget } from '../get-event-target';
 
 describe( 'isNavigationCandidate', () => {
 	let elements;
@@ -90,5 +91,25 @@ describe( 'isNavigationCandidate', () => {
 
 			expect( result ).toBe( true );
 		} );
+	} );
+} );
+
+describe( 'getEventTarget', () => {
+	it( 'returns the first composed path entry when available', () => {
+		const host = document.createElement( 'div' );
+		const textarea = document.createElement( 'textarea' );
+		const event = {
+			target: host,
+			composedPath: () => [ textarea, host ],
+		};
+
+		expect( getEventTarget( event ) ).toBe( textarea );
+	} );
+
+	it( 'falls back to event.target when composedPath is unavailable', () => {
+		const host = document.createElement( 'div' );
+		const event = { target: host };
+
+		expect( getEventTarget( event ) ).toBe( host );
 	} );
 } );

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -9,12 +9,17 @@ import {
 	documentHasSelection,
 	documentHasUncollapsedSelection,
 	isEntirelySelected,
+	isTextField,
 } from '@wordpress/dom';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../store';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
-import { setClipboardBlocks, setContentEditableWrapper } from './utils';
+import { getEventTarget } from './get-event-target';
+import {
+	setClipboardBlocks,
+	setContentEditableWrapper,
+} from './utils';
 import { getPasteEventData } from '../../utils/pasting';
 import { getBlockClientId } from '../../utils/dom';
 
@@ -98,6 +103,17 @@ export default function useClipboardHandler() {
 			// Let native copy/paste behaviour take over in input fields.
 			// But always handle multiple selected blocks.
 			if ( ! hasMultiSelection() ) {
+				const eventTarget = getEventTarget( event );
+				// Open shadow roots retarget `event.target` to the host; use
+				// the composed path so text fields inside shadow DOM keep
+				// native clipboard behaviour.
+				if (
+					eventTarget?.nodeName &&
+					isTextField( eventTarget )
+				) {
+					return;
+				}
+
 				const { ownerDocument } = event.target;
 				// If copying, only consider actual text selection as selection.
 				// Otherwise, any focus on an input field is considered.

--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -16,10 +16,7 @@ import { useRefEffect } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../store';
 import { useNotifyCopy } from '../../utils/use-notify-copy';
 import { getEventTarget } from './get-event-target';
-import {
-	setClipboardBlocks,
-	setContentEditableWrapper,
-} from './utils';
+import { setClipboardBlocks, setContentEditableWrapper } from './utils';
 import { getPasteEventData } from '../../utils/pasting';
 import { getBlockClientId } from '../../utils/dom';
 
@@ -105,11 +102,13 @@ export default function useClipboardHandler() {
 			if ( ! hasMultiSelection() ) {
 				const eventTarget = getEventTarget( event );
 				// Open shadow roots retarget `event.target` to the host; use
-				// the composed path so text fields inside shadow DOM keep
-				// native clipboard behaviour.
+				// the composed path so inputs/textareas inside shadow DOM keep
+				// native clipboard behaviour. Skip contentEditable nodes so
+				// RichText still uses writing-flow block copy/cut/paste.
 				if (
 					eventTarget?.nodeName &&
-					isTextField( eventTarget )
+					isTextField( eventTarget ) &&
+					eventTarget.contentEditable !== 'true'
 				) {
 					return;
 				}

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -8,6 +8,7 @@ import {
 	getBlockClientId,
 	getSelectionEditableElement,
 } from '../../utils/dom';
+import { getEventTarget } from './get-event-target';
 
 export default function useSelectAll() {
 	const { getBlockOrder, getSelectedBlockClientIds, getBlockRootClientId } =
@@ -27,10 +28,13 @@ export default function useSelectAll() {
 			// When the wrapper is contentEditable and holds focus (the
 			// selected block supports `editableRoot`), the event targets the
 			// wrapper; resolve the editable element containing the selection.
+			// Prefer the composed path so open shadow-root fields are not
+			// treated as the host.
+			const eventTarget = getEventTarget( event );
 			const editable =
 				( event.target === node &&
 					getSelectionEditableElement( selection, node ) ) ||
-				event.target;
+				eventTarget;
 
 			if (
 				selectedClientIds.length < 2 &&

--- a/packages/block-editor/src/components/writing-flow/utils.js
+++ b/packages/block-editor/src/components/writing-flow/utils.js
@@ -11,6 +11,7 @@ import {
 import { getPasteEventData } from '../../utils/pasting';
 import { store as blockEditorStore } from '../../store';
 
+export { getEventTarget } from './get-event-target';
 export const requiresWrapperOnCopy = Symbol( 'requiresWrapperOnCopy' );
 
 /**


### PR DESCRIPTION
## What
Fixes #82755

Select-all and paste now use the composed event target, so text fields inside open shadow roots keep native Cmd/Ctrl+A and paste behaviour instead of triggering block-level operations.

## How
- Add `getEventTarget()` helper using `event.composedPath()[0]`
- Use it in writing-flow select-all and clipboard handlers
- Let native clipboard behaviour win when the composed target is a text field

## Test plan
- [ ] Reproduce with the console snippet from #82755
- [ ] Focus the shadow textarea and press Cmd/Ctrl+A - text should select, not all blocks
- [ ] Paste into the shadow textarea - text should insert, block should not be replaced
- [ ] Confirm Custom HTML / normal text fields still behave as before