### PR TITLE
Data: Remove the unused AsyncModeConsumer export

### DIFF
--- a/packages/data/src/components/async-mode-provider/context.ts
+++ b/packages/data/src/components/async-mode-provider/context.ts
@@ -3,10 +3,6 @@ import { createContext } from '@wordpress/element';
 export const Context = createContext( false );
 Context.displayName = 'AsyncModeContext';
 
-const { Consumer, Provider } = Context;
-
-export const AsyncModeConsumer = Consumer;
-
 /**
  * Context Provider Component used to switch the data module component rerendering
  * between Sync and Async modes.
@@ -41,4 +37,4 @@ export const AsyncModeConsumer = Consumer;
  *
  * @param {boolean} props.value Enable Async Mode.
  */
-export default Provider;
+export default Context.Provider;

--- a/packages/data/src/components/async-mode-provider/index.ts
+++ b/packages/data/src/components/async-mode-provider/index.ts
@@ -1,2 +1,2 @@
 export { default as useAsyncMode } from './use-async-mode';
-export { default as AsyncModeProvider, AsyncModeConsumer } from './context';
+export { default as AsyncModeProvider } from './context';


### PR DESCRIPTION
## What?
Removes the `AsyncModeConsumer` export from `@wordpress/data`'s async mode provider. No user-visible change.

## Why?
`AsyncModeConsumer` lost its last caller in #15737 (May 2019), which rewrote `withSelect` on top of `useSelect` and replaced it with the `useAsyncMode` hook. It was never exported from the package root, so it was internal dead code, not part of the public API.

## Testing Instructions
No behavior change.

## Use of AI Tools
Assisted by Claude.